### PR TITLE
Send bitbake -e <package> output to the server for further processing

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -322,7 +322,7 @@
       {
         "command": "bitbake.scan-recipe-env",
         "title": "BitBake: Scan Recipe",
-        "description": "Scan the recipe for the complete information about the environment."
+        "description": "Run 'bitbake -e' on the chosen recipe to improve the language services such as hover definition"
       },
       {
         "command": "bitbake.drop-recipe",

--- a/client/package.json
+++ b/client/package.json
@@ -320,6 +320,11 @@
         "description": "Run a specific task for a bitbake recipe."
       },
       {
+        "command": "bitbake.scan-recipe-env",
+        "title": "BitBake: Scan Recipe",
+        "description": "Scan the recipe for the complete information about the environment."
+      },
+      {
         "command": "bitbake.drop-recipe",
         "title": "BitBake: Drop a recipe from the active workspace",
         "description": "Stop watching or suggesting a recipe in bitbake commands.",
@@ -433,6 +438,10 @@
         {
           "command": "bitbake.run-task",
           "group": "0@bitbake_recipe@2"
+        },
+        {
+          "command": "bitbake.scan-recipe-env",
+          "group": "0@bitbake_recipe@3"
         },
         {
           "command": "bitbake.devtool-modify",

--- a/client/src/__tests__/unit-tests/driver/bitbake-driver.test.ts
+++ b/client/src/__tests__/unit-tests/driver/bitbake-driver.test.ts
@@ -5,6 +5,7 @@
 
 import * as fs from 'fs'
 import { BitbakeDriver } from '../../../driver/BitbakeDriver'
+import { type BitbakeTaskDefinition } from '../../../ui/BitbakeTaskProvider'
 
 describe('BitbakeDriver Tests', () => {
   it('should protect from shell injections', (done) => {
@@ -75,5 +76,25 @@ describe('BitbakeDriver Tests', () => {
 
     const script = driver.composeBitbakeScript('bitbake busybox')
     expect(script).toEqual(expect.stringContaining("docker run --rm -it -v /home/user/yocto:/workdir crops/poky --workdir=/workdir /bin/bash -c '. /home/user/yocto/poky/oe-init-build-env && bitbake busybox'"))
+  })
+
+  describe('composeBitbakeCommand', () => {
+    let bitbakeDriver: BitbakeDriver
+    beforeEach(() => {
+      bitbakeDriver = new BitbakeDriver()
+    })
+
+    it('should compose bitbake command for scanning recipe environment', () => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const bitbakeTaskDefinition = {
+        recipes: ['recipe1'],
+        options: {
+          env: true
+        }
+      } as BitbakeTaskDefinition
+
+      const command = bitbakeDriver.composeBitbakeCommand(bitbakeTaskDefinition)
+      expect(command).toEqual('bitbake recipe1 -e')
+    })
   })
 })

--- a/client/src/driver/BitbakeDriver.ts
+++ b/client/src/driver/BitbakeDriver.ts
@@ -134,6 +134,13 @@ export class BitbakeDriver {
       return sanitizeForShell(bitbakeTaskDefinition.specialCommand) as string
     }
 
+    const OPTIONS_MAP: Record<keyof BitbakeTaskDefinition['options'], string> = {
+      continue: '-k',
+      force: '-f',
+      parseOnly: '-p',
+      env: '-e'
+    }
+
     let command = 'bitbake'
 
     bitbakeTaskDefinition.recipes?.forEach(recipe => {
@@ -142,14 +149,13 @@ export class BitbakeDriver {
     if (bitbakeTaskDefinition.task !== undefined) {
       command = appendCommandParam(command, `-c ${sanitizeForShell(bitbakeTaskDefinition.task)}`)
     }
-    if (bitbakeTaskDefinition.options?.continue === true) {
-      command = appendCommandParam(command, '-k')
-    }
-    if (bitbakeTaskDefinition.options?.force === true) {
-      command = appendCommandParam(command, '-f')
-    }
-    if (bitbakeTaskDefinition.options?.parseOnly === true) {
-      command = appendCommandParam(command, '-p')
+    const options = bitbakeTaskDefinition.options
+    if (options !== undefined) {
+      Object.keys(options).forEach(key => {
+        if (options[key as keyof BitbakeTaskDefinition['options']] === true) {
+          command = appendCommandParam(command, OPTIONS_MAP[key as keyof BitbakeTaskDefinition['options']])
+        }
+      })
     }
 
     return command

--- a/client/src/driver/BitbakeRecipeScanner.ts
+++ b/client/src/driver/BitbakeRecipeScanner.ts
@@ -57,9 +57,7 @@ export class BitbakeRecipeScanner {
             if (this.scanResults !== '') {
               logger.debug('[onDidEndTask] Sending recipe environment to the server')
               const requestParam: RequestParams['ProcessRecipeScanResults'] = { scanResults: this.scanResults, uri: this._currentUriForScan }
-              const processedScanResults = await this._languageClient.sendRequest(RequestMethod.ProcessRecipeScanResults, requestParam)
-
-              logger.debug('processedScanResults: ' + JSON.stringify(processedScanResults))
+              await this._languageClient.sendNotification(RequestMethod.ProcessRecipeScanResults, requestParam)
             }
           }
         }

--- a/client/src/driver/BitbakeRecipeScanner.ts
+++ b/client/src/driver/BitbakeRecipeScanner.ts
@@ -1,0 +1,66 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode'
+import { type LanguageClient } from 'vscode-languageclient/node'
+import { logger } from '../lib/src/utils/OutputLogger'
+import { runBitbakeTask } from '../ui/BitbakeCommands'
+import { type BitbakeCustomExecution, type BitbakeTaskProvider } from '../ui/BitbakeTaskProvider'
+import { RequestMethod } from '../lib/src/types/requests'
+
+export class BitbakeRecipeScanner {
+  private isPending: boolean = false
+  private _languageClient: LanguageClient | undefined
+
+  public scanResults: string = ''
+
+  async scan (chosenRecipe: string, taskProvider: BitbakeTaskProvider): Promise<void> {
+    const scanRecipeEnvTask = new vscode.Task(
+      { type: 'bitbake', recipes: [chosenRecipe], options: { parseOnly: true, env: true } },
+      vscode.TaskScope.Workspace,
+      'Bitbake: Scan recipe env',
+      'bitbake'
+    )
+
+    const runningTasks = vscode.tasks.taskExecutions
+    if (runningTasks.some((execution) => execution.task.name === scanRecipeEnvTask.name)) {
+      logger.debug('Bitbake parsing task is already running')
+      this.isPending = true
+    }
+
+    await runBitbakeTask(scanRecipeEnvTask, taskProvider)
+  }
+
+  subscribeToTaskEnd (context: vscode.ExtensionContext, taskProvider: BitbakeTaskProvider): void {
+    context.subscriptions.push(vscode.tasks.onDidEndTask(async (e) => {
+      if (e.execution.task.name === 'Bitbake: Scan recipe env') {
+        if (this.isPending) {
+          this.isPending = false
+          await this.scan(e.execution.task.definition.recipes?.[0] ?? '', taskProvider)
+        }
+
+        const executionEngine = e.execution.task.execution as BitbakeCustomExecution
+        if (executionEngine !== undefined) {
+          this.scanResults = executionEngine.pty?.outputDataString ?? ''
+          if (this._languageClient === undefined) {
+            logger.error('[onDidEndTask] Language client not set, unable to forward recipe environment to the server')
+          } else {
+            if (this.scanResults !== '') {
+              logger.debug('[onDidEndTask] Sending recipe environment to the server')
+              void this._languageClient.sendRequest(RequestMethod.ProcessRecipeScanResults, { scanResults: this.scanResults })
+            }
+          }
+        }
+      }
+    }))
+  }
+
+  setLanguageClient (client: LanguageClient): void {
+    this._languageClient = client
+  }
+}
+
+const bitbakeRecipeScanner = new BitbakeRecipeScanner()
+export default bitbakeRecipeScanner

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -114,7 +114,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
         event.affectsConfiguration('bitbake.pathToBitbakeFolder') ||
         event.affectsConfiguration('bitbake.pathToBuildFolder') ||
         event.affectsConfiguration('bitbake.commandWrapper')) {
-      await clientNotificationManager.resetNeverShowAgain('custom/bitbakeSettingsError')
+      await clientNotificationManager.resetNeverShowAgain('bitbake/bitbakeSettingsError')
       logger.debug('Bitbake settings changed')
       updatePythonPath()
       void vscode.commands.executeCommand('bitbake.rescan-project')

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -11,7 +11,7 @@ import { logger } from './lib/src/utils/OutputLogger'
 import { activateLanguageServer, deactivateLanguageServer } from './language/languageClient'
 import { BitbakeDriver } from './driver/BitbakeDriver'
 import { BitbakeTaskProvider } from './ui/BitbakeTaskProvider'
-import { registerBitbakeCommands, registerDevtoolCommands, setLanguageClient } from './ui/BitbakeCommands'
+import { registerBitbakeCommands, registerDevtoolCommands } from './ui/BitbakeCommands'
 import { BitbakeWorkspace } from './ui/BitbakeWorkspace'
 import { BitbakeRecipesView } from './ui/BitbakeRecipesView'
 import { BitbakeStatusBar } from './ui/BitbakeStatusBar'
@@ -20,8 +20,9 @@ import { BitbakeDocumentLinkProvider } from './documentLinkProvider'
 import { DevtoolWorkspacesView } from './ui/DevtoolWorkspacesView'
 import { bitbakeESDKMode, setBitbakeESDKMode } from './driver/BitbakeESDK'
 import path from 'path'
+import bitbakeRecipeScanner from './driver/BitbakeRecipeScanner'
 
-export let client: LanguageClient
+let client: LanguageClient
 const bitbakeDriver: BitbakeDriver = new BitbakeDriver()
 let bitbakeTaskProvider: BitbakeTaskProvider
 let taskProvider: vscode.Disposable
@@ -88,9 +89,11 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
   bitbakeTaskProvider = new BitbakeTaskProvider(bitbakeDriver)
   client = await activateLanguageServer(context)
   bitBakeProjectScanner.setClient(client)
-  setLanguageClient(client)
 
   taskProvider = vscode.tasks.registerTaskProvider('bitbake', bitbakeTaskProvider)
+
+  bitbakeRecipeScanner.setLanguageClient(client)
+  bitbakeRecipeScanner.subscribeToTaskEnd(context, bitbakeTaskProvider)
 
   clientNotificationManager.setMemento(context.workspaceState)
   bitbakeRecipesView = new BitbakeRecipesView(bitbakeWorkspace, bitBakeProjectScanner)

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -11,7 +11,7 @@ import { logger } from './lib/src/utils/OutputLogger'
 import { activateLanguageServer, deactivateLanguageServer } from './language/languageClient'
 import { BitbakeDriver } from './driver/BitbakeDriver'
 import { BitbakeTaskProvider } from './ui/BitbakeTaskProvider'
-import { registerBitbakeCommands, registerDevtoolCommands } from './ui/BitbakeCommands'
+import { registerBitbakeCommands, registerDevtoolCommands, setLanguageClient } from './ui/BitbakeCommands'
 import { BitbakeWorkspace } from './ui/BitbakeWorkspace'
 import { BitbakeRecipesView } from './ui/BitbakeRecipesView'
 import { BitbakeStatusBar } from './ui/BitbakeStatusBar'
@@ -21,7 +21,7 @@ import { DevtoolWorkspacesView } from './ui/DevtoolWorkspacesView'
 import { bitbakeESDKMode, setBitbakeESDKMode } from './driver/BitbakeESDK'
 import path from 'path'
 
-let client: LanguageClient
+export let client: LanguageClient
 const bitbakeDriver: BitbakeDriver = new BitbakeDriver()
 let bitbakeTaskProvider: BitbakeTaskProvider
 let taskProvider: vscode.Disposable
@@ -88,6 +88,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
   bitbakeTaskProvider = new BitbakeTaskProvider(bitbakeDriver)
   client = await activateLanguageServer(context)
   bitBakeProjectScanner.setClient(client)
+  setLanguageClient(client)
 
   taskProvider = vscode.tasks.registerTaskProvider('bitbake', bitbakeTaskProvider)
 

--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -88,7 +88,7 @@ export async function activateLanguageServer (context: ExtensionContext): Promis
   const client: LanguageClient = new LanguageClient('bitbake', 'Bitbake Language Server', serverOptions, clientOptions)
   requestsManager.client = client
 
-  client.onRequest('custom/verifyConfigurationFileAssociation', async (param) => {
+  client.onRequest('bitbake/verifyConfigurationFileAssociation', async (param) => {
     if (param.filePath?.endsWith('.conf') === true) {
       const doc = await workspace.openTextDocument(param.filePath)
       const { languageId } = doc

--- a/client/src/lib/src/types/notifications.ts
+++ b/client/src/lib/src/types/notifications.ts
@@ -10,7 +10,7 @@ enum NotificationType {
 }
 
 export const NotificationMethod: Record<NotificationType, string> = {
-  [NotificationType.EmbeddedLanguageDocs]: 'custom/EmbeddedLanguageDocs'
+  [NotificationType.EmbeddedLanguageDocs]: 'bitbake/EmbeddedLanguageDocs'
 }
 
 export interface NotificationParams {

--- a/client/src/lib/src/types/requests.ts
+++ b/client/src/lib/src/types/requests.ts
@@ -13,9 +13,9 @@ export enum RequestType {
 }
 
 export const RequestMethod: Record<RequestType, string> = {
-  [RequestType.EmbeddedLanguageTypeOnPosition]: 'custom/requestEmbeddedLanguageDocInfos',
-  [RequestType.getLinksInDocument]: 'custom/getLinksInDocument',
-  [RequestType.ProcessRecipeScanResults]: 'custom/ProcessRecipeScanResults'
+  [RequestType.EmbeddedLanguageTypeOnPosition]: 'bitbake/requestEmbeddedLanguageDocInfos',
+  [RequestType.getLinksInDocument]: 'bitbake/getLinksInDocument',
+  [RequestType.ProcessRecipeScanResults]: 'bitbake/ProcessRecipeScanResults'
 }
 
 export interface RequestParams {

--- a/client/src/lib/src/types/requests.ts
+++ b/client/src/lib/src/types/requests.ts
@@ -8,17 +8,20 @@ import { type EmbeddedLanguageType } from './embedded-languages'
 
 export enum RequestType {
   EmbeddedLanguageTypeOnPosition = 'EmbeddedLanguageTypeOnPosition',
-  getLinksInDocument = 'getLinksInDocument'
+  getLinksInDocument = 'getLinksInDocument',
+  ProcessRecipeScanResults = 'ProcessRecipeScanResults'
 }
 
 export const RequestMethod: Record<RequestType, string> = {
-  [RequestType.EmbeddedLanguageTypeOnPosition]: 'custom/requestEmbeddedLanguageTypeOnPosition',
-  [RequestType.getLinksInDocument]: 'custom/getLinksInDocument'
+  [RequestType.EmbeddedLanguageTypeOnPosition]: 'custom/requestEmbeddedLanguageDocInfos',
+  [RequestType.getLinksInDocument]: 'custom/getLinksInDocument',
+  [RequestType.ProcessRecipeScanResults]: 'custom/ProcessRecipeScanResults'
 }
 
 export interface RequestParams {
   [RequestType.EmbeddedLanguageTypeOnPosition]: { uriString: string, position: Position }
   [RequestType.getLinksInDocument]: { documentUri: string }
+  [RequestType.ProcessRecipeScanResults]: { scanResults: string }
 }
 
 export interface RequestResult {

--- a/client/src/lib/src/types/requests.ts
+++ b/client/src/lib/src/types/requests.ts
@@ -21,10 +21,11 @@ export const RequestMethod: Record<RequestType, string> = {
 export interface RequestParams {
   [RequestType.EmbeddedLanguageTypeOnPosition]: { uriString: string, position: Position }
   [RequestType.getLinksInDocument]: { documentUri: string }
-  [RequestType.ProcessRecipeScanResults]: { scanResults: string }
+  [RequestType.ProcessRecipeScanResults]: { scanResults: string, uri: any }
 }
 
 export interface RequestResult {
   [RequestType.EmbeddedLanguageTypeOnPosition]: Promise<EmbeddedLanguageType | undefined | null> // for unknown reasons, the client receives null instead of undefined
   [RequestType.getLinksInDocument]: Promise<Array<{ value: string, range: Range }>>
+  [RequestType.ProcessRecipeScanResults]: Record<string, unknown> | undefined
 }

--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -31,6 +31,7 @@ export function registerBitbakeCommands (context: vscode.ExtensionContext, bitba
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.parse-recipes', async () => { await parseAllrecipes(bitbakeWorkspace, bitbakeTaskProvider) }))
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.build-recipe', async (uri) => { await buildRecipeCommand(bitbakeWorkspace, bitbakeTaskProvider.bitbakeDriver, uri) }))
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.clean-recipe', async (uri) => { await cleanRecipeCommand(bitbakeWorkspace, bitbakeTaskProvider.bitbakeDriver, uri) }))
+  context.subscriptions.push(vscode.commands.registerCommand('bitbake.scan-recipe-env', async (uri) => { await scanRecipeCommand(bitbakeWorkspace, bitbakeTaskProvider.bitbakeDriver, uri) }))
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.run-task', async (uri, task) => { await runTaskCommand(bitbakeWorkspace, bitbakeTaskProvider.bitbakeDriver, uri, task) }))
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.drop-recipe', async (uri) => { await dropRecipe(bitbakeWorkspace, uri) }))
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.watch-recipe', async (recipe) => { await addActiveRecipe(bitbakeWorkspace, recipe) }))
@@ -111,6 +112,23 @@ async function cleanRecipeCommand (bitbakeWorkspace: BitbakeWorkspace, bitbakeDr
         task: 'clean'
       } as BitbakeTaskDefinition,
     `Bitbake: Clean: ${chosenRecipe}`)
+  }
+}
+
+async function scanRecipeCommand (bitbakeWorkspace: BitbakeWorkspace, bitbakeDriver: BitbakeDriver, uri?: any): Promise<void> {
+  const chosenRecipe = await selectRecipe(bitbakeWorkspace, uri)
+  if (chosenRecipe !== undefined) {
+    logger.debug(`Command: scan-recipe-env: ${chosenRecipe}`)
+    await runBitbakeTerminal(
+      bitbakeDriver,
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      {
+        recipes: [chosenRecipe],
+        options: {
+          env: true
+        }
+      } as BitbakeTaskDefinition,
+    `Bitbake: Scan recipe env: ${chosenRecipe}`)
   }
 }
 

--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -118,7 +118,7 @@ async function cleanRecipeCommand (bitbakeWorkspace: BitbakeWorkspace, bitbakeDr
 }
 
 async function scanRecipeCommand (bitbakeWorkspace: BitbakeWorkspace, taskProvider: BitbakeTaskProvider, uri?: any): Promise<void> {
-  const chosenRecipe = await selectRecipe(bitbakeWorkspace, uri)
+  const chosenRecipe = await selectRecipe(bitbakeWorkspace, uri, false)
 
   if (chosenRecipe === undefined) {
     logger.debug('Command: scan-recipe-env: chosen recipe is undefined. Abort command')

--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -134,7 +134,7 @@ async function scanRecipeCommand (bitbakeWorkspace: BitbakeWorkspace, taskProvid
 
   bitbakeSanity = true
 
-  await bitbakeRecipeScanner.scan(chosenRecipe, taskProvider)
+  await bitbakeRecipeScanner.scan(chosenRecipe, taskProvider, uri)
 }
 
 async function runTaskCommand (bitbakeWorkspace: BitbakeWorkspace, bitbakeDriver: BitbakeDriver, uri?: any, task?: any): Promise<void> {

--- a/client/src/ui/BitbakeTaskProvider.ts
+++ b/client/src/ui/BitbakeTaskProvider.ts
@@ -15,6 +15,7 @@ export interface BitbakeTaskDefinition extends vscode.TaskDefinition {
     continue?: boolean
     force?: boolean
     parseOnly?: boolean
+    env?: boolean // Recipe environment
   }
   specialCommand?: string
 }

--- a/client/src/ui/BitbakeTaskProvider.ts
+++ b/client/src/ui/BitbakeTaskProvider.ts
@@ -45,8 +45,7 @@ export class BitbakeTaskProvider implements vscode.TaskProvider {
 
     if (canResolveTask) {
       const bitbakeCommand = this.bitbakeDriver.composeBitbakeCommand(bitbakeTaskDefinition)
-      // No matchers when scanning recipe environment
-      const problemMatchers = bitbakeTaskDefinition.options?.env === true ? [] : ['$bitbake-ParseError', '$bitbake-Variable', '$bitbake-generic', '$bitbake-task-error', '$bitbake-UnableToParse']
+      const problemMatchers = ['$bitbake-ParseError', '$bitbake-Variable', '$bitbake-generic', '$bitbake-task-error', '$bitbake-UnableToParse']
 
       const resolvedTask = new vscode.Task(
         task.definition,

--- a/client/src/ui/BitbakeTerminal.ts
+++ b/client/src/ui/BitbakeTerminal.ts
@@ -58,6 +58,7 @@ export class BitbakePseudoTerminal implements vscode.Pseudoterminal {
   onDidClose = this.closeEmitter.event
   onDidChangeName = this.changeNameEmitter.event
   lastExitCode: number = 0
+  outputDataString: string = ''
 
   readonly parentTerminal: BitbakeTerminal | undefined
   bitbakeDriver: BitbakeDriver
@@ -119,6 +120,7 @@ export class BitbakePseudoTerminal implements vscode.Pseudoterminal {
     processResolved.stdout?.on('data', (data) => {
       this.output(data.toString())
       logger.debug(data.toString())
+      this.outputDataString += data.toString()
     })
     processResolved.stdout?.once('data', () => {
       // I wanted to use appropriate events like process.on('spawn') or terminal.open() but they are not triggered at the right time for

--- a/client/src/ui/BitbakeTerminal.ts
+++ b/client/src/ui/BitbakeTerminal.ts
@@ -120,7 +120,9 @@ export class BitbakePseudoTerminal implements vscode.Pseudoterminal {
     processResolved.stdout?.on('data', (data) => {
       this.output(data.toString())
       logger.debug(data.toString())
-      this.outputDataString += data.toString()
+      if (this.isTaskTerminal()) {
+        this.outputDataString += data.toString()
+      }
     })
     processResolved.stdout?.once('data', () => {
       // I wanted to use appropriate events like process.on('spawn') or terminal.open() but they are not triggered at the right time for

--- a/client/src/ui/ClientNotificationManager.ts
+++ b/client/src/ui/ClientNotificationManager.ts
@@ -14,7 +14,7 @@ export class ClientNotificationManager {
   }
 
   showBitbakeSettingsError (message?: string): void {
-    if (!this.checkIsNeverShowAgain('custom/bitbakeSettingsError')) {
+    if (!this.checkIsNeverShowAgain('bitbake/bitbakeSettingsError')) {
       void window.showErrorMessage(
         'BitBake could not be configured and started. To enable advanced Bitbake features, please configure the Bitbake extension.\n\n' + message,
         'Open Settings',
@@ -25,7 +25,7 @@ export class ClientNotificationManager {
           if (item === 'Open Settings') {
             void commands.executeCommand('workbench.action.openWorkspaceSettings', '@ext:yocto-project.yocto-bitbake')
           } else if (item === 'Don\'t Show Again') {
-            void this.neverShowAgain('custom/bitbakeSettingsError')
+            void this.neverShowAgain('bitbake/bitbakeSettingsError')
           }
         }, (reason) => {
           logger.warn('Could not show bitbake error dialog: ' + reason)

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -55,7 +55,7 @@ describe('analyze', () => {
           location: {
             range: {
               end: {
-                character: 11,
+                character: 17,
                 line: 1
               },
               start: {
@@ -65,7 +65,8 @@ describe('analyze', () => {
             },
             uri: DUMMY_URI
           },
-          name: 'BAR'
+          name: 'BAR',
+          overrides: ['o1', 'o2']
         },
         {
           kind: 13,
@@ -83,47 +84,27 @@ describe('analyze', () => {
             uri: DUMMY_URI
           },
           name: 'FOO'
+        },
+        {
+          kind: 12,
+          location: {
+            range: {
+              end: {
+                character: 1,
+                line: 5
+              },
+              start: {
+                character: 0,
+                line: 3
+              }
+            },
+            uri: DUMMY_URI
+          },
+          overrides: ['o1', 'o2'],
+          name: 'my_func'
         }
       ])
     )
-    expect(globalDeclarations).toMatchInlineSnapshot(`
-      [
-        {
-          "kind": 13,
-          "location": {
-            "range": {
-              "end": {
-                "character": 11,
-                "line": 0,
-              },
-              "start": {
-                "character": 0,
-                "line": 0,
-              },
-            },
-            "uri": "${DUMMY_URI}",
-          },
-          "name": "FOO",
-        },
-        {
-          "kind": 13,
-          "location": {
-            "range": {
-              "end": {
-                "character": 11,
-                "line": 1,
-              },
-              "start": {
-                "character": 0,
-                "line": 1,
-              },
-            },
-            "uri": "${DUMMY_URI}",
-          },
-          "name": "BAR",
-        },
-      ]
-    `)
   })
 
   it('analyzes the document and returns word at point', async () => {

--- a/server/src/__tests__/fixtures/declarations.bb
+++ b/server/src/__tests__/fixtures/declarations.bb
@@ -1,2 +1,6 @@
 FOO = '123'
-BAR = '456'
+BAR:o1:o2 = '456'
+
+python my_func:o1:o2(){
+    pass
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -118,8 +118,8 @@ connection.onRequest(RequestMethod.getLinksInDocument, (params: RequestParams['g
   return analyzer.getLinksInStringContent(params.documentUri)
 })
 
-connection.onRequest(RequestMethod.ProcessRecipeScanResults, (param: RequestParams['ProcessRecipeScanResults']) => {
-  logger.debug(`[OnRequest] <ProcessRecipeScanResults> uri:  ${JSON.stringify(param.uri)}`)
+connection.onNotification(RequestMethod.ProcessRecipeScanResults, (param: RequestParams['ProcessRecipeScanResults']) => {
+  logger.debug(`[onNotification] <ProcessRecipeScanResults> uri:  ${JSON.stringify(param.uri)}`)
   analyzer.processRecipeScanResults(param.scanResults, param.uri)
 })
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -118,6 +118,10 @@ connection.onRequest(RequestMethod.getLinksInDocument, (params: RequestParams['g
   return analyzer.getLinksInStringContent(params.documentUri)
 })
 
+connection.onRequest(RequestMethod.ProcessRecipeScanResults, (param: RequestParams['ProcessRecipeScanResults']) => {
+  logger.debug(`[OnRequest] <ProcessRecipeScanResults> ${param.scanResults.length}`)
+})
+
 connection.listen()
 
 documents.onDidChangeContent(async (event) => {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -119,7 +119,8 @@ connection.onRequest(RequestMethod.getLinksInDocument, (params: RequestParams['g
 })
 
 connection.onRequest(RequestMethod.ProcessRecipeScanResults, (param: RequestParams['ProcessRecipeScanResults']) => {
-  logger.debug(`[OnRequest] <ProcessRecipeScanResults> ${param.scanResults.length}`)
+  logger.debug(`[OnRequest] <ProcessRecipeScanResults> uri:  ${JSON.stringify(param.uri)}`)
+  analyzer.processRecipeScanResults(param.scanResults, param.uri)
 })
 
 connection.listen()

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -141,7 +141,7 @@ documents.onDidChangeContent(async (event) => {
   // Other language extensions might also associate .conf files with their langauge modes
   if (textDocument.uri.endsWith('.conf')) {
     logger.debug('verifyConfigurationFileAssociation')
-    await connection.sendRequest('custom/verifyConfigurationFileAssociation', { filePath: new URL(textDocument.uri).pathname })
+    await connection.sendRequest('bitbake/verifyConfigurationFileAssociation', { filePath: new URL(textDocument.uri).pathname })
   }
 })
 


### PR DESCRIPTION
This PR adds an option in the contextual menu to trigger **bitbake some-recipe -e** in the terminal and ~uses the results to provide more robust information about the environment of the selected recipe such as the complete include history, the current final value for a variable, etc.~ sends the results to the server for further processing.

Edit: This PR only prepares the parsing. 
Edit-2: The actual processing will be in other PRs.

Ticket No. 10429