### PR TITLE
Fix: Only rescan when bitbake settings are changed

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -69,6 +69,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
     if (event.affectsConfiguration('bitbake')) {
       bitbakeDriver.loadSettings(vscode.workspace.getConfiguration('bitbake'), vscode.workspace.workspaceFolders?.[0].uri.fsPath)
       logger.debug('Bitbake settings changed')
+      void vscode.commands.executeCommand('bitbake.rescan-project')
     }
     if (event.affectsConfiguration('bitbake.loggingLevel')) {
       loadLoggerSettings()

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -91,7 +91,6 @@ connection.onShutdown(() => {
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
 connection.onDidChangeConfiguration(async (change) => {
   logger.level = change.settings.bitbake.loggingLevel
-  void connection.sendRequest('bitbake/rescanProject')
   parseOnSave = change.settings.bitbake.parseOnSave
 })
 


### PR DESCRIPTION
The extension started scanning twice at startup. It turns out this was because the extension was sending a rescan request when the python embedded settings where updated. This was fixed by only sending a rescan request when the bitbake settings are changed.