### PR TITLE
No parsing recipes on watch event

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -102,7 +102,6 @@ connection.onDidChangeWatchedFiles(async (change) => {
       void embeddedLanguageDocsManager.deleteEmbeddedLanguageDocs(change.uri)
     }
   })
-  void connection.sendRequest('bitbake/parseAllRecipes')
 })
 
 connection.onCompletion(onCompletionHandler)

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -12,8 +12,7 @@ import {
   TextDocuments,
   ProposedFeatures,
   TextDocumentSyncKind,
-  type InitializeParams,
-  FileChangeType
+  type InitializeParams
 } from 'vscode-languageserver/node'
 import { bitBakeDocScanner } from './BitBakeDocScanner'
 import { TextDocument } from 'vscode-languageserver-textdocument'
@@ -92,16 +91,6 @@ connection.onShutdown(() => {
 connection.onDidChangeConfiguration(async (change) => {
   logger.level = change.settings.bitbake.loggingLevel
   parseOnSave = change.settings.bitbake.parseOnSave
-})
-
-// eslint-disable-next-line @typescript-eslint/no-misused-promises
-connection.onDidChangeWatchedFiles(async (change) => {
-  logger.debug(`onDidChangeWatchedFiles: ${JSON.stringify(change)}`)
-  change.changes?.forEach((change) => {
-    if (change.type === FileChangeType.Deleted) {
-      void embeddedLanguageDocsManager.deleteEmbeddedLanguageDocs(change.uri)
-    }
-  })
 })
 
 connection.onCompletion(onCompletionHandler)


### PR DESCRIPTION
Currently, the parsing of recipes will happen in `onDidSave`. 
@idillon-sfl According to https://github.com/yoctoproject/vscode-bitbake/pull/30
If we want to remove any watch events, the embedded part needs to be implemented somewhere else.