### PR TITLE
Feat: Add support for embedded bash tools

### DIFF
--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -55,6 +55,13 @@ export async function activateLanguageServer (context: ExtensionContext): Promis
     })
   })
 
+  const sendSettings = async (): Promise<void> => {
+    const settings = workspace.getConfiguration()
+    await client.sendNotification('workspace/didChangeConfiguration', { settings })
+  }
+
+  workspace.onDidChangeConfiguration(sendSettings)
+
   // Options to control the language client
   const clientOptions: LanguageClientOptions = {
     // Register the server for bitbake documents
@@ -142,6 +149,7 @@ export async function activateLanguageServer (context: ExtensionContext): Promis
 
   // Start the client and launch the server
   await client.start()
+  await sendSettings()
 
   return client
 }

--- a/client/src/lib/src/BitbakeSettings.ts
+++ b/client/src/lib/src/BitbakeSettings.ts
@@ -44,7 +44,7 @@ export function loadBitbakeSettings (settings: any, workspaceFolder: string): Bi
   return resolvedSettings
 }
 
-function resolveSettingPath (configurationPath: string | undefined, variables: NodeJS.Dict<string>): string | undefined {
+export function resolveSettingPath (configurationPath: string | undefined, variables: NodeJS.Dict<string>): string | undefined {
   if (configurationPath === '' || configurationPath === undefined) {
     return undefined
   }

--- a/integration-tests/project-folder/sources/meta-fixtures/hover.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures/hover.bb
@@ -12,4 +12,6 @@ python do_build() {
 }
 
 do_build() {
+    bbwarn
+    oe_runmake
 }

--- a/integration-tests/src/tests/hover.test.ts
+++ b/integration-tests/src/tests/hover.test.ts
@@ -73,15 +73,15 @@ suite('Bitbake Hover Test Suite', () => {
     await testHover(position, expected)
   }).timeout(BITBAKE_TIMEOUT)
 
-  test('Hover shows description for function defined into meta/classes-global/logging.bbclass', async () => {
+  test('Hover shows description for function defined into poky/meta/classes-global/logging.bbclass', async () => {
     const position = new vscode.Position(14, 6)
-    const expected = 'Function: **bbwarn** - *defined in'
+    const expected = 'Function: **bbwarn** - *defined in ../poky/meta/classes-global/logging.bbclass*'
     await testHover(position, expected)
   }).timeout(BITBAKE_TIMEOUT)
 
-  test('Hover shows description for function defined into meta/classes-global/base.bbclass', async () => {
+  test('Hover shows description for function defined into poky/meta/classes-global/base.bbclass', async () => {
     const position = new vscode.Position(15, 6)
-    const expected = 'Function: **oe_runmake** - *defined in'
+    const expected = 'Function: **oe_runmake** - *defined in ../poky/meta/classes-global/base.bbclass*'
     await testHover(position, expected)
   }).timeout(BITBAKE_TIMEOUT)
 })

--- a/integration-tests/src/tests/hover.test.ts
+++ b/integration-tests/src/tests/hover.test.ts
@@ -72,4 +72,16 @@ suite('Bitbake Hover Test Suite', () => {
     const expected = 'The default task for all recipes. This task depends on all other normal'
     await testHover(position, expected)
   }).timeout(BITBAKE_TIMEOUT)
+
+  test('Hover shows description for function defined into meta/classes-global/logging.bbclass', async () => {
+    const position = new vscode.Position(14, 6)
+    const expected = 'Function: **bbwarn** - *defined in'
+    await testHover(position, expected)
+  }).timeout(BITBAKE_TIMEOUT)
+
+  test('Hover shows description for function defined into meta/classes-global/base.bbclass', async () => {
+    const position = new vscode.Position(15, 6)
+    const expected = 'Function: **oe_runmake** - *defined in'
+    await testHover(position, expected)
+  }).timeout(BITBAKE_TIMEOUT)
 })

--- a/server/src/embedded-languages/bash-support.ts
+++ b/server/src/embedded-languages/bash-support.ts
@@ -25,7 +25,7 @@ export const bashHeader = [
   ''
 ].join('\n')
 
-export const generateBashEmbeddedLanguageDoc = (analyzedDocument: AnalyzedDocument): EmbeddedLanguageDoc => {
+export const generateBashEmbeddedLanguageDoc = (analyzedDocument: AnalyzedDocument, pokyFolder?: string): EmbeddedLanguageDoc => {
   const embeddedLanguageDoc = initEmbeddedLanguageDoc(analyzedDocument.document, 'bash')
   TreeSitterUtils.forEach(analyzedDocument.tree.rootNode, (node) => {
     switch (node.type) {
@@ -39,11 +39,23 @@ export const generateBashEmbeddedLanguageDoc = (analyzedDocument: AnalyzedDocume
     }
   })
   insertBashHeader(embeddedLanguageDoc)
+  if (pokyFolder !== undefined) {
+    insertBashTools(embeddedLanguageDoc, pokyFolder)
+  }
   return embeddedLanguageDoc
 }
 
 const insertBashHeader = (embeddedLanguageDoc: EmbeddedLanguageDoc): void => {
   insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, 0, 0, bashHeader)
+}
+
+const insertBashTools = (embeddedLanguageDoc: EmbeddedLanguageDoc, pokyFolder: string): void => {
+  const bashTools = [
+    `. ${pokyFolder}/meta/classes-global/logging.bbclass`,
+    `. ${pokyFolder}/meta/classes-global/base.bbclass`,
+    ''
+  ].join('\n')
+  insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, 0, 0, bashTools)
 }
 
 const handleFunctionDefinitionNode = (node: SyntaxNode, embeddedLanguageDoc: EmbeddedLanguageDoc): void => {

--- a/server/src/embedded-languages/general-support.ts
+++ b/server/src/embedded-languages/general-support.ts
@@ -11,13 +11,13 @@ import { generatePythonEmbeddedLanguageDoc } from './python-support'
 import { type EmbeddedLanguageDoc, type EmbeddedLanguageType } from '../lib/src/types/embedded-languages'
 import { analyzer } from '../tree-sitter/analyzer'
 
-export const generateEmbeddedLanguageDocs = (textDocument: TextDocument): EmbeddedLanguageDoc[] | undefined => {
+export const generateEmbeddedLanguageDocs = (textDocument: TextDocument, pokyFolder?: string): EmbeddedLanguageDoc[] | undefined => {
   const analyzedDocument = analyzer.getAnalyzedDocument(textDocument.uri)
   if (analyzedDocument === undefined) {
     return
   }
   return [
-    generateBashEmbeddedLanguageDoc(analyzedDocument),
+    generateBashEmbeddedLanguageDoc(analyzedDocument, pokyFolder),
     generatePythonEmbeddedLanguageDoc(analyzedDocument)
   ]
 }


### PR DESCRIPTION
This adds hover, completion and diagnotics for the functions defined into `poky/meta/classes-global/logging.bbclass`  and `poky/meta/classes-global/base.bbclass`. It also prevents them from being marked as undefined by the diagnostics tools.

This also reintroduces synchronization for the vscode settings on the language server (onDidChangeConfiguration was not working anymore). 