### PR TITLE
Fix: use unexpanded workspaceFolder var for python extraPaths

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -41,12 +41,13 @@ function updatePythonPath (): void {
   const pythonConfig = vscode.workspace.getConfiguration('python')
   const pathToBitbakeFolder = bitbakeConfig.pathToBitbakeFolder
   const pathToBitbakeLib = `${pathToBitbakeFolder}/lib`
-  const extraPaths = pythonConfig.get<string[]>('autoComplete.extraPaths') ?? []
-  if (!extraPaths.includes(pathToBitbakeLib)) {
-    extraPaths.push(`${pathToBitbakeFolder}/lib`)
+  for (const pythonSubConf of ['autoComplete.extraPaths', 'analysis.extraPaths']) {
+    const extraPaths = pythonConfig.get<string[]>(pythonSubConf) ?? []
+    if (!extraPaths.includes(pathToBitbakeLib)) {
+      extraPaths.push(`${pathToBitbakeFolder}/lib`)
+      void pythonConfig.update(pythonSubConf, extraPaths, vscode.ConfigurationTarget.Workspace)
+    }
   }
-  void pythonConfig.update('autoComplete.extraPaths', extraPaths, vscode.ConfigurationTarget.Workspace)
-  void pythonConfig.update('analysis.extraPaths', extraPaths, vscode.ConfigurationTarget.Workspace)
 }
 
 export async function activate (context: vscode.ExtensionContext): Promise<void> {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -78,6 +78,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
     if (event.affectsConfiguration('bitbake')) {
       bitbakeDriver.loadSettings(vscode.workspace.getConfiguration('bitbake'), vscode.workspace.workspaceFolders?.[0].uri.fsPath)
       logger.debug('Bitbake settings changed')
+      updatePythonPath()
       void vscode.commands.executeCommand('bitbake.rescan-project')
     }
     if (event.affectsConfiguration('bitbake.loggingLevel')) {
@@ -88,6 +89,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
     logger.debug('Bitbake workspace changed: ' + JSON.stringify(event))
     loadLoggerSettings()
     bitbakeDriver.loadSettings(vscode.workspace.getConfiguration('bitbake'), vscode.workspace.workspaceFolders?.[0].uri.fsPath)
+    updatePythonPath()
     bitbakeWorkspace.loadBitbakeWorkspace(context.workspaceState)
   }))
 

--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -16,14 +16,14 @@ import { type BitBakeProjectScanner } from '../driver/BitBakeProjectScanner'
 
 let parsingPending = false
 
-export function registerBitbakeCommands (context: vscode.ExtensionContext, bitbakeWorkspace: BitbakeWorkspace, bitbakeTaskProvider: BitbakeTaskProvider, bitbakePorjectScanner: BitBakeProjectScanner): void {
+export function registerBitbakeCommands (context: vscode.ExtensionContext, bitbakeWorkspace: BitbakeWorkspace, bitbakeTaskProvider: BitbakeTaskProvider, bitbakeProjectScanner: BitBakeProjectScanner): void {
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.parse-recipes', async () => { await parseAllrecipes(bitbakeWorkspace, bitbakeTaskProvider) }))
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.build-recipe', async (uri) => { await buildRecipeCommand(bitbakeWorkspace, bitbakeTaskProvider, uri) }))
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.clean-recipe', async (uri) => { await cleanRecipeCommand(bitbakeWorkspace, bitbakeTaskProvider, uri) }))
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.run-task', async (uri, task) => { await runTaskCommand(bitbakeWorkspace, bitbakeTaskProvider, uri, task) }))
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.drop-recipe', async (uri) => { await dropRecipe(bitbakeWorkspace, uri) }))
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.watch-recipe', async (recipe) => { await addActiveRecipe(bitbakeWorkspace, recipe) }))
-  context.subscriptions.push(vscode.commands.registerCommand('bitbake.rescan-project', async () => { await rescanProject(bitbakePorjectScanner) }))
+  context.subscriptions.push(vscode.commands.registerCommand('bitbake.rescan-project', async () => { await rescanProject(bitbakeProjectScanner) }))
 
   // Handles enqueued parsing requests (onSave)
   context.subscriptions.push(
@@ -183,11 +183,11 @@ function extractRecipeName (filename: string | undefined): string | undefined {
   return path.basename(filename).split('.')[0].split('_')[0]
 }
 
-async function rescanProject (bitbakePorjectScanner: BitBakeProjectScanner): Promise<void> {
-  if (await bitbakePorjectScanner.bitbakeDriver?.checkBitbakeSettingsSanity() !== true) {
+async function rescanProject (bitbakeProjectScanner: BitBakeProjectScanner): Promise<void> {
+  if (await bitbakeProjectScanner.bitbakeDriver?.checkBitbakeSettingsSanity() !== true) {
     logger.warn('bitbake settings are not sane, skip rescan')
     return
   }
 
-  await bitbakePorjectScanner.rescanProject()
+  await bitbakeProjectScanner.rescanProject()
 }


### PR DESCRIPTION
    
If we set the python extraPaths to the expanded `$pathToBitbakeFolder+'/lib'`, it will
result in an absolute path, i.e.


   ``` json
       "python.autoComplete.extraPaths": [
            "/home/patrick/git/<workspace>/poky/bitbake/lib"
        ],
```

Settings with such an absolute path cannot be version controlled.
Instead, use the path before it is expanded and still contains the
`$workspaceFolder` variable. Then, the written settings look like this:

``` json
    "python.autoComplete.extraPaths": [
        "${workspaceFolder}/poky/bitbake/lib"
    ],
```

This is more portable and can be tracked via git.

I tested the change by checking the hover info on some `bb.<func>()` calls, and can confirm the Python extension uses uses the configured extraPaths.

Also fix a small typo that caught my eye. :) 