### PR TITLE
Fix: Hover for Python functions that are Yocto tasks

### DIFF
--- a/client/src/language/middlewareHover.ts
+++ b/client/src/language/middlewareHover.ts
@@ -11,9 +11,13 @@ import { getEmbeddedLanguageDocPosition } from './utils'
 import { getFileContent } from '../lib/src/utils/files'
 
 export const middlewareProvideHover: HoverMiddleware['provideHover'] = async (document, position, token, next) => {
+  const nextResult = await next(document, position, token)
+  if (nextResult !== undefined) {
+    return nextResult
+  }
   const embeddedLanguageDocInfos = await requestsManager.getEmbeddedLanguageDocInfos(document.uri.toString(), position)
   if (embeddedLanguageDocInfos === undefined || embeddedLanguageDocInfos === null) {
-    return await next(document, position, token)
+    return
   }
   const embeddedLanguageDocContent = await getFileContent(Uri.parse(embeddedLanguageDocInfos.uri).fsPath)
   if (embeddedLanguageDocContent === undefined) {

--- a/integration-tests/project-folder/sources/meta-fixtures/hover.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures/hover.bb
@@ -7,3 +7,9 @@ python do_foo(){
 do_bar(){
     echo '123'
 }
+
+python do_build() {
+}
+
+do_build() {
+}

--- a/integration-tests/src/tests/hover.test.ts
+++ b/integration-tests/src/tests/hover.test.ts
@@ -62,4 +62,16 @@ suite('Bitbake Hover Test Suite', () => {
     const expected = 'echo'
     await testHover(position, expected)
   }).timeout(300000)
+
+  test('Hover shows Yocto task description on python function declaration', async () => {
+    const position = new vscode.Position(10, 9)
+    const expected = 'The default task for all recipes. This task depends on all other normal'
+    await testHover(position, expected)
+  }).timeout(300000)
+
+  test('Hover shows Yocto task description on bash function declaration', async () => {
+    const position = new vscode.Position(13, 1)
+    const expected = 'The default task for all recipes. This task depends on all other normal'
+    await testHover(position, expected)
+  }).timeout(300000)
 })


### PR DESCRIPTION
See previous discussion: https://github.com/savoirfairelinux/vscode-bitbake/pull/98