### PR TITLE
Fix: Stop saving all open editors when saving a bitbake file

### DIFF
--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -95,7 +95,12 @@ export async function activateLanguageServer (context: ExtensionContext): Promis
   })
 
   client.onRequest('bitbake/parseAllRecipes', async () => {
-    return await commands.executeCommand('bitbake.parse-recipes')
+    // Temporarily disable task.saveBeforeRun
+    // This request happens on bitbake document save. We don't want to save all files when any bitbake file is saved.
+    const saveBeforeRun = await workspace.getConfiguration('task').get('saveBeforeRun')
+    await workspace.getConfiguration('task').update('saveBeforeRun', 'never', undefined, true)
+    await commands.executeCommand('bitbake.parse-recipes')
+    await workspace.getConfiguration('task').update('saveBeforeRun', saveBeforeRun, undefined, true)
   })
 
   client.onRequest('bitbake/rescanProject', async () => {


### PR DESCRIPTION
The default behavior of vscode is to save all open editors when a task is run. We currently run the parsing task for any bitbake file save. This means that if you have multiple bitbake files open, all of them will be saved when any one of them is saved which is not the desired behavior.

This patch temporarily disables the saveBeforeRun setting when the bitbake/parseAllRecipes request is received.