### PR TITLE
Feat: Grab comments above global symbols and show them on hover

### DIFF
--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -211,7 +211,7 @@ describe('sourceIncludeFiles', () => {
 
     const fsReadFileSyncMock = jest.spyOn(fs, 'readFileSync')
 
-    analyzer.sourceIncludeFiles(uri, [])
+    analyzer.sourceIncludeFiles(uri, [], {})
 
     expect(fsReadFileSyncMock).toHaveBeenCalledWith(FIXTURE_URI.DIRECTIVE.replace('file://', ''), 'utf8')
     expect(fsReadFileSyncMock).toHaveBeenCalledWith(FIXTURE_URI.FOO_INC.replace('file://', ''), 'utf8')
@@ -240,7 +240,7 @@ describe('sourceIncludeFiles', () => {
 
     const loggerMock = jest.spyOn(logger, 'debug')
 
-    analyzer.sourceIncludeFiles(uri, [])
+    analyzer.sourceIncludeFiles(uri, [], {})
 
     let loggerDebugCalledTimes = 0
     loggerMock.mock.calls.forEach((call) => {
@@ -274,7 +274,7 @@ describe('sourceIncludeFiles', () => {
 
     /* eslint-disable-next-line prefer-const */
     let symbols: GlobalDeclarations[] = []
-    analyzer.sourceIncludeFiles(uri, symbols)
+    analyzer.sourceIncludeFiles(uri, symbols, {})
 
     expect(symbols).toEqual(
       expect.arrayContaining([

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -211,7 +211,7 @@ describe('sourceIncludeFiles', () => {
 
     const fsReadFileSyncMock = jest.spyOn(fs, 'readFileSync')
 
-    analyzer.sourceIncludeFiles(uri, [], {})
+    analyzer.sourceIncludeFiles(uri, [], [])
 
     expect(fsReadFileSyncMock).toHaveBeenCalledWith(FIXTURE_URI.DIRECTIVE.replace('file://', ''), 'utf8')
     expect(fsReadFileSyncMock).toHaveBeenCalledWith(FIXTURE_URI.FOO_INC.replace('file://', ''), 'utf8')
@@ -240,7 +240,7 @@ describe('sourceIncludeFiles', () => {
 
     const loggerMock = jest.spyOn(logger, 'debug')
 
-    analyzer.sourceIncludeFiles(uri, [], {})
+    analyzer.sourceIncludeFiles(uri, [], [])
 
     let loggerDebugCalledTimes = 0
     loggerMock.mock.calls.forEach((call) => {
@@ -274,7 +274,7 @@ describe('sourceIncludeFiles', () => {
 
     /* eslint-disable-next-line prefer-const */
     let symbols: GlobalDeclarations[] = []
-    analyzer.sourceIncludeFiles(uri, symbols, {})
+    analyzer.sourceIncludeFiles(uri, symbols, [])
 
     expect(symbols).toEqual(
       expect.arrayContaining([

--- a/server/src/__tests__/fixtures/bbclass/baz.bbclass
+++ b/server/src/__tests__/fixtures/bbclass/baz.bbclass
@@ -1,1 +1,4 @@
 DESCRIPTION = 'baz.bbclass'
+
+# comment 1 for MYVAR in baz.bbclass
+MYVAR = '456'

--- a/server/src/__tests__/fixtures/directive.bb
+++ b/server/src/__tests__/fixtures/directive.bb
@@ -10,12 +10,11 @@ SYMBOL_IN_STRING = 'hover is a package ${FOO} \
         this hover too, other words should not. \
         '
 # comment 1 for DESCRIPTION line 1
-# comment 1 for DESCRIPTION line 2
 DESCRIPTION = 'file://dummy.patch'
-# comment 2 for DESCRIPTION
-DESCRIPTION += 'file://dummy-2.patch'
 # comment 1 for custom variable MYVAR
 MYVAR = '123'
+# comment 2 for custom variable MYVAR
+MYVAR:append = '456'
 # comment 1 for do_build
 do_build(){
 

--- a/server/src/__tests__/fixtures/directive.bb
+++ b/server/src/__tests__/fixtures/directive.bb
@@ -9,3 +9,18 @@ SYMBOL_IN_STRING = 'hover is a package ${FOO} \
         parentFolder/hover should also be seen as symbol \
         this hover too, other words should not. \
         '
+# comment 1 for DESCRIPTION line 1
+# comment 1 for DESCRIPTION line 2
+DESCRIPTION = 'file://dummy.patch'
+# comment 2 for DESCRIPTION
+DESCRIPTION += 'file://dummy-2.patch'
+# comment 1 for custom variable MYVAR
+MYVAR = '123'
+# comment 1 for do_build
+do_build(){
+
+}
+# comment 1 for my_func
+my_func(){
+
+}

--- a/server/src/__tests__/fixtures/inc/bar.inc
+++ b/server/src/__tests__/fixtures/inc/bar.inc
@@ -1,3 +1,5 @@
 DESCRIPTION = 'bar.inc'
 export PYTHON = 'python3'
 APPEND = 'append bar'
+# comment 1 for MYVAR in bar.inc
+MYVAR = '456'

--- a/server/src/__tests__/hover.test.ts
+++ b/server/src/__tests__/hover.test.ts
@@ -500,7 +500,7 @@ describe('on hover', () => {
         uri: DUMMY_URI
       },
       position: {
-        line: 13,
+        line: 14,
         character: 1
       }
     })
@@ -510,66 +510,66 @@ describe('on hover', () => {
         uri: DUMMY_URI
       },
       position: {
-        line: 17,
+        line: 22,
         character: 1
       }
     })
 
-    const shouldShow3 = await onHoverHandler({
+    const shouldNotShow1 = await onHoverHandler({
       textDocument: {
         uri: DUMMY_URI
       },
       position: {
-        line: 19,
+        line: 12,
         character: 1
       }
     })
 
-    const shouldShow4 = await onHoverHandler({
+    const shouldNotShow2 = await onHoverHandler({
       textDocument: {
         uri: DUMMY_URI
       },
       position: {
-        line: 23,
+        line: 18,
         character: 1
       }
     })
 
     const DUMMY_URI_TRIMMED = DUMMY_URI.replace('file://', '')
-    // 1. should show all comments above
+
+    // 1. should show all comments above the symbols that don't have docs from yocto/bitbake
     // 2. should show comments for all declarations for the same variable in the same file
-    // 3. TODO: should show comments for the same variable in the include files
+    // 3. should show comments for the same variable in the include files
     expect(shouldShow1).toEqual(
       expect.objectContaining({
         contents: expect.objectContaining({
-          value: expect.stringContaining(`**Comments**\n___\n comment 1 for DESCRIPTION line 1\n comment 1 for DESCRIPTION line 2\n\nSource: ${DUMMY_URI_TRIMMED} \`L: 14\`\n___\n comment 2 for DESCRIPTION\n\nSource: ${DUMMY_URI_TRIMMED} \`L: 16\``)
-        })
-      })
-    )
-
-    // show comments for custom variable and comments for this variable from the include file
-    expect(shouldShow2).toEqual(
-      expect.objectContaining({
-        contents: expect.objectContaining({
-          value: expect.stringContaining(`**Comments**\n___\n comment 1 for custom variable MYVAR\n\nSource: ${DUMMY_URI_TRIMMED} \`L: 18\`\n___\n comment 1 for MYVAR in bar.inc\n\nSource: ${FIXTURE_DOCUMENT.BAR_INC.uri.replace('file://', '')} \`L: 5\``)
-        })
-      })
-    )
-
-    // show comments for yocto task
-    expect(shouldShow3).toEqual(
-      expect.objectContaining({
-        contents: expect.objectContaining({
-          value: expect.stringContaining(`**Comments**\n___\n comment 1 for do_build\n\nSource: ${DUMMY_URI_TRIMMED} \`L: 20\``)
+          value: expect.stringContaining(` comment 1 for custom variable MYVAR\n\nSource: ${DUMMY_URI_TRIMMED} \`L: 15\`\n___\n comment 2 for custom variable MYVAR\n\nSource: ${DUMMY_URI_TRIMMED} \`L: 17\`\n___\n comment 1 for MYVAR in bar.inc\n\nSource: ${FIXTURE_DOCUMENT.BAR_INC.uri.replace('file://', '')} \`L: 5\``)
         })
       })
     )
 
     // show comments for custom function
-    expect(shouldShow4).toEqual(
+    expect(shouldShow2).toEqual(
       expect.objectContaining({
         contents: expect.objectContaining({
-          value: expect.stringContaining(`**Comments**\n___\n comment 1 for my_func\n\nSource: ${DUMMY_URI_TRIMMED} \`L: 24\``)
+          value: expect.stringContaining(` comment 1 for my_func\n\nSource: ${DUMMY_URI_TRIMMED} \`L: 23\``)
+        })
+      })
+    )
+    // Don't show comments for variables/tasks that already have docs from yocto/bitbake
+
+    expect(shouldNotShow1).not.toEqual(
+      expect.objectContaining({
+        contents: expect.objectContaining({
+          value: expect.stringContaining(`comment 1 for my_func\n\nSource: ${DUMMY_URI_TRIMMED} \`L: 23\``)
+        })
+      })
+    )
+
+    expect(shouldNotShow2).not.toEqual(
+      expect.objectContaining({
+        contents: expect.objectContaining({
+          value: expect.stringContaining(`comment 1 for do_build\n\nSource: ${DUMMY_URI_TRIMMED} \`L: 19\``)
         })
       })
     )

--- a/server/src/__tests__/hover.test.ts
+++ b/server/src/__tests__/hover.test.ts
@@ -539,11 +539,12 @@ describe('on hover', () => {
 
     // 1. should show all comments above the symbols that don't have docs from yocto/bitbake
     // 2. should show comments for all declarations for the same variable in the same file
-    // 3. should show comments for the same variable in the include files
+    // 3. The higher priority comments replace the lower ones according to the order: .bbclass, .conf, .inc, .bb, .bbappend
+
     expect(shouldShow1).toEqual(
       expect.objectContaining({
         contents: expect.objectContaining({
-          value: expect.stringContaining(` comment 1 for custom variable MYVAR\n\nSource: ${DUMMY_URI_TRIMMED} \`L: 15\`\n___\n comment 2 for custom variable MYVAR\n\nSource: ${DUMMY_URI_TRIMMED} \`L: 17\`\n___\n comment 1 for MYVAR in bar.inc\n\nSource: ${FIXTURE_DOCUMENT.BAR_INC.uri.replace('file://', '')} \`L: 5\``)
+          value: expect.stringContaining(` comment 1 for MYVAR in baz.bbclass\n\nSource: ${FIXTURE_DOCUMENT.BAZ_BBCLASS.uri.replace('file://', '')} \`L: 4\``)
         })
       })
     )

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -130,7 +130,7 @@ function getGlobalSymbolComments (uri: string, word: string): string | null {
       })
 
       if (commentsToShow.length > 0) {
-        return `${commentsToShow.map((item) => item.comments.map(comment => comment.slice(1)).join('\n') + `\n\nSource: ${item.uri.replace('file://', '')} \`L: ${item.line + 1}\``).join('\n___\n')}`
+        return `${commentsToShow[0].comments.map(comment => comment.slice(1)).join('\n') + `\n\nSource: ${commentsToShow[0].uri.replace('file://', '')} \`L: ${commentsToShow[0].line + 1}\``}`
       }
     }
   }

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -75,7 +75,11 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
   }
 
   const comments = getGlobalSymbolComments(textDocument.uri, word)
-  hoverValue += comments ?? ''
+
+  // Append comments for variables or tasks that don't have documentation from Yocto/BitBake
+  if (hoverValue === '' && comments !== null) {
+    hoverValue += comments ?? ''
+  }
 
   if (hoverValue !== '') {
     const hover: Hover = {
@@ -102,7 +106,7 @@ function getGlobalSymbolComments (uri: string, word: string): string | null {
     if (symbolComments[word] !== undefined) {
       const allCommentsForSymbol = symbolComments[word]
       if (allCommentsForSymbol.length > 0) {
-        return `\n___\n**Comments**\n___\n${allCommentsForSymbol.map((item) => item.comments.map(comment => comment.slice(1)).join('\n') + `\n\nSource: ${item.uri.replace('file://', '')} \`L: ${item.line + 1}\``).join('\n___\n')}`
+        return `${allCommentsForSymbol.map((item) => item.comments.map(comment => comment.slice(1)).join('\n') + `\n\nSource: ${item.uri.replace('file://', '')} \`L: ${item.line + 1}\``).join('\n___\n')}`
       }
     }
   }


### PR DESCRIPTION
This PR adds the comments above the symbols (Variables and functions) defined in the global scope in the hover definition.
**Sample results**:
Show all comments in the current file and included files
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/3ae96cbc-5c6b-4e2e-9fbc-3031a2f21e99)
The comments are appended at the end
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/5a65fdf9-2d55-42a2-bdcb-6ae1a52bb83e)

Caveat:
The results won't reflect right after modifications on the comments in the included files because it needs to run `analyze()` to update the values. Currently, it needs additional input to trigger it.

What I have in mind are these two:
1. Somehow trigger the `analyze()` on the current file when the included files are modified.
2. Maintain the references of the comments in the included files so that the current file always gets the updated comments.

Despite the caveat, the feature itself is ready for review.