### PR TITLE
Fix: Disable ShellCheck rule SC2317

### DIFF
--- a/server/src/__tests__/embedded-languages.test.ts
+++ b/server/src/__tests__/embedded-languages.test.ts
@@ -11,7 +11,7 @@ import { generateParser } from '../tree-sitter/parser'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { type EmbeddedLanguageType } from '../lib/src/types/embedded-languages'
 import { imports } from '../embedded-languages/python-support'
-import { shebang } from '../embedded-languages/bash-support'
+import { bashHeader } from '../embedded-languages/bash-support'
 
 describe('Create basic embedded bash documents', () => {
   beforeAll(async () => {
@@ -26,23 +26,23 @@ describe('Create basic embedded bash documents', () => {
     [
       'basic',
       'foo(){\nBAR=""\n}',
-      `${shebang}foo(){\nBAR=""\n}`
+      `${bashHeader}foo(){\nBAR=""\n}`
     ],
     [
       'with override',
       'foo:append(){\nBAR=""\n}',
-      `${shebang}foo       (){\nBAR=""\n}`
+      `${bashHeader}foo       (){\nBAR=""\n}`
     ],
     [
       'with inline python',
       // eslint-disable-next-line no-template-curly-in-string
       'foo(){\n${@FOO}\n}',
-      `${shebang}foo(){\n\${?   }\n}`
+      `${bashHeader}foo(){\n\${?   }\n}`
     ],
     [
       'with fakeroot',
       'fakeroot foo(){\nBAR=""\n}',
-      `${shebang}         foo(){\nBAR=""\n}`
+      `${bashHeader}         foo(){\nBAR=""\n}`
     ]
   ])('%s', async (description, input, result) => {
     const embeddedContent = await createEmbeddedContent(input, 'bash')

--- a/server/src/embedded-languages/bash-support.ts
+++ b/server/src/embedded-languages/bash-support.ts
@@ -10,7 +10,20 @@ import { type EmbeddedLanguageDoc } from '../lib/src/types/embedded-languages'
 import { type SyntaxNode } from 'web-tree-sitter'
 import { logger } from '../lib/src/utils/OutputLogger'
 
-export const shebang = '#!/bin/sh\n'
+const shebang = '#!/bin/sh\n'
+
+// Diagnostics to disable with the VS Code extension ShellCheck.
+// These would appear incorrectly, and we have not managed to find a proper workaround.
+const shellcheckDisables = [
+  // "Command appears to be unreachable." This happens because we remove the overiddes and functions end up having the same names.
+  '# shellcheck disable=SC2317'
+]
+
+export const bashHeader = [
+  shebang,
+  ...shellcheckDisables,
+  ''
+].join('\n')
 
 export const generateBashEmbeddedLanguageDoc = (analyzedDocument: AnalyzedDocument): EmbeddedLanguageDoc => {
   const embeddedLanguageDoc = initEmbeddedLanguageDoc(analyzedDocument.document, 'bash')
@@ -25,8 +38,12 @@ export const generateBashEmbeddedLanguageDoc = (analyzedDocument: AnalyzedDocume
         return false
     }
   })
-  insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, 0, 0, shebang)
+  insertBashHeader(embeddedLanguageDoc)
   return embeddedLanguageDoc
+}
+
+const insertBashHeader = (embeddedLanguageDoc: EmbeddedLanguageDoc): void => {
+  insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, 0, 0, bashHeader)
 }
 
 const handleFunctionDefinitionNode = (node: SyntaxNode, embeddedLanguageDoc: EmbeddedLanguageDoc): void => {


### PR DESCRIPTION
Before this fix, ShellCheck gives a warning about functions being unreachable when there is an override. It happens because we delete the override part (ex. `:append`) in the embedded language document, so ShellCheck sees the same function.

![Screenshot from 2024-02-01 21-26-59](https://github.com/yoctoproject/vscode-bitbake/assets/92585455/7db30cd9-871d-4458-8ec9-2a0c51673aaa)

This PR simply disables that warning.