### PR TITLE
Fix some package names can't trigger go-to-definition

### DIFF
--- a/server/src/__tests__/definition.test.ts
+++ b/server/src/__tests__/definition.test.ts
@@ -164,6 +164,7 @@ describe('on definition', () => {
   it('provides go to definition for symbols found in the string content', async () => {
     const parsedHoverPath = path.parse(FIXTURE_DOCUMENT.HOVER.uri.replace('file://', ''))
     const somePackagePath = path.parse(FIXTURE_DOCUMENT.HOVER.uri.replace('file://', '').replace('hover.bb', 'some-package.bb'))
+    const somePackagePath2 = path.parse(FIXTURE_DOCUMENT.HOVER.uri.replace('file://', '').replace('hover.bb', 'some-package+1.inc'))
 
     bitBakeProjectScannerClient.bitbakeScanResult._recipes = [
       {
@@ -183,6 +184,11 @@ describe('on definition', () => {
       {
         name: somePackagePath.name,
         path: somePackagePath,
+        extraInfo: 'layer: core'
+      },
+      {
+        name: somePackagePath2.name,
+        path: somePackagePath2,
         extraInfo: 'layer: core'
       }
     ]
@@ -232,6 +238,36 @@ describe('on definition', () => {
       }
     })
 
+    const shouldWork5 = onDefinitionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 28,
+        character: 42
+      }
+    })
+
+    const shouldWork6 = onDefinitionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 28,
+        character: 65
+      }
+    })
+
+    const shouldWork7 = onDefinitionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 28,
+        character: 78
+      }
+    })
+
     const shouldNotWork = onDefinitionHandler({
       textDocument: {
         uri: DUMMY_URI
@@ -257,6 +293,26 @@ describe('on definition', () => {
     expect(shouldWork4).toEqual(
       [{
         uri: 'file://' + somePackagePath.dir + '/some-package.bb',
+        range: {
+          start: {
+            line: 0,
+            character: 0
+          },
+          end: {
+            line: 0,
+            character: 0
+          }
+        }
+      }]
+    )
+
+    expect(shouldWork5).toEqual(shouldWork4)
+
+    expect(shouldWork6).toEqual(shouldWork4)
+
+    expect(shouldWork7).toEqual(
+      [{
+        uri: 'file://' + somePackagePath2.dir + '/some-package+1.inc',
         range: {
           start: {
             line: 0,

--- a/server/src/__tests__/definition.test.ts
+++ b/server/src/__tests__/definition.test.ts
@@ -163,6 +163,7 @@ describe('on definition', () => {
 
   it('provides go to definition for symbols found in the string content', async () => {
     const parsedHoverPath = path.parse(FIXTURE_DOCUMENT.HOVER.uri.replace('file://', ''))
+    const somePackagePath = path.parse(FIXTURE_DOCUMENT.HOVER.uri.replace('file://', '').replace('hover.bb', 'some-package.bb'))
 
     bitBakeProjectScannerClient.bitbakeScanResult._recipes = [
       {
@@ -177,6 +178,11 @@ describe('on definition', () => {
             name: 'hover-append'
           }
         ],
+        extraInfo: 'layer: core'
+      },
+      {
+        name: somePackagePath.name,
+        path: somePackagePath,
         extraInfo: 'layer: core'
       }
     ]
@@ -216,6 +222,16 @@ describe('on definition', () => {
       }
     })
 
+    const shouldWork4 = onDefinitionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 26,
+        character: 20
+      }
+    })
+
     const shouldNotWork = onDefinitionHandler({
       textDocument: {
         uri: DUMMY_URI
@@ -237,6 +253,22 @@ describe('on definition', () => {
     expect(shouldWork2).toEqual(shouldWork1)
 
     expect(shouldWork3).toEqual(shouldWork1)
+
+    expect(shouldWork4).toEqual(
+      [{
+        uri: 'file://' + somePackagePath.dir + '/some-package.bb',
+        range: {
+          start: {
+            line: 0,
+            character: 0
+          },
+          end: {
+            line: 0,
+            character: 0
+          }
+        }
+      }]
+    )
 
     expect(shouldNotWork).toEqual([])
   })

--- a/server/src/__tests__/definition.test.ts
+++ b/server/src/__tests__/definition.test.ts
@@ -165,6 +165,7 @@ describe('on definition', () => {
     const parsedHoverPath = path.parse(FIXTURE_DOCUMENT.HOVER.uri.replace('file://', ''))
     const somePackagePath = path.parse(FIXTURE_DOCUMENT.HOVER.uri.replace('file://', '').replace('hover.bb', 'some-package.bb'))
     const somePackagePath2 = path.parse(FIXTURE_DOCUMENT.HOVER.uri.replace('file://', '').replace('hover.bb', 'some-package+1.inc'))
+    const somePackagePath3 = path.parse(FIXTURE_DOCUMENT.HOVER.uri.replace('file://', '').replace('hover.bb', 'some-package-2.0.bb'))
 
     bitBakeProjectScannerClient.bitbakeScanResult._recipes = [
       {
@@ -189,6 +190,11 @@ describe('on definition', () => {
       {
         name: somePackagePath2.name,
         path: somePackagePath2,
+        extraInfo: 'layer: core'
+      },
+      {
+        name: somePackagePath3.name,
+        path: somePackagePath3,
         extraInfo: 'layer: core'
       }
     ]
@@ -268,6 +274,16 @@ describe('on definition', () => {
       }
     })
 
+    const shouldWork8 = onDefinitionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 26,
+        character: 33
+      }
+    })
+
     const shouldNotWork = onDefinitionHandler({
       textDocument: {
         uri: DUMMY_URI
@@ -313,6 +329,22 @@ describe('on definition', () => {
     expect(shouldWork7).toEqual(
       [{
         uri: 'file://' + somePackagePath2.dir + '/some-package+1.inc',
+        range: {
+          start: {
+            line: 0,
+            character: 0
+          },
+          end: {
+            line: 0,
+            character: 0
+          }
+        }
+      }]
+    )
+
+    expect(shouldWork8).toEqual(
+      [{
+        uri: 'file://' + somePackagePath3.dir + '/some-package-2.0.bb',
         range: {
           start: {
             line: 0,

--- a/server/src/__tests__/fixtures/directive.bb
+++ b/server/src/__tests__/fixtures/directive.bb
@@ -23,7 +23,7 @@ do_build(){
 my_func(){
 
 }
-# package names that contain hyphen
-RDEPENDS:${PN} += 'some-package'
+# package names that contain hyphen; some numbers with dots
+RDEPENDS:${PN} += 'some-package some-package-2.0'
 # package names that follow '--enable-' or '--disable-', and when + is part of the name
 PACKAGECONFIG[some-package3] = "--enable-some-package,--disable-some-package,some-package+1"

--- a/server/src/__tests__/fixtures/directive.bb
+++ b/server/src/__tests__/fixtures/directive.bb
@@ -23,3 +23,5 @@ do_build(){
 my_func(){
 
 }
+# package names that contain hyphen
+RDEPENDS:${PN} += 'some-package'

--- a/server/src/__tests__/fixtures/directive.bb
+++ b/server/src/__tests__/fixtures/directive.bb
@@ -25,3 +25,5 @@ my_func(){
 }
 # package names that contain hyphen
 RDEPENDS:${PN} += 'some-package'
+# package names that follow '--enable-' or '--disable-', and when + is part of the name
+PACKAGECONFIG[some-package3] = "--enable-some-package,--disable-some-package,some-package+1"

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -586,7 +586,7 @@ export default class Analyzer {
    */
   public getSymbolsInStringContent (uri: string, line: number, character: number): SymbolInformation[] {
     const allSymbolsAtPosition: SymbolInformation[] = []
-    const wholeWordRegex = /(?<![-.:])\b(\w+)\b(?![-.:])/g
+    const wholeWordRegex = /(?<![-.:])\b([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\b(?![-.:])/g
     const n = this.nodeAtPoint(uri, line, character)
     if (n?.type === 'string_content') {
       this.processSymbolsInStringContent(n, wholeWordRegex, (start, end, match) => {

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -586,12 +586,13 @@ export default class Analyzer {
    */
   public getSymbolsInStringContent (uri: string, line: number, character: number): SymbolInformation[] {
     const allSymbolsAtPosition: SymbolInformation[] = []
-    const wholeWordRegex = /(?<![-.:])(--(enable|disable)-)?\b(?<name>[a-zA-Z0-9][a-zA-Z0-9-+]*[a-zA-Z0-9])\b(?![-.:])/g
+    const wholeWordRegex = /(?<![-.:])(--(enable|disable)-)?\b(?<name>[a-zA-Z0-9][a-zA-Z0-9-+.]*[a-zA-Z0-9])\b(?![-.:])/g
     const n = this.nodeAtPoint(uri, line, character)
     if (n?.type === 'string_content') {
       this.processSymbolsInStringContent(n, wholeWordRegex, (start, end, match) => {
         const symbolName = match.groups?.name
         if (symbolName !== undefined) {
+          logger.debug(`[Analyzer] Found symbol in string content: ${symbolName}`)
           if (this.positionIsInRange(line, character, { start, end })) {
             const foundRecipe = bitBakeProjectScannerClient.bitbakeScanResult._recipes.find((recipe) => {
               return recipe.name === symbolName


### PR DESCRIPTION
Fixed the regex that caused some package names containing special characters to not get matched.

Example:
`base-files` in:
https://github.com/yoctoproject/poky/blob/master/meta/recipes-extended/bash/bash.inc#L25
`gtk+3` in:
https://github.com/yoctoproject/poky/blob/98c5c96dd3902cdc4a455a9ed46591037ab3f676/meta/recipes-connectivity/avahi/avahi_0.8.bb#L52
`glib-2.0` in:
https://github.com/yoctoproject/poky/blob/98c5c96dd3902cdc4a455a9ed46591037ab3f676/meta/recipes-connectivity/bluez5/bluez5.inc#L9C1-L9C26