### PR TITLE
Fix: Completion on last character of embedded language blocks

### DIFF
--- a/integration-tests/project-folder/sources/meta-fixtures/completion.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures/completion.bb
@@ -1,9 +1,9 @@
-DESCRIPTION = 'FOO'
-
 python do_foo(){
-    print('123')
+    pri
 }
 
 do_bar(){
-    echo '123'
+    ech
 }
+
+DESCRIP

--- a/integration-tests/src/tests/completion.test.ts
+++ b/integration-tests/src/tests/completion.test.ts
@@ -45,19 +45,19 @@ suite('Bitbake Completion Test Suite', () => {
   }
 
   test('Completion appears properly on bitbake variable', async () => {
-    const position = new vscode.Position(0, 2)
+    const position = new vscode.Position(8, 7)
     const expected = 'DESCRIPTION'
     await testCompletion(position, expected)
   }).timeout(BITBAKE_TIMEOUT)
 
   test('Completion appears properly on embedded python', async () => {
-    const position = new vscode.Position(3, 6)
+    const position = new vscode.Position(1, 7)
     const expected = 'print'
     await testCompletion(position, expected)
   }).timeout(BITBAKE_TIMEOUT)
 
   test('Completion appears properly on embedded bash', async () => {
-    const position = new vscode.Position(7, 6)
+    const position = new vscode.Position(5, 7)
     const expected = 'echo'
     await testCompletion(position, expected)
   }).timeout(BITBAKE_TIMEOUT)

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -261,8 +261,8 @@ export default class Analyzer {
   ): boolean {
     let n = this.nodeAtPoint(uri, line, column)
 
-    while (n?.parent !== null && n?.parent !== undefined) {
-      if (TreeSitterUtils.isShellDefinition(n.parent)) {
+    while (n !== null) {
+      if (TreeSitterUtils.isShellDefinition(n)) {
         return true
       }
       n = n.parent
@@ -277,8 +277,8 @@ export default class Analyzer {
     column: number
   ): boolean {
     let n = this.nodeAtPoint(uri, line, column)
-    while (n?.parent !== null && n?.parent !== undefined) {
-      if (TreeSitterUtils.isInlinePython(n.parent) || TreeSitterUtils.isPythonDefinition(n.parent)) {
+    while (n !== null) {
+      if (TreeSitterUtils.isInlinePython(n) || TreeSitterUtils.isPythonDefinition(n)) {
         return true
       }
       n = n.parent


### PR DESCRIPTION
Completion was broken on the last character of Python or Bash blocks.

For example, in the following code, if the cursor was on just after the `h` in `ech`, the user would see "normal" bitbake completion items instead of bash completion items. 
```shell
test() {
    ech
}
```

Completion is still not as responsive as we'd like it to be, especially in Python. I am still looking for a solution.