### PR TITLE
Feat: Add hover for Yocto defined variables in embedded Python

### DIFF
--- a/server/src/BitBakeDocScanner.ts
+++ b/server/src/BitBakeDocScanner.ts
@@ -74,6 +74,7 @@ export class BitBakeDocScanner {
   private _yoctoVariableInfo: VariableInfo[] = []
   private _variableFlagInfo: VariableFlagInfo[] = []
   private _yoctoTaskInfo: DocInfo[] = []
+  private _pythonDatastoreFunction: string[] = []
   private _docPath: string = path.join(__dirname, '../../client/resources/docs') // This default path is for the test. The path after the compilation can be different
   private readonly _keywordInfo: DocInfo[] = KEYWORDS
 
@@ -97,11 +98,16 @@ export class BitBakeDocScanner {
     return this._keywordInfo
   }
 
+  get pythonDatastoreFunction (): string[] {
+    return this._pythonDatastoreFunction
+  }
+
   public clearScannedDocs (): void {
     this._bitbakeVariableInfo = []
     this._yoctoVariableInfo = []
     this._variableFlagInfo = []
     this._yoctoTaskInfo = []
+    this._pythonDatastoreFunction = []
   }
 
   public setDocPathAndParse (extensionPath: string): void {
@@ -110,6 +116,7 @@ export class BitBakeDocScanner {
     this.parseBitbakeVariablesFile()
     this.parseYoctoVariablesFile()
     this.parseYoctoTaskFile()
+    this.parsePythonDatastoreFunction()
   }
 
   // TODO: Generalize these parse functions. They all read a file, match some content and store it.
@@ -266,6 +273,26 @@ export class BitBakeDocScanner {
       }
     }
     this._variableFlagInfo = variableFlagInfo
+  }
+
+  public parsePythonDatastoreFunction (): void {
+    const filePath = path.join(this._docPath, 'bitbake-user-manual-metadata.rst')
+    const pattern = /^ {3}\* - ``d\.(?<name>.*)\("X"(.*)\)``/gm
+    let file = ''
+    try {
+      file = fs.readFileSync(filePath, 'utf8')
+    } catch {
+      logger.warn(`Failed to read file at ${filePath}`)
+    }
+    const pythonDatastoreFunction: string[] = []
+    for (const match of file.matchAll(pattern)) {
+      const name = match.groups?.name
+      if (name === undefined) {
+        return
+      }
+      pythonDatastoreFunction.push(name)
+    }
+    this._pythonDatastoreFunction = pythonDatastoreFunction
   }
 }
 

--- a/server/src/__tests__/fixtures/hover.bb
+++ b/server/src/__tests__/fixtures/hover.bb
@@ -31,3 +31,19 @@ my_do_build(){
 inherit dummy
 include dummy.inc
 require dummy.inc
+
+python (){
+    d.getVar("DESCRIPTION")
+    d.setVar('DESCRIPTION', 'value')
+    b.getVar('DESCRIPTION')
+    d.test('DESCRIPTION')
+    d.getVar("FOO")
+    e.data.getVar('DESCRIPTION')
+}
+
+def test ():
+    d.setVar('DESCRIPTION')
+
+VAR = "${@d.getVar("DESCRIPTION")}"
+
+d.getVar("DESCRIPTION")

--- a/server/src/__tests__/hover.test.ts
+++ b/server/src/__tests__/hover.test.ts
@@ -315,4 +315,143 @@ describe('on hover', () => {
       })
     )
   })
+
+  it('shows definition on hovering variable in Python functions for accessing datastore', async () => {
+    bitBakeDocScanner.parseBitbakeVariablesFile()
+    bitBakeDocScanner.parsePythonDatastoreFunction()
+    await analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.HOVER
+    })
+
+    const shouldShow1 = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 35,
+        character: 14
+      }
+    })
+
+    const shouldShow2 = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 36,
+        character: 14
+      }
+    })
+
+    const shouldShow3 = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 40,
+        character: 19
+      }
+    })
+
+    const shouldShow4 = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 46,
+        character: 20
+      }
+    })
+
+    const shouldShow5 = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 44,
+        character: 14
+      }
+    })
+
+    const shouldNotShow1 = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 37,
+        character: 14
+      }
+    })
+
+    const shouldNotShow2 = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 38,
+        character: 12
+      }
+    })
+
+    const shouldNotShow3 = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 39,
+        character: 19
+      }
+    })
+
+    const shouldNotShow4 = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 48,
+        character: 10
+      }
+    })
+
+    expect(shouldShow1).toEqual({
+      contents: {
+        kind: 'markdown',
+        value: '**DESCRIPTION**\n___\n   A long description for the recipe.\n\n'
+      }
+    })
+
+    expect(shouldShow2).toEqual({
+      contents: {
+        kind: 'markdown',
+        value: '**DESCRIPTION**\n___\n   A long description for the recipe.\n\n'
+      }
+    })
+
+    expect(shouldShow3).toEqual({
+      contents: {
+        kind: 'markdown',
+        value: '**DESCRIPTION**\n___\n   A long description for the recipe.\n\n'
+      }
+    })
+
+    expect(shouldShow4).toEqual({
+      contents: {
+        kind: 'markdown',
+        value: '**DESCRIPTION**\n___\n   A long description for the recipe.\n\n'
+      }
+    })
+
+    expect(shouldShow5).toEqual({
+      contents: {
+        kind: 'markdown',
+        value: '**DESCRIPTION**\n___\n   A long description for the recipe.\n\n'
+      }
+    })
+
+    expect(shouldNotShow1).toBe(null)
+    expect(shouldNotShow2).toBe(null)
+    expect(shouldNotShow3).toBe(null)
+    expect(shouldNotShow4).toBe(null)
+  })
 })

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -18,7 +18,7 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
   }
   // Show documentation of a bitbake variable
   // Triggers on global declaration expressions like "VAR = 'foo'" and inside variable expansion like "FOO = ${VAR}" but skip the ones like "python VAR(){}"
-  const canShowHoverDefinitionForVariableName: boolean = (analyzer.getGlobalDeclarationSymbols(textDocument.uri).some((symbol) => symbol.name === word) && analyzer.isIdentifierOfVariableAssignment(params)) || analyzer.isVariableExpansion(textDocument.uri, position.line, position.character)
+  const canShowHoverDefinitionForVariableName: boolean = (analyzer.getGlobalDeclarationSymbols(textDocument.uri).some((symbol) => symbol.name === word) && analyzer.isIdentifierOfVariableAssignment(params)) || analyzer.isVariableExpansion(textDocument.uri, position.line, position.character) || analyzer.isPythonDatastoreVariable(textDocument.uri, position.line, position.character)
   if (canShowHoverDefinitionForVariableName) {
     const found = [
       ...bitBakeDocScanner.bitbakeVariableInfo.filter((bitbakeVariable) => !bitBakeDocScanner.yoctoVariableInfo.some(yoctoVariable => yoctoVariable.name === bitbakeVariable.name)),


### PR DESCRIPTION
This adds hover for Yocto defined variables in embedded Python. It works with [the functions to access the datastore](https://docs.yoctoproject.org/bitbake/bitbake-user-manual/bitbake-user-manual-metadata.html#functions-for-accessing-datastore-variables)

![Screenshot from 2023-12-19 19-42-08](https://github.com/yoctoproject/vscode-bitbake/assets/92585455/5b453db7-7a15-4a6f-900c-0f17dbc24401)
