### PR TITLE
Fix: Handle dialog promise rejection

### DIFF
--- a/client/src/driver/BitBakeProjectScanner.ts
+++ b/client/src/driver/BitBakeProjectScanner.ts
@@ -115,7 +115,7 @@ export class BitBakeProjectScanner {
   }
 
   private async getContainerParentInodes (filepath: string): Promise<number[]> {
-    const commandResult = await this.executeBitBakeCommand(`f=${filepath}; while [[ $f != / ]]; do stat -c %i $f; f=$(dirname "$f"); done;`)
+    const commandResult = await this.executeBitBakeCommand(`f=${filepath}; while [[ $f != / ]]; do stat -c %i $f; f=$(realpath $(dirname "$f")); done;`)
     const stdout = commandResult.stdout.toString().trim()
     const regex = /^\d+$/gm
     const matches = stdout.match(regex)

--- a/client/src/ui/ClientNotificationManager.ts
+++ b/client/src/ui/ClientNotificationManager.ts
@@ -15,23 +15,21 @@ export class ClientNotificationManager {
 
   showBitbakeError (message?: string): void {
     if (!this.checkIsNeverShowAgain('custom/bitbakeSettingsError')) {
-      try {
-        void window.showErrorMessage(
-          'BitBake could not be configured and started. To enable advanced Bitbake features, please configure the Bitbake extension.',
-          { detail: message, modal: true },
-          'Open Settings',
-          'Don\'t show again'
-        )
-          .then((item) => {
-            if (item === 'Open Settings') {
-              void commands.executeCommand('workbench.action.openWorkspaceSettings', '@ext:yocto-project.yocto-bitbake')
-            } else if (item === 'Don\'t show again') {
-              void this.neverShowAgain('custom/bitbakeSettingsError')
-            }
-          })
-      } catch (error) {
-        logger.warn('Could not show bitbake error dialog: ' + JSON.stringify(error))
-      }
+      void window.showErrorMessage(
+        'BitBake could not be configured and started. To enable advanced Bitbake features, please configure the Bitbake extension.',
+        { detail: message, modal: true },
+        'Open Settings',
+        'Don\'t show again'
+      )
+        .then((item) => {
+          if (item === 'Open Settings') {
+            void commands.executeCommand('workbench.action.openWorkspaceSettings', '@ext:yocto-project.yocto-bitbake')
+          } else if (item === 'Don\'t show again') {
+            void this.neverShowAgain('custom/bitbakeSettingsError')
+          }
+        }, (reason) => {
+          logger.warn('Could not show bitbake error dialog: ' + reason)
+        })
     }
   }
 

--- a/integration-tests/src/tests/bitbake-commands.test.ts
+++ b/integration-tests/src/tests/bitbake-commands.test.ts
@@ -26,6 +26,8 @@ suite('Bitbake Commands Test Suite', () => {
   })
 
   suiteTeardown(async function (this: Mocha.Context) {
+    this.timeout(10000)
+
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const workspaceURI: vscode.Uri = vscode.workspace.workspaceFolders![0].uri
     const buildFolder = vscode.Uri.joinPath(workspaceURI, 'build')

--- a/integration-tests/src/tests/bitbake-parse.test.ts
+++ b/integration-tests/src/tests/bitbake-parse.test.ts
@@ -47,6 +47,7 @@ suite('Bitbake Commands Test Suite', () => {
   })
 
   suiteTeardown(async function (this: Mocha.Context) {
+    this.timeout(10000)
     await vscode.workspace.fs.delete(buildFolder, { recursive: true })
   })
 

--- a/integration-tests/src/tests/command-wrapper.test.ts
+++ b/integration-tests/src/tests/command-wrapper.test.ts
@@ -45,6 +45,7 @@ suite('Bitbake Command Wrapper', () => {
   })
 
   suiteTeardown(async function (this: Mocha.Context) {
+    this.timeout(300000)
     await vscode.workspace.fs.delete(buildFolder, { recursive: true })
 
     const bitbakeConfiguration = vscode.workspace.getConfiguration('bitbake')


### PR DESCRIPTION
In integration tests in CI, the dialog promise is rejected at random time events. try/catch does not catch the error, it must actually be handled in the promise rejection handler.