### PR TITLE
Feat: Handle Quick Fix python.addImport

### DIFF
--- a/client/src/language/codeActionProvider.ts
+++ b/client/src/language/codeActionProvider.ts
@@ -1,0 +1,112 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import vscode from 'vscode'
+import { requestsManager } from './RequestManager'
+import { embeddedLanguageDocsManager } from './EmbeddedLanguageDocsManager'
+import { getEmbeddedLanguageDocRange, getIndentationOnLine, getOriginalDocPosition } from './utils'
+import { logger } from '../lib/src/utils/OutputLogger'
+import { type Range } from 'vscode-languageclient'
+import { type EmbeddedLanguageType } from '../lib/src/types/embedded-languages'
+
+export class BitbakeCodeActionProvider implements vscode.CodeActionProvider {
+  async provideCodeActions (document: vscode.TextDocument, range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext, token: vscode.CancellationToken): Promise<vscode.CodeAction[]> {
+    const diagnostics = context.diagnostics
+    const actions = await Promise.all(
+      diagnostics.map(async (diagnostic) => await buildActionFromDiagnostic(document, diagnostic))
+    ).then((results) => results.flat())
+    return actions
+  }
+}
+
+const buildActionFromDiagnostic = async (document: vscode.TextDocument, diagnostic: vscode.Diagnostic): Promise<vscode.CodeAction[]> => {
+  const originalRange = diagnostic.range
+  const embeddedLanguageType = await requestsManager.getEmbeddedLanguageTypeOnPosition(document.uri.toString(), originalRange.start)
+  if (embeddedLanguageType === undefined || embeddedLanguageType === null) {
+    // We currently do not provide fixes for the Bitbake language, we only forwards embedded language fixes
+    return []
+  } else {
+    return await buildActionFromEmbeddedLanguageDiagnostic(document, originalRange, embeddedLanguageType)
+  }
+}
+
+const buildActionFromEmbeddedLanguageDiagnostic = async (
+  document: vscode.TextDocument,
+  originalRange: vscode.Range,
+  embeddedLanguageType: EmbeddedLanguageType
+): Promise<vscode.CodeAction[]> => {
+  const embeddedLanguageDocInfos = embeddedLanguageDocsManager.getEmbeddedLanguageDocInfos(document.uri.toString(), embeddedLanguageType)
+  if (embeddedLanguageDocInfos === undefined || embeddedLanguageDocInfos === null) {
+    return []
+  }
+  const embeddedLanguageTextDocument = await vscode.workspace.openTextDocument(embeddedLanguageDocInfos.uri)
+  const embeddedRange = getEmbeddedLanguageDocRange(
+    document,
+    embeddedLanguageTextDocument,
+    embeddedLanguageDocInfos.characterIndexes,
+    originalRange
+  )
+
+  const tempActions = await vscode.commands.executeCommand<vscode.CodeAction[]>(
+    'vscode.executeCodeActionProvider',
+    embeddedLanguageDocInfos.uri,
+    embeddedRange
+  )
+
+  const actions: vscode.CodeAction[] = []
+  tempActions.forEach((action) => {
+    switch (action.command?.command) {
+      case 'python.addImport':
+        handlePythonAddImport(action, document, embeddedLanguageTextDocument, embeddedLanguageDocInfos.characterIndexes)
+        break
+      default:
+        return
+    }
+    actions.push(action)
+  })
+
+  return actions
+}
+
+type PythonAddImportArguments = [
+  path: string,
+  range: Range,
+  targetName: string,
+  moduleName: string | null,
+]
+const handlePythonAddImport = (
+  action: vscode.CodeAction,
+  originalTextDocument: vscode.TextDocument,
+  embeddedLanguageTextDocument: vscode.TextDocument,
+  characterIndexes: number[]
+): void => {
+  if (action.command === undefined) {
+    return
+  }
+  if (action.command?.command !== 'python.addImport') {
+    logger.error(`[handlePythonAddImport] Invalid command ${action.command?.command} (should be 'python.addImport')`)
+    return
+  }
+  const [, range, targetName, moduleName] = action.command?.arguments as PythonAddImportArguments
+  const originalStartPosition = getOriginalDocPosition(
+    originalTextDocument,
+    embeddedLanguageTextDocument,
+    characterIndexes,
+    new vscode.Position(range.start.line, range.start.character)
+  )
+  if (originalStartPosition === undefined) {
+    return
+  }
+  const indentationOnLine = getIndentationOnLine(originalTextDocument, originalStartPosition.line)
+  const moduleSpecification = moduleName !== null ? `from ${moduleName} ` : ''
+  const workspaceEdit = new vscode.WorkspaceEdit()
+  workspaceEdit.insert(
+    originalTextDocument.uri,
+    new vscode.Position(originalStartPosition.line, 0),
+    `${indentationOnLine}${moduleSpecification}import ${targetName}\n`
+  )
+  delete action.command
+  action.edit = workspaceEdit
+}

--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -30,6 +30,7 @@ import { logger } from '../lib/src/utils/OutputLogger'
 import { NotificationMethod, type NotificationParams } from '../lib/src/types/notifications'
 import { updateDiagnostics } from './diagnosticsSupport'
 import { getLanguageConfiguration } from './languageConfiguration'
+import { BitbakeCodeActionProvider } from './codeActionProvider'
 
 export async function activateLanguageServer (context: ExtensionContext): Promise<LanguageClient> {
   const serverModule = context.asAbsolutePath(path.join('server', 'server.js'))
@@ -85,6 +86,10 @@ export async function activateLanguageServer (context: ExtensionContext): Promis
       void updateDiagnostics(uri)
     })
   })
+
+  context.subscriptions.push(
+    languages.registerCodeActionsProvider('bitbake', new BitbakeCodeActionProvider())
+  )
 
   if (context.storageUri?.fsPath === undefined) {
     logger.error('Failed to get storage path')

--- a/client/src/language/utils.ts
+++ b/client/src/language/utils.ts
@@ -44,12 +44,28 @@ export const getEmbeddedLanguageDocPosition = (
   return embeddedLanguageTextDocument.positionAt(embeddedLanguageDocOffset)
 }
 
+export const getEmbeddedLanguageDocRange = (
+  originalTextDocument: TextDocument,
+  embeddedLanguageTextDocument: TextDocument,
+  characterIndexes: number[],
+  originalRange: Range
+): Range => {
+  const start = getEmbeddedLanguageDocPosition(originalTextDocument, embeddedLanguageTextDocument, characterIndexes, originalRange.start)
+  const end = getEmbeddedLanguageDocPosition(originalTextDocument, embeddedLanguageTextDocument, characterIndexes, originalRange.end)
+  return new Range(start, end)
+}
+
 export const checkIsPositionEqual = (position1: Position, position2: Position): boolean => {
   return position1.line === position2.line && position1.character === position2.character
 }
 
 export const checkIsRangeEqual = (range1: Range, range2: Range): boolean => {
   return checkIsPositionEqual(range1.start, range2.start) && checkIsPositionEqual(range1.end, range2.end)
+}
+
+export const getIndentationOnLine = (document: TextDocument, lineNumber: number): string => {
+  const line = document.lineAt(lineNumber)
+  return line.text.slice(0, line.firstNonWhitespaceCharacterIndex)
 }
 
 export const checkIsDefinitionUriEqual = (definition: Location | LocationLink, uri: Uri): boolean => {

--- a/integration-tests/project-folder/sources/meta-fixtures/code-actions.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures/code-actions.bb
@@ -1,0 +1,3 @@
+python() {
+    random()
+}

--- a/integration-tests/src/tests/code-actions.test.ts
+++ b/integration-tests/src/tests/code-actions.test.ts
@@ -1,0 +1,77 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import path from 'path'
+import { assertWillComeTrue } from '../utils/async'
+import { BITBAKE_TIMEOUT } from '../utils/bitbake'
+import { checkIsPositionEqual } from '../utils/vscode-tools'
+
+suite('Bitbake CodeAction Test Suite', () => {
+  const filePath = path.resolve(__dirname, '../../project-folder/sources/meta-fixtures/code-actions.bb')
+  const docUri = vscode.Uri.parse(`file://${filePath}`)
+
+  suiteSetup(async function (this: Mocha.Context) {
+    this.timeout(100000)
+    const vscodeBitbake = vscode.extensions.getExtension('yocto-project.yocto-bitbake')
+    if (vscodeBitbake === undefined) {
+      assert.fail('Bitbake extension is not available')
+    }
+    await vscodeBitbake.activate()
+    await vscode.workspace.openTextDocument(docUri)
+  })
+
+  const testPythonAddImport = async (
+    targetRange: vscode.Range,
+    expectedTitle: string,
+    expectedNewText: string,
+    expectedRange: vscode.Range
+  ): Promise<void> => {
+    let actionResult: vscode.CodeAction[] = []
+
+    await assertWillComeTrue(async () => {
+      actionResult = await vscode.commands.executeCommand<vscode.CodeAction[]>(
+        'vscode.executeCodeActionProvider',
+        docUri,
+        targetRange
+      )
+      return actionResult.length > 0
+    })
+
+    const expectedAction = actionResult.find(action => action.title === expectedTitle)
+    if (expectedAction === undefined) {
+      assert.fail('expectedAction is undefined')
+    }
+    assert.notEqual(expectedAction, undefined)
+    const workspaceEdit = expectedAction.edit
+    if (workspaceEdit === undefined) {
+      assert.fail('edit is undefined')
+    }
+    assert.strictEqual(workspaceEdit.entries().length, 1)
+    const [uri, textEdit] = workspaceEdit.entries()[0]
+    assert.strictEqual(uri.fsPath, docUri.fsPath)
+    assert.strictEqual(textEdit.length, 1)
+    assert.strictEqual(textEdit[0].newText, expectedNewText)
+    const range = textEdit[0].range
+    assert.strictEqual(checkIsPositionEqual(range.start, expectedRange.start), true)
+  }
+
+  test('CodeAction can properly show "import random"', async () => {
+    const targetRange = new vscode.Range(1, 4, 1, 10)
+    const expectedTitle = 'Add "import random"'
+    const expectedNewText = '    import random\n'
+    const expectedRange = new vscode.Range(1, 0, 1, 0)
+    await testPythonAddImport(targetRange, expectedTitle, expectedNewText, expectedRange)
+  }).timeout(BITBAKE_TIMEOUT)
+
+  test('CodeAction can properly show "from random import random"', async () => {
+    const targetRange = new vscode.Range(1, 4, 1, 10)
+    const expectedTitle = 'Add "from random import random"'
+    const expectedNewText = '    from random import random\n'
+    const expectedRange = new vscode.Range(1, 0, 1, 0)
+    await testPythonAddImport(targetRange, expectedTitle, expectedNewText, expectedRange)
+  }).timeout(BITBAKE_TIMEOUT)
+})


### PR DESCRIPTION
This proposes vscode-python's quick fixes when Python imports are missing.
![Screenshot from 2024-01-19 20-00-10](https://github.com/yoctoproject/vscode-bitbake/assets/92585455/f578e3f8-9aed-4d6d-b12e-d3188d7aba53)
![Screenshot from 2024-01-19 20-00-36](https://github.com/yoctoproject/vscode-bitbake/assets/92585455/ffb53909-a6aa-4ba5-8406-5b1b8592332a)


Final result is
``` python
python() {
    import random
    random()
}
```

It is not very sophisticated. The new import will always appear on the line just before. Furthermore, if it imports two objects from the same module, it will create two lines instead of putting both imports on the same line (it will never do `from random import random, choice`.

For now it is more a proof a concept, in order to decide if we want to put more efforts on quick fixes.