### PR TITLE
Feat: Go to definition for uris in string content

### DIFF
--- a/server/src/__tests__/definition.test.ts
+++ b/server/src/__tests__/definition.test.ts
@@ -6,7 +6,7 @@
 import { analyzer } from '../tree-sitter/analyzer'
 import { generateParser } from '../tree-sitter/parser'
 import { onDefinitionHandler } from '../connectionHandlers/onDefinition'
-import { FIXTURE_DOCUMENT, DUMMY_URI, FIXTURE_URI } from './fixtures/fixtures'
+import { FIXTURE_DOCUMENT, DUMMY_URI, FIXTURE_URI, FIXTURE_FOLDER } from './fixtures/fixtures'
 import path from 'path'
 import { bitBakeProjectScannerClient } from '../BitbakeProjectScannerClient'
 
@@ -237,5 +237,43 @@ describe('on definition', () => {
     expect(shouldWork3).toEqual(shouldWork1)
 
     expect(shouldNotWork).toEqual([])
+  })
+
+  it('provides go to definition for uris found in the string content', async () => {
+    await analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.DIRECTIVE
+    })
+
+    analyzer.workspaceFolders = [{ uri: FIXTURE_FOLDER, name: 'test' }]
+
+    const shouldWork1 = onDefinitionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 12,
+        character: 13
+      }
+    })
+
+    const shouldWork2 = onDefinitionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 13,
+        character: 10
+      }
+    })
+
+    expect(shouldWork1).toEqual([
+      {
+        uri: FIXTURE_URI.FOO_INC,
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } }
+      }
+    ])
+
+    expect(shouldWork2).toEqual(shouldWork1)
   })
 })

--- a/server/src/__tests__/fixtures/directive.bb
+++ b/server/src/__tests__/fixtures/directive.bb
@@ -9,3 +9,6 @@ SYMBOL_IN_STRING = 'hover is a package ${FOO} \
         parentFolder/hover should also be seen as symbol \
         this hover too, other words should not. \
         '
+
+SRC_URI = 'file://foo.inc \
+        file://foo.inc'

--- a/server/src/__tests__/fixtures/fixtures.ts
+++ b/server/src/__tests__/fixtures/fixtures.ts
@@ -12,7 +12,7 @@ import path from 'path'
 import fs from 'fs'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 
-const FIXTURE_FOLDER = path.join(__dirname, './')
+export const FIXTURE_FOLDER = path.join(__dirname, './')
 
 type FIXTURE_URI_KEY = keyof typeof FIXTURE_URI
 

--- a/server/src/connectionHandlers/onDefinition.ts
+++ b/server/src/connectionHandlers/onDefinition.ts
@@ -72,16 +72,15 @@ export function onDefinitionHandler (textDocumentPositionParams: TextDocumentPos
     }
     // Symbols in string content
     if (analyzer.isStringContent(documentUri, position.line, position.character)) {
-      const allSymbolsFoundAtPosition = analyzer.getSymbolInStringContentForPosition(documentUri, position.line, position.character)
-      if (allSymbolsFoundAtPosition !== undefined) {
-        allSymbolsFoundAtPosition.forEach((symbol) => {
-          definitions.push({
-            uri: symbol.location.uri,
-            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } }
-          })
+      const allSymbolsAtPosition = analyzer.getSymbolsInStringContent(documentUri, position.line, position.character)
+
+      allSymbolsAtPosition.forEach((symbol) => {
+        definitions.push({
+          uri: symbol.location.uri,
+          range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } }
         })
-        return definitions
-      }
+      })
+      return definitions
     }
   }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -61,6 +61,7 @@ connection.onInitialize(async (params: InitializeParams): Promise<InitializeResu
 
   const parser = await generateParser()
   analyzer.initialize(parser)
+  analyzer.workspaceFolders = params.workspaceFolders
 
   bitBakeProjectScannerClient.onChange.on('scanReady', () => {
     logger.debug('[On scanReady] Analyzing the current document again...')

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -13,7 +13,8 @@ import {
   type Diagnostic,
   type SymbolInformation,
   type Range,
-  SymbolKind
+  SymbolKind,
+  type WorkspaceFolder
 } from 'vscode-languageserver'
 import type Parser from 'web-tree-sitter'
 import { TextDocument } from 'vscode-languageserver-textdocument'
@@ -40,6 +41,7 @@ export default class Analyzer {
   private parser?: Parser
   private uriToAnalyzedDocument: Record<string, AnalyzedDocument | undefined> = {}
   private debouncedExecuteAnalyzation?: ReturnType<typeof debounce>
+  public workspaceFolders: WorkspaceFolder[] | undefined | null = []
 
   public getDocumentTexts (uri: string): string[] | undefined {
     return this.uriToAnalyzedDocument[uri]?.document.getText().split(/\r?\n/g)


### PR DESCRIPTION
This PR provides `go to definition` for uris prefixed with `file://` in the string content. Example:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/12a84aff-5630-4c2e-a462-047cca83793d)

Caveat:
Since VSCode inherently handles the URIs in the string with `ctrl + click` to provide redirection. It is difficult to trigger `go to definition` with the same shortcut, the `go to definition` in the normal `right-click` context menu will still work.
