### PR TITLE
Fix some errors not matched by problem matcher

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -205,12 +205,22 @@
           "autoDetect",
           "${cwd}"
         ],
-        "pattern": {
-          "regexp": "^.*ParseError (at|in) (.+?):(\\d+)?:? (.+)$",
-          "file": 2,
-          "line": 3,
-          "message": 4
-        }
+        "pattern": [
+          {
+            "regexp": "^.*ParseError (at|in) (.+?):(\\d+)?:? (unparsed line: '(.+)')$",
+            "file": 2,
+            "line": 3,
+            "message": 4,
+            "code": 5,
+            "column": 0
+          },
+          {
+            "regexp": "(ERROR): (Unable to parse (.+))$",
+            "severity": 1,
+            "file": 3,
+            "message": 2
+          }
+        ]
       },
       {
         "name": "bitbake-UnableToParse",
@@ -244,7 +254,7 @@
         }
       },
       {
-        "name": "bitbake-generic",
+        "name": "bitbake-compilation-python-function",
         "source": "bitbake",
         "owner": "bitbake",
         "fileLocation": [
@@ -252,10 +262,26 @@
           "${cwd}"
         ],
         "pattern": {
-          "regexp": "^Parsing recipes...(ERROR): (.+?): (.*)$",
+          "regexp": "(ERROR): (.+): (Error in compiling python function) in (.*), line (\\d+):$",
           "file": 2,
           "severity": 1,
+          "line": 5,
           "message": 3
+        }
+      },
+      {
+        "name": "bitbake-execution-error",
+        "source": "bitbake",
+        "owner": "bitbake",
+        "fileLocation": [
+          "autoDetect",
+          "${cwd}"
+        ],
+        "pattern": {
+          "regexp": "(^Parsing recipes...)?(ERROR): (.+?): (.*):?$",
+          "file": 3,
+          "severity": 2,
+          "message": 4
         }
       },
       {

--- a/client/package.json
+++ b/client/package.json
@@ -213,12 +213,6 @@
             "message": 4,
             "code": 5,
             "column": 0
-          },
-          {
-            "regexp": "(ERROR): (Unable to parse (.+))$",
-            "severity": 1,
-            "file": 3,
-            "message": 2
           }
         ]
       },
@@ -231,9 +225,10 @@
           "${cwd}"
         ],
         "pattern": {
-          "regexp": "^ERROR: (Unable to parse) (.+)$",
-          "file": 2,
-          "message": 1,
+          "regexp": "(ERROR): (Unable to parse (.+))$",
+          "severity": 1,
+          "file": 3,
+          "message": 2,
           "kind": "File"
         }
       },

--- a/client/package.json
+++ b/client/package.json
@@ -307,6 +307,7 @@
       {
         "command": "bitbake.watch-recipe",
         "title": "BitBake: Add a recipe to the active workspace",
+        "icon": "$(add)",
         "description": "Start watching or suggesting a recipe in bitbake commands."
       },
       {
@@ -440,8 +441,13 @@
       ],
       "view/title": [
         {
-          "command": "bitbake.rescan-project",
+          "command": "bitbake.watch-recipe",
           "group": "navigation@0",
+          "when": "view == bitbakeRecipes"
+        },
+        {
+          "command": "bitbake.rescan-project",
+          "group": "navigation@1",
           "when": "view == bitbakeRecipes"
         }
       ],

--- a/client/package.json
+++ b/client/package.json
@@ -241,7 +241,7 @@
           "${cwd}"
         ],
         "pattern": {
-          "regexp": "^Parsing recipes...(ERROR): (.+?): (.*?) file: (.+) line: (\\d+) (.*)$",
+          "regexp": "(^Parsing recipes...)?(ERROR): (.+?): (.*?) file: (.+) line: (\\d+) (.*)$",
           "file": 2,
           "line": 5,
           "severity": 1,

--- a/client/src/ui/BitbakeTaskProvider.ts
+++ b/client/src/ui/BitbakeTaskProvider.ts
@@ -51,7 +51,7 @@ export class BitbakeTaskProvider implements vscode.TaskProvider {
             this.bitbakeDriver.composeBitbakeScript(bitbakeCommand))
           return pty
         }),
-        ['$bitbake-ParseError', '$bitbake-Variable', '$bitbake-generic', '$bitbake-task-error', '$bitbake-UnableToParse']
+        ['$bitbake-ParseError', '$bitbake-Variable', '$bitbake-compilation-python-function', '$bitbake-execution-error', '$bitbake-task-error', '$bitbake-UnableToParse']
       )
       if ((bitbakeTaskDefinition.task === undefined || bitbakeTaskDefinition.task.includes('build')) &&
           bitbakeTaskDefinition.options?.parseOnly !== true) {

--- a/integration-tests/project-folder/sources/meta-error/recipes-error/error/compilation-python-function.bb
+++ b/integration-tests/project-folder/sources/meta-error/recipes-error/error/compilation-python-function.bb
@@ -1,0 +1,6 @@
+# ERROR: [file-path]: Error in compiling python function in [file-path], line [line-number]:
+# [multiline-error-info]
+# SyntaxError: [error-reason] ([file-name], line [line-number])
+python() {
+    garbage(code
+}

--- a/integration-tests/project-folder/sources/meta-error/recipes-error/error/error.bb
+++ b/integration-tests/project-folder/sources/meta-error/recipes-error/error/error.bb
@@ -1,1 +1,0 @@
-undefinedvariable

--- a/integration-tests/project-folder/sources/meta-error/recipes-error/error/execution-python-function.bb
+++ b/integration-tests/project-folder/sources/meta-error/recipes-error/error/execution-python-function.bb
@@ -1,0 +1,7 @@
+# ERROR: [file-path]: Error executing a python function in  <code>:
+# [multiline-error-info]
+# Exception: TypeError: [error-reason]
+LICENSE="GPL-2.0-only"
+python() {
+    '2' + 2
+}

--- a/integration-tests/project-folder/sources/meta-error/recipes-error/error/task-error.bb
+++ b/integration-tests/project-folder/sources/meta-error/recipes-error/error/task-error.bb
@@ -1,0 +1,14 @@
+# When .vscode/tasks.json has the following entry:
+# {
+#     "tasks": [
+#         {
+#             "type":"bitbake",
+#             "recipes": ["base-files"],
+#         }
+#     ]
+# }
+
+#ERROR: Task ([file-path]:do_install) failed with exit code '1'
+do_install:append () {
+    bbfatal should crash
+}

--- a/integration-tests/project-folder/sources/meta-error/recipes-error/error/unable-to-parse.bb
+++ b/integration-tests/project-folder/sources/meta-error/recipes-error/error/unable-to-parse.bb
@@ -1,0 +1,8 @@
+# WARNING: [file-path]: Error during finalise of [file-path]
+# ERROR: Unable to parse [file-path]
+# [multiline-error-info]
+# SyntaxError: [error-reason]
+LICENSE="GPL-2.0-only"
+python do_compile() {
+    garbage(code
+}

--- a/integration-tests/project-folder/sources/meta-error/recipes-error/error/unparsed-line.bb
+++ b/integration-tests/project-folder/sources/meta-error/recipes-error/error/unparsed-line.bb
@@ -1,0 +1,6 @@
+# NOTE:
+# Some error lines start with 'Parsing recipes...' but sometimes these words appear on a different line than the ones with 'ERROR:'
+# Hence do not use '^Parsing recipes...' as part of the regex
+
+# ERROR: ParseError at [file-path]:[line-number]: unparsed line: 'undefinedvariable'
+undefinedvariable

--- a/integration-tests/project-folder/sources/meta-error/recipes-error/error/variable-error.bb
+++ b/integration-tests/project-folder/sources/meta-error/recipes-error/error/variable-error.bb
@@ -1,0 +1,2 @@
+# ERROR: Variable BB_ENV_EXTRAWHITE has been renamed to BB_ENV_PASSTHROUGH_ADDITIONS (file: [file-path] line: [line-number])
+BB_ENV_EXTRAWHITE = "deprecated var"

--- a/integration-tests/src/tests/bitbake-parse.test.ts
+++ b/integration-tests/src/tests/bitbake-parse.test.ts
@@ -46,7 +46,9 @@ suite('Bitbake Parsing Test Suite', () => {
       'recipes-error/error/compilation-python-function.bb',
       'recipes-error/error/execution-python-function.bb',
       'recipes-error/error/unable-to-parse.bb',
-      'recipes-error/error/unparsed-line.bb'
+      'recipes-error/error/unparsed-line.bb',
+      'recipes-error/error/task-error.bb',
+      'recipes-error/error/variable-error.bb'
     ]
 
     const workspacePath: string = workspaceURI.fsPath

--- a/integration-tests/src/utils/bitbake.ts
+++ b/integration-tests/src/utils/bitbake.ts
@@ -10,8 +10,7 @@ export const BITBAKE_TIMEOUT = 300000
 
 // TODO If bitbake-layers vscode commands are added in the future, use them instead
 export async function addLayer (layer: string, workspaceFolder: string): Promise<void> {
-  const buildFolder = vscode.Uri.joinPath(vscode.Uri.file(workspaceFolder), 'build')
-  const bblayersConf = vscode.Uri.joinPath(buildFolder, 'conf/bblayers.conf')
+  const bblayersConf = getBBlayersConfUri(workspaceFolder)
   const bblayersConfContent = await vscode.workspace.fs.readFile(bblayersConf)
   let fileContent = bblayersConfContent.toString()
   fileContent += `\nBBLAYERS+="${layer}"\n`
@@ -20,8 +19,7 @@ export async function addLayer (layer: string, workspaceFolder: string): Promise
 
 // Replace with remove-layer command if available
 export async function resetLayer (layer: string, workspaceFolder: string): Promise<void> {
-  const buildFolder = vscode.Uri.joinPath(vscode.Uri.file(workspaceFolder), 'build')
-  const bblayersConf = vscode.Uri.joinPath(buildFolder, 'conf/bblayers.conf')
+  const bblayersConf = getBBlayersConfUri(workspaceFolder)
   const bblayersConfContent = await vscode.workspace.fs.readFile(bblayersConf)
 
   // Remove last line
@@ -41,4 +39,30 @@ export async function awaitBitbakeParsingResult (): Promise<void> {
   })
   await assertWillComeTrue(async () => taskExecuted)
   disposable.dispose()
+}
+
+export async function excludeRecipes (recipes: string[], workspaceFolder: string): Promise<void> {
+  const bblayersConfUri = getBBlayersConfUri(workspaceFolder)
+  const bblayersConfContent = await vscode.workspace.fs.readFile(bblayersConfUri)
+  let fileContent = bblayersConfContent.toString()
+  for (const recipe of recipes) {
+    fileContent += `\nBBMASK+="${recipe}"\n`
+  }
+  await vscode.workspace.fs.writeFile(bblayersConfUri, Buffer.from(fileContent))
+}
+
+export async function resetExcludedRecipes (workspaceFolder: string): Promise<void> {
+  const bblayersConfUri = getBBlayersConfUri(workspaceFolder)
+  const bblayersConfContent = await vscode.workspace.fs.readFile(bblayersConfUri)
+
+  const lines = bblayersConfContent.toString().split('\n')
+  const fileContentWithoutBBMASK = lines.filter((line) => (
+    !line.includes('BBMASK')
+  )).join('\n')
+  await vscode.workspace.fs.writeFile(bblayersConfUri, Buffer.from(fileContentWithoutBBMASK))
+}
+
+function getBBlayersConfUri (workspaceFolder: string): vscode.Uri {
+  const buildFolder = vscode.Uri.joinPath(vscode.Uri.file(workspaceFolder), 'build')
+  return vscode.Uri.joinPath(buildFolder, 'conf/bblayers.conf')
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -143,7 +143,7 @@ documents.onDidChangeContent(async (event) => {
 
 documents.onDidSave(async (event) => {
   if (parseOnSave && !eSDKMode) {
-    logger.debug(`onDidSave ${JSON.stringify(event)}`)
+    logger.debug('[onDidSave] Parsing all recipes...')
     void connection.sendRequest('bitbake/parseAllRecipes')
   }
 })


### PR DESCRIPTION
Removed `bitbake-generic` since it could cover a wide range of error messages. Precise ones should be used to avoid overlap since they differ in the positions of the line numbers.

