### PR TITLE
Feat: Add completion for Yocto defined variables in embedded languages

### DIFF
--- a/client/src/language/middlewareCompletion.ts
+++ b/client/src/language/middlewareCompletion.ts
@@ -11,6 +11,10 @@ import { getEmbeddedLanguageDocPosition, getOriginalDocRange } from './utils'
 import { embeddedLanguageDocsManager } from './EmbeddedLanguageDocsManager'
 
 export const middlewareProvideCompletion: CompletionMiddleware['provideCompletionItem'] = async (document, position, context, token, next) => {
+  const nextResult = await next(document, position, context, token)
+  if (Array.isArray(nextResult) && nextResult.length > 0) {
+    return nextResult
+  }
   const embeddedLanguageType = await requestsManager.getEmbeddedLanguageTypeOnPosition(document.uri.toString(), position)
   if (embeddedLanguageType === undefined || embeddedLanguageType === null) {
     return await next(document, position, context, token)

--- a/client/src/lib/src/utils/arrays.ts
+++ b/client/src/lib/src/utils/arrays.ts
@@ -1,0 +1,26 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+export const mergeArraysDistinctly = <ElementType, KeyType>(
+  array1: ElementType[],
+  array2: ElementType[],
+  getKey: (a: ElementType) => KeyType // A key on which two elements are equal
+): ElementType[] => {
+  const mergedArray: ElementType[] = []
+  const seenKeys = new Set<KeyType>()
+
+  array1.forEach((item) => {
+    mergedArray.push(item)
+    seenKeys.add(getKey(item))
+  })
+
+  array2.forEach((item) => {
+    if (!seenKeys.has(getKey(item))) {
+      mergedArray.push(item)
+    }
+  })
+
+  return mergedArray
+}

--- a/integration-tests/project-folder/sources/meta-fixtures/completion.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures/completion.bb
@@ -1,9 +1,9 @@
 python do_foo(){
-    pri
+    p
 }
 
 do_bar(){
-    ech
+    e
 }
 
 DESCRIP

--- a/integration-tests/src/tests/completion.test.ts
+++ b/integration-tests/src/tests/completion.test.ts
@@ -44,21 +44,33 @@ suite('Bitbake Completion Test Suite', () => {
     })
   }
 
-  test('Completion appears properly on bitbake variable', async () => {
+  test('Completion item for Yocto variable shows up in BitBake region', async () => {
     const position = new vscode.Position(8, 7)
     const expected = 'DESCRIPTION'
     await testCompletion(position, expected)
   }).timeout(BITBAKE_TIMEOUT)
 
-  test('Completion appears properly on embedded python', async () => {
-    const position = new vscode.Position(1, 7)
+  test('Completion item for Python built in function shows up Python region', async () => {
+    const position = new vscode.Position(1, 6)
     const expected = 'print'
     await testCompletion(position, expected)
   }).timeout(BITBAKE_TIMEOUT)
 
-  test('Completion appears properly on embedded bash', async () => {
-    const position = new vscode.Position(5, 7)
+  test('Completion item for Yocto task shows up in Python region', async () => {
+    const position = new vscode.Position(1, 6)
+    const expected = 'do_package'
+    await testCompletion(position, expected)
+  }).timeout(BITBAKE_TIMEOUT)
+
+  test('Completion item for built in Bash function shows up in Bash region', async () => {
+    const position = new vscode.Position(5, 6)
     const expected = 'echo'
+    await testCompletion(position, expected)
+  }).timeout(BITBAKE_TIMEOUT)
+
+  test('Completion item for Yocto task shows up in Bash region', async () => {
+    const position = new vscode.Position(5, 6)
+    const expected = 'do_populate_sdk_ext'
     await testCompletion(position, expected)
   }).timeout(BITBAKE_TIMEOUT)
 })

--- a/server/src/__tests__/completions.test.ts
+++ b/server/src/__tests__/completions.test.ts
@@ -310,7 +310,7 @@ describe('On Completion', () => {
         uri: DUMMY_URI
       },
       position: {
-        line: 18,
+        line: 23,
         character: 13
       }
     })
@@ -739,5 +739,135 @@ describe('On Completion', () => {
         })
       ])
     )
+  })
+
+  it('provides proper completion items on python datastore variables', async () => {
+    analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.COMPLETION
+    })
+
+    bitBakeDocScanner.parseBitbakeVariablesFile()
+    bitBakeDocScanner.parseYoctoVariablesFile()
+    bitBakeDocScanner.parseYoctoTaskFile()
+    bitBakeDocScanner.parsePythonDatastoreFunction()
+
+    // Completion items on string_start node
+    const resultOnStringStart = onCompletionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 19,
+        character: 14
+      }
+    })
+
+    // string_start has Yocto variable among the completion items
+    expect(resultOnStringStart).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'DESCRIPTION',
+          labelDetails: {
+            description: 'Source: Yocto'
+          },
+          documentation: {
+            value: '```man\nDESCRIPTION (bitbake-language-server)\n\n\n```\n```bitbake\n\n```\n---\n   The package description used by package managers. If not set,\n   `DESCRIPTION` takes the value of the `SUMMARY`\n   variable.\n\n\n[Reference](https://docs.yoctoproject.org/ref-manual/variables.html#term-DESCRIPTION)',
+            kind: 'markdown'
+          },
+          insertText: undefined,
+          insertTextFormat: 1
+        })
+      ])
+    )
+
+    // string_start has symbol among the completion items
+    expect(
+      resultOnStringStart.find((item) => item.label === 'DVAR')
+    ).not.toBeUndefined()
+
+    // string_start does not have task among the completion items
+    expect(resultOnStringStart).not.toEqual(
+      /* eslint-disable no-template-curly-in-string */
+      expect.arrayContaining([
+        {
+          documentation: {
+            value: '```man\ndo_build (bitbake-language-server)\n\n\n```\n```bitbake\ndo_build(){\n\t# Your code here\n}\n```\n---\nThe default task for all recipes. This task depends on all other normal\ntasks required to build a recipe.\n\n[Reference](https://docs.yoctoproject.org/singleindex.html#do-build)',
+            kind: 'markdown'
+          },
+          labelDetails: {
+            description: ''
+          },
+          insertText: 'do_build(){\n\t${1:# Your code here}\n}',
+          insertTextFormat: 2,
+          label: 'do_build',
+          kind: 15
+        }
+      ])
+    )
+
+    // string_start does not have reserved word among the completion items
+    expect(
+      resultOnStringStart.find((item) => item.label === 'deltask')
+    ).toBeUndefined()
+
+    // Completion items on string_content node
+    const resultOnStringContent = onCompletionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 19,
+        character: 15
+      }
+    })
+
+    // string_content has Yocto variable among the completion items
+    expect(resultOnStringContent).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'DESCRIPTION',
+          labelDetails: {
+            description: 'Source: Yocto'
+          },
+          documentation: {
+            value: '```man\nDESCRIPTION (bitbake-language-server)\n\n\n```\n```bitbake\n\n```\n---\n   The package description used by package managers. If not set,\n   `DESCRIPTION` takes the value of the `SUMMARY`\n   variable.\n\n\n[Reference](https://docs.yoctoproject.org/ref-manual/variables.html#term-DESCRIPTION)',
+            kind: 'markdown'
+          },
+          insertText: undefined,
+          insertTextFormat: 1
+        })
+      ])
+    )
+
+    // string_content has symbol among the completion items
+    expect(
+      resultOnStringContent.find((item) => item.label === 'DVAR')
+    ).not.toBeUndefined()
+
+    // string_content does not have task among the completion items
+    expect(resultOnStringContent).not.toEqual(
+      /* eslint-disable no-template-curly-in-string */
+      expect.arrayContaining([
+        {
+          documentation: {
+            value: '```man\ndo_build (bitbake-language-server)\n\n\n```\n```bitbake\ndo_build(){\n\t# Your code here\n}\n```\n---\nThe default task for all recipes. This task depends on all other normal\ntasks required to build a recipe.\n\n[Reference](https://docs.yoctoproject.org/singleindex.html#do-build)',
+            kind: 'markdown'
+          },
+          labelDetails: {
+            description: ''
+          },
+          insertText: 'do_build(){\n\t${1:# Your code here}\n}',
+          insertTextFormat: 2,
+          label: 'do_build',
+          kind: 15
+        }
+      ])
+    )
+
+    // string_content does not have reserved word among the completion items
+    expect(
+      resultOnStringContent.find((item) => item.label === 'deltask')
+    ).toBeUndefined()
   })
 })

--- a/server/src/__tests__/fixtures/completion.bb
+++ b/server/src/__tests__/fixtures/completion.bb
@@ -15,5 +15,10 @@ inherit co
 def myFunc(param = [1,2,3]):
     pass
 
+DVAR=''
+python() {
+    d.getVar("D")
+}
+
 # Show completion at the last line https://github.com/amaanq/tree-sitter-bitbake/issues/9
 MYVAR:append:

--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -152,7 +152,7 @@ function getBitBakeCompletionItems (textDocumentPositionParams: TextDocumentPosi
 }
 
 function getBashCompletionItems (): CompletionItem[] {
-  return []
+  return getYoctoTaskSnippets()
 }
 
 function getPythonCompletionItems (documentUri: string, word: string | null, wordPosition: Position): CompletionItem[] {
@@ -163,7 +163,10 @@ function getPythonCompletionItems (documentUri: string, word: string | null, wor
       ...symbolCompletionItems
     ]
   }
-  return []
+  if (analyzer.isStringContent(documentUri, wordPosition.line, wordPosition.character)) {
+    return []
+  }
+  return getYoctoTaskSnippets()
 }
 
 function getYoctoTaskSnippets (): CompletionItem[] {


### PR DESCRIPTION
This adds completion items for Yocto variables inside Python datastore functions. 
![Screenshot from 2024-02-02 19-42-56](https://github.com/yoctoproject/vscode-bitbake/assets/92585455/6394f265-032f-4a72-af05-ebc090815f56)

This also add completion items for Yocto tasks inside Python and Shell functions. 
![Screenshot from 2024-02-02 19-40-44](https://github.com/yoctoproject/vscode-bitbake/assets/92585455/f1e5f5b9-3c1e-4afc-9991-96c71001fa8e)
![Screenshot from 2024-02-02 19-41-11](https://github.com/yoctoproject/vscode-bitbake/assets/92585455/cb44f7a1-7cb0-4029-a2d1-d7110532f26f)

Completion items for variable expansions inside Shell regions is waiting for a fix on tree-sitter-bitbake (see [PR19](https://github.com/amaanq/tree-sitter-bitbake/pull/19))