### PR TITLE
Chore: Add oe to Python path and imports

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -19,6 +19,7 @@ import { BitBakeProjectScanner } from './driver/BitBakeProjectScanner'
 import { BitbakeDocumentLinkProvider } from './documentLinkProvider'
 import { DevtoolWorkspacesView } from './ui/DevtoolWorkspacesView'
 import { bitbakeESDKMode, setBitbakeESDKMode } from './driver/BitbakeESDK'
+import path from 'path'
 
 let client: LanguageClient
 const bitbakeDriver: BitbakeDriver = new BitbakeDriver()
@@ -50,10 +51,13 @@ function updatePythonPath (): void {
   const pythonConfig = vscode.workspace.getConfiguration('python')
   const pathToBitbakeFolder = bitbakeConfig.pathToBitbakeFolder
   const pathToBitbakeLib = `${pathToBitbakeFolder}/lib`
+  const pathToPokyMetaLib = path.join(pathToBitbakeFolder, '../meta/lib') // We assume BitBake is into Poky
   for (const pythonSubConf of ['autoComplete.extraPaths', 'analysis.extraPaths']) {
     const extraPaths = pythonConfig.get<string[]>(pythonSubConf) ?? []
-    if (!extraPaths.includes(pathToBitbakeLib)) {
-      extraPaths.push(`${pathToBitbakeFolder}/lib`)
+    for (const pathToAdd of [pathToBitbakeLib, pathToPokyMetaLib]) {
+      if (!extraPaths.includes(pathToAdd)) {
+        extraPaths.push(pathToAdd)
+      }
       void pythonConfig.update(pythonSubConf, extraPaths, vscode.ConfigurationTarget.Workspace)
     }
   }

--- a/client/src/language/middlewareDefinition.ts
+++ b/client/src/language/middlewareDefinition.ts
@@ -139,8 +139,8 @@ const getDefinitionOfD = async <DefinitionType extends Location | LocationLink>(
   return await redirectDefinition(definition, dRange, dataSmartPosition)
 }
 
-export const eRange = new Range(4, 0, 4, 1) // Where `e` is located in the embedded language document
-export const eventPosition = new Position(4, 12) // Where `Event` (event.Event()) is reachable in the embedded language document
+export const eRange = new Range(3, 0, 3, 1) // Where `e` is located in the embedded language document
+export const eventPosition = new Position(3, 14) // Where `Event` (event.Event()) is reachable in the embedded language document
 
 // Handle `e` in `e.data.getVar('')`
 const getDefinitionOfE = async <DefinitionType extends Location | LocationLink>(

--- a/integration-tests/project-folder/sources/meta-fixtures/definition.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures/definition.bb
@@ -9,6 +9,7 @@ TEST = "${@e.data.getVar()}"
 def test ():
   d = ''
   print(d)
+  oe
 
 test() {
   FOO=''

--- a/integration-tests/src/tests/definition.test.ts
+++ b/integration-tests/src/tests/definition.test.ts
@@ -77,8 +77,14 @@ suite('Bitbake Definition Test Suite', () => {
     await testDefinition(position, expectedPathEnding)
   }).timeout(300000)
 
+  test('Definition appears properly in Python on oe', async () => {
+    const position = new vscode.Position(11, 3)
+    const expectedPathEnding = 'meta/lib/oe/__init__.py'
+    await testDefinition(position, expectedPathEnding)
+  }).timeout(300000)
+
   test('Definition appears properly on Bash variable', async () => {
-    const position = new vscode.Position(14, 3)
+    const position = new vscode.Position(15, 3)
     const expectedPathEnding = filePath
     const expectedRange = new vscode.Range(13, 2, 13, 8)
     await testDefinition(position, expectedPathEnding, expectedRange)

--- a/server/src/embedded-languages/python-support.ts
+++ b/server/src/embedded-languages/python-support.ts
@@ -20,6 +20,7 @@ export const imports = [
   'e = event.Event()',
   'e.data = d',
   'import os',
+  'import oe.data, oe.path, oe.utils, oe.types, oe.package, oe.packagegroup, oe.sstatesig, oe.lsb, oe.cachedpath, oe.license, oe.qa, oe.reproducible, oe.rust, oe.buildcfgoe',
   ''
 ].join('\n')
 

--- a/server/src/embedded-languages/python-support.ts
+++ b/server/src/embedded-languages/python-support.ts
@@ -13,14 +13,12 @@ import { embeddedLanguageDocsManager } from './documents-manager'
 import { type EmbeddedLanguageDoc, insertTextIntoEmbeddedLanguageDoc, initEmbeddedLanguageDoc } from './utils'
 
 export const imports = [
-  'import bb',
-  'from bb import data_smart',
-  'd = data_smart.DataSmart()',
-  'from bb import event',
-  'e = event.Event()',
+  'import bb, bb.build, bb.compress.zstd, bb.data, bb.data_smart, bb.event, bb.fetch2, bb.parse, bb.persist_data, bb.process, bb.progress, bb.runqueue, bb.siggen, bb.utils',
+  'import oe.data, oe.path, oe.utils, oe.types, oe.package, oe.packagegroup, oe.sstatesig, oe.lsb, oe.cachedpath, oe.license, oe.qa, oe.reproducible, oe.rust, oe.buildcfgoe',
+  'd = bb.data_smart.DataSmart()',
+  'e = bb.event.Event()',
   'e.data = d',
   'import os',
-  'import oe.data, oe.path, oe.utils, oe.types, oe.package, oe.packagegroup, oe.sstatesig, oe.lsb, oe.cachedpath, oe.license, oe.qa, oe.reproducible, oe.rust, oe.buildcfgoe',
   ''
 ].join('\n')
 


### PR DESCRIPTION
It also improves the handling of bb. For example, the previous version was not able to find any information for bb.utils.