### PR TITLE
Fix: can't match package names with extra postfix

### DIFF
--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -586,11 +586,11 @@ export default class Analyzer {
    */
   public getSymbolsInStringContent (uri: string, line: number, character: number): SymbolInformation[] {
     const allSymbolsAtPosition: SymbolInformation[] = []
-    const wholeWordRegex = /(?<![-.:])(--(enable|disable)-)?\b(?<name>[a-zA-Z0-9][a-zA-Z0-9-+.]*[a-zA-Z0-9])\b(?![-.:])/g
+    const wholeWordRegex = /(?<![-.:])(--(enable|disable)-)?\b(?<name>[a-zA-Z0-9][a-zA-Z0-9-+.]*[a-zA-Z0-9])\b(-binaries)?(?![-.:])/g
     const n = this.nodeAtPoint(uri, line, character)
     if (n?.type === 'string_content') {
       this.processSymbolsInStringContent(n, wholeWordRegex, (start, end, match) => {
-        const symbolName = match.groups?.name
+        const symbolName = match.groups?.name.replace(/(-binaries)$/, '')
         if (symbolName !== undefined) {
           logger.debug(`[Analyzer] Found symbol in string content: ${symbolName}`)
           if (this.positionIsInRange(line, character, { start, end })) {


### PR DESCRIPTION
Match package names that follow this patter: 
`PACKAGES += "${BPN}-binaries" `

Example: 
https://github.com/yoctoproject/poky/blob/1bbdc674aef8abada28d130a23752c1d8a4620b9/meta/recipes-core/glibc/glibc-locale.inc#L39

Ticket No. 13779