### PR TITLE
Feat: Improve auto-indentation

### DIFF
--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -28,6 +28,7 @@ import { embeddedLanguageDocsManager } from './EmbeddedLanguageDocsManager'
 import { logger } from '../lib/src/utils/OutputLogger'
 import { NotificationMethod, type NotificationParams } from '../lib/src/types/notifications'
 import { updateDiagnostics } from './diagnosticsSupport'
+import { getLanguageConfiguration } from './languageConfiguration'
 
 export async function activateLanguageServer (context: ExtensionContext): Promise<LanguageClient> {
   const serverModule = context.asAbsolutePath(path.join('server', 'server.js'))
@@ -68,6 +69,8 @@ export async function activateLanguageServer (context: ExtensionContext): Promis
       provideHover: middlewareProvideHover
     }
   }
+
+  languages.setLanguageConfiguration('bitbake', getLanguageConfiguration())
 
   languages.onDidChangeDiagnostics(e => {
     e.uris.forEach(uri => {

--- a/client/src/language/languageConfiguration.ts
+++ b/client/src/language/languageConfiguration.ts
@@ -1,0 +1,123 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { IndentAction, type LanguageConfiguration } from 'vscode'
+import { verboseRegExp } from '../lib/src/utils/regexp'
+
+export function getLanguageConfiguration (): LanguageConfiguration {
+  return {
+    // These rules are from vscode-python extension. We assume Python rules won't interfere into bash code or regular BitBake code.
+    // The comments are also from vscode-python, and refer to issues on its repository.
+    // https://github.com/microsoft/vscode-python/blob/63cf2633919f694bf62e104129f050f8a0a3f85b/src/client/language/languageConfiguration.ts
+    onEnterRules: [
+      // multi-line separator
+      {
+        beforeText: verboseRegExp(`
+          ^
+          (?! \\s+ \\\\ )
+          [^#\n]+
+          \\\\
+          $
+        `),
+        action: {
+          indentAction: IndentAction.Indent
+        }
+      },
+      // continue comments
+      {
+        beforeText: /^\s*#.*/,
+        afterText: /.+$/,
+        action: {
+          indentAction: IndentAction.None,
+          appendText: '# '
+        }
+      },
+      // indent on enter (block-beginning statements)
+      {
+        /**
+             * This does not handle all cases. However, it does handle nearly all usage.
+             * Here's what it does not cover:
+             * - the statement is split over multiple lines (and hence the ":" is on a different line)
+             * - the code block is inlined (after the ":")
+             * - there are multiple statements on the line (separated by semicolons)
+             * Also note that `lambda` is purposefully excluded.
+             */
+        beforeText: verboseRegExp(`
+          ^
+          \\s*
+          (?:
+            (?:
+              (?:
+                class |
+                def |
+                async \\s+ def |
+                except |
+                for |
+                async \\s+ for |
+                if |
+                elif |
+                while |
+                with |
+                async \\s+ with |
+                match |
+                case
+              )
+              \\b .*
+            ) |
+            else |
+            try |
+            finally
+          )
+          \\s*
+          [:]
+          \\s*
+          (?: [#] .* )?
+          $
+        `),
+        action: {
+          indentAction: IndentAction.Indent
+        }
+      },
+      // outdent on enter (block-ending statements)
+      {
+        /**
+             * This does not handle all cases. Notable omissions here are
+             * "return" and "raise" which are complicated by the need to
+             * only outdent when the cursor is at the end of an expression
+             * rather than, say, between the parentheses of a tail-call or
+             * exception construction. (see issue #10583)
+             */
+        beforeText: verboseRegExp(`
+          ^
+          (?:
+            (?:
+              \\s*
+              (?:
+                pass
+              )
+            ) |
+            (?:
+              \\s+
+              (?:
+                raise |
+                break |
+                continue
+              )
+            )
+          )
+          \\s*
+          (?: [#] .* )?
+          $
+        `),
+        action: {
+          indentAction: IndentAction.Outdent
+        }
+      }
+      // Note that we do not currently have an auto-dedent
+      // solution for "elif", "else", "except", and "finally".
+      // We had one but had to remove it (see issue #6886).
+    ]
+  }
+}

--- a/client/src/lib/src/utils/regexp.ts
+++ b/client/src/lib/src/utils/regexp.ts
@@ -1,0 +1,29 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+// This function is from vscode-python under the MIT license
+// https://github.com/microsoft/vscode-python/blob/63cf2633919f694bf62e104129f050f8a0a3f85b/src/client/common/utils/regexp.ts
+/* Generate a RegExp from a "verbose" pattern.
+ *
+ * All whitespace in the pattern is removed, including newlines.  This
+ * allows the pattern to be much more readable by allowing it to span
+ * multiple lines and to separate tokens with insignificant whitespace.
+ * The functionality is similar to the VERBOSE ("x") flag in Python's
+ * regular expressions.
+ *
+ * Note that significant whitespace in the pattern must be explicitly
+ * indicated by "\s".  Also, unlike with regular expression literals,
+ * backslashes must be escaped.  Conversely, forward slashes do not
+ * need to be escaped.
+ *
+ * Line comments are also removed.  A comment is two spaces followed
+ * by `#` followed by a space and then the rest of the text to the
+ * end of the line.
+ */
+export function verboseRegExp (pattern: string, flags?: string): RegExp {
+  pattern = pattern.replace(/(^| {2})# .*$/gm, '')
+  pattern = pattern.replace(/\s+?/g, '')
+  return RegExp(pattern, flags)
+}


### PR DESCRIPTION
This increase or decrease the indentation in Python as the user types. For example, the indentation will increase if the user presses enter after `if True:`. It will decrease when the user presses enter after `continue`. It will also start a comment on a new line if the user presses enter after `a` into `# a comment` (this one even works into Bash code).

After exploring various solutions that did not work, I decided to simply copy-paste the code from vscode-python. I can't imagine any realistic case where the Python rules would interfere into Bash code. It will give inconsistent indentation in Bash code if the user press enter after writing something such `if:`, but this would be just as invalid bash code with or without indentation anyway.

I've not attempted to add auto-indentation for bash code, as Bash IDE does not do it.