### PR TITLE
Handle problems spamming

### DIFF
--- a/client/TROUBLESHOOTING.md
+++ b/client/TROUBLESHOOTING.md
@@ -3,11 +3,13 @@
 ## Known Issues
 
 ### Problems from Unknown Files Appear in the Problems Tab
+*Note Diagnostics are currently deactivated to avoid further issues*
 Errors and warnings appear twice in the "PROBLEMS" tab. They first appear for the BitBake files to which they belong, and then again for Bash or Python files with UUID names (ex. 9ad23ed5-9278-41e0-98cd-349750c1e2c0.py). As the first one is expected and desired, the second is not. This issue arises from the way we handle diagnostics (errors and warnings). See [Trade-offs on Diagnostics](TROUBLESHOOTING.md#trade-offs-on-diagnostics).
 
 Unfortunately, the VS Code API does not offer a way to programmatically filter the "PROBLEMS" tab. However, manual filtering is still possible. Typing `!workspaceStorage` or `!workspaceStorage/**/yocto-project.yocto-bitbake/embedded-documents` (if more precision is needed) should filter out all these unwanted problems.
 
 ### Tabs from Unknown Files Open and Close Quickly
+*Note Diagnostics are currently deactivated to avoid further issues*
 While typing, tabs with UUID names (ex. aa2a3ba2-769c-4900-8f5f-31ea16bfbc8f.sh) might occasionally open in the tabs bar and then close shortly thereafter.  This occurs as a result of our method for handling diagnostics (errors and warnings). See [Trade-offs on Diagnostics](TROUBLESHOOTING.md#trade-offs-on-diagnostics).
 
 We haven't found a way to prevent these tabs from opening, but we try to close them as quickly as possible.
@@ -15,6 +17,7 @@ We haven't found a way to prevent these tabs from opening, but we try to close t
 ## Trade-offs
 
 ### Trade-offs on Diagnostics
+*Note Diagnostics are currently deactivated to avoid further issues*
 Some functionalities for [embedded Bash and Python code](https://code.visualstudio.com/api/language-extensions/embedded-languages) are provided by other VS Code extensions, such as ms-python.python or timonwong.shellcheck. To achieve this, we extract the Bash and Python content from the BitBake files and create temporary Bash or Python files that can be analyzed by Bash or Python extensions. We adapt the results of these extensions, and present them to the user. It works well for Completion, Definition and Hover. Unfortunately VS Code [does not yet offer such functionality for diagnostics](https://github.com/yoctoproject/vscode-bitbake/pull/18). We still achieve it by some homemade hacky technique that consists of opening the temporary documents in the background, in a way to trigger the generation of diagnostics. It brings a couple of issues, but we hope it is still worth having the diagnostics.
 
 The related issues:

--- a/client/src/language/EmbeddedLanguageDocsManager.ts
+++ b/client/src/language/EmbeddedLanguageDocsManager.ts
@@ -143,6 +143,8 @@ export default class EmbeddedLanguageDocsManager {
     const workspaceEdit = new WorkspaceEdit()
     workspaceEdit.replace(uri, fullRange, embeddedLanguageDoc.content)
     await workspace.applyEdit(workspaceEdit)
+    // Sometimes document closes before the saving, so we open it again just in case
+    await workspace.openTextDocument(uri)
     await document.save()
     this.registerEmbeddedLanguageDocInfos(embeddedLanguageDoc, uri)
     const fileWaitingToUpdate = this.filesWaitingToUpdate.get(uri.toString())

--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -27,7 +27,6 @@ import { middlewareProvideDefinition } from './middlewareDefinition'
 import { embeddedLanguageDocsManager } from './EmbeddedLanguageDocsManager'
 import { logger } from '../lib/src/utils/OutputLogger'
 import { NotificationMethod, type NotificationParams } from '../lib/src/types/notifications'
-import { updateDiagnostics } from './diagnosticsSupport'
 
 export async function activateLanguageServer (context: ExtensionContext): Promise<LanguageClient> {
   const serverModule = context.asAbsolutePath(path.join('server', 'server.js'))
@@ -71,7 +70,8 @@ export async function activateLanguageServer (context: ExtensionContext): Promis
 
   languages.onDidChangeDiagnostics(e => {
     e.uris.forEach(uri => {
-      void updateDiagnostics(uri)
+      // Deactivation until we understand why problems are spamming when a lot of documents are opened
+      // void updateDiagnostics(uri)
     })
   })
 

--- a/integration-tests/src/tests/diagnostics.test.ts
+++ b/integration-tests/src/tests/diagnostics.test.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
+/*
 import * as assert from 'assert'
 import * as vscode from 'vscode'
 import path from 'path'
@@ -42,3 +43,4 @@ suite('Bitbake Diagnostics Test Suite', () => {
     })
   }).timeout(BITBAKE_TIMEOUT)
 })
+*/

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -122,8 +122,8 @@ connection.listen()
 
 documents.onDidChangeContent(async (event) => {
   const textDocument = event.document
-
-  if (textDocument.getText().length > 0) {
+  const previousVersion = analyzer.getAnalyzedDocument(textDocument.uri)?.version ?? -1
+  if (textDocument.getText().length > 0 && previousVersion < textDocument.version) {
     const diagnostics = analyzer.analyze({ document: textDocument, uri: textDocument.uri })
     const embeddedLanguageDocs: NotificationParams['EmbeddedLanguageDocs'] | undefined = generateEmbeddedLanguageDocs(event.document)
     if (embeddedLanguageDocs !== undefined) {

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -29,6 +29,7 @@ import { bitBakeProjectScannerClient } from '../BitbakeProjectScannerClient'
 import { bitBakeDocScanner } from '../BitBakeDocScanner'
 
 export interface AnalyzedDocument {
+  version: number // TextDocument is mutable and its version updates as the document updates
   document: TextDocument
   globalDeclarations: GlobalDeclarations
   globalSymbolComments: GlobalSymbolComments
@@ -81,6 +82,7 @@ export default class Analyzer {
     this.sourceIncludeFiles(uri, extraSymbols, includeFileUris, { td: document, tree })
 
     this.uriToAnalyzedDocument[uri] = {
+      version: document.version,
       document,
       globalDeclarations,
       globalSymbolComments,
@@ -499,6 +501,7 @@ export default class Analyzer {
           globalDeclarations = getGlobalDeclarationsAndComments({ tree: parsedTree, uri })[0]
 
           this.uriToAnalyzedDocument[uri] = {
+            version: textDocument.version,
             document: textDocument,
             globalDeclarations,
             globalSymbolComments: getGlobalDeclarationsAndComments({ tree: parsedTree, uri })[1],


### PR DESCRIPTION
This fixes two problems that occurred when many documents were being opened in the editor:
- onDidChangeContent being called non-stop
- failure to programmatically save a document because it is closed

However, there are others problems happening in that situation that could not be solved.

If you reactivate the diagnostics and open a lot of documents (about thirty), the diagnostics start becoming unstable. They start being re-analyzed non-stop,  making them appearing and disappearing, and slowing down everything. For that reason, the diagnostics have been deactivated