### PR TITLE
Fix: Resolve devtool workspace for new eSDK projects

### DIFF
--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -22,7 +22,7 @@ import { DevtoolWorkspaceTreeItem } from './DevtoolWorkspacesView'
 import { finishProcessExecution } from '../lib/src/utils/ProcessUtils'
 import { type SpawnSyncReturns } from 'child_process'
 import { clientNotificationManager } from './ClientNotificationManager'
-import { configureDevtoolSDKFallback } from '../driver/BitbakeESDK'
+import { bitbakeESDKMode, configureDevtoolSDKFallback } from '../driver/BitbakeESDK'
 import bitbakeRecipeScanner from '../driver/BitbakeRecipeScanner'
 import { type BitbakeTerminalProfileProvider, openBitbakeTerminalProfile } from './BitbakeTerminalProfile'
 
@@ -73,6 +73,10 @@ async function parseAllrecipes (bitbakeWorkspace: BitbakeWorkspace, taskProvider
     return
   }
   bitbakeSanity = true
+
+  if (bitbakeESDKMode) {
+    return
+  }
 
   // We have to use tasks instead of BitbakeTerminal because we want the problemMatchers to detect parsing errors
   const parseAllRecipesTask = new vscode.Task(

--- a/client/src/ui/BitbakeRecipesView.ts
+++ b/client/src/ui/BitbakeRecipesView.ts
@@ -86,10 +86,8 @@ class BitbakeTreeDataProvider implements vscode.TreeDataProvider<BitbakeRecipeTr
       return []
     }
 
-    if (this.bitbakeScanResults === undefined) {
-      while (this.bitbakeScanResults === undefined) {
-        await new Promise(resolve => setTimeout(resolve, 300))
-      }
+    while (this.bitbakeScanResults === undefined) {
+      await new Promise(resolve => setTimeout(resolve, 300))
     }
     const fileItems: BitbakeRecipeTreeItem[] = []
     this.bitbakeScanResults._recipes.forEach((recipe: ElementInfo) => {


### PR DESCRIPTION
When opening a fresh eSDK, there is no devtool workspace open yet. The previous logic had to wait before resolving. This made the "New devtool workspace" missing from the tree view.