### PR TITLE
Fix: Handle empty hover middleware forwarding

### DIFF
--- a/client/src/language/middlewareHover.ts
+++ b/client/src/language/middlewareHover.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { type HoverMiddleware } from 'vscode-languageclient'
-import { type Hover, commands, workspace } from 'vscode'
+import { type Hover, commands, workspace, MarkdownString } from 'vscode'
 
 import { getEmbeddedLanguageDocPosition } from './utils'
 import { embeddedLanguageDocsManager } from './EmbeddedLanguageDocsManager'
@@ -35,5 +35,13 @@ export const middlewareProvideHover: HoverMiddleware['provideHover'] = async (do
     embeddedLanguageDocInfos.uri,
     adjustedPosition
   )
-  return result[0]
+  return result.find((hover) => {
+    const contents = hover.contents
+    return contents.find((content) => {
+      if (content instanceof MarkdownString) {
+        return content.value !== ''
+      }
+      return content !== ''
+    })
+  })
 }

--- a/client/src/language/middlewareHover.ts
+++ b/client/src/language/middlewareHover.ts
@@ -12,7 +12,7 @@ import { requestsManager } from './RequestManager'
 
 export const middlewareProvideHover: HoverMiddleware['provideHover'] = async (document, position, token, next) => {
   const nextResult = await next(document, position, token)
-  if (nextResult !== undefined) {
+  if (nextResult !== undefined && nextResult !== null) {
     return nextResult
   }
   const embeddedLanguageType = await requestsManager.getEmbeddedLanguageTypeOnPosition(document.uri.toString(), position)

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -12,7 +12,8 @@ import {
   TextDocuments,
   ProposedFeatures,
   TextDocumentSyncKind,
-  type InitializeParams
+  type InitializeParams,
+  type TextDocumentChangeEvent
 } from 'vscode-languageserver/node'
 import { bitBakeDocScanner } from './BitBakeDocScanner'
 import { TextDocument } from 'vscode-languageserver-textdocument'
@@ -120,7 +121,7 @@ connection.onRequest(RequestMethod.getLinksInDocument, (params: RequestParams['g
 
 connection.listen()
 
-documents.onDidChangeContent(async (event) => {
+const analyzeDocument = async (event: TextDocumentChangeEvent<TextDocument>): Promise<void> => {
   const textDocument = event.document
   const previousVersion = analyzer.getAnalyzedDocument(textDocument.uri)?.version ?? -1
   if (textDocument.getText().length > 0 && previousVersion < textDocument.version) {
@@ -139,7 +140,11 @@ documents.onDidChangeContent(async (event) => {
     logger.debug('verifyConfigurationFileAssociation')
     await connection.sendRequest('custom/verifyConfigurationFileAssociation', { filePath: new URL(textDocument.uri).pathname })
   }
-})
+}
+
+documents.onDidOpen(analyzeDocument)
+
+documents.onDidChangeContent(analyzeDocument)
 
 documents.onDidSave(async (event) => {
   if (parseOnSave && !eSDKMode) {


### PR DESCRIPTION
For embedded languages hover, if a third party extension contributed empty hovers, we would return the first result that might be empty, resulting in the interesting hovers from embedded languages extension being lost. We add a find() to filter out empty hovers.