### PR TITLE
Fix: scanned results lost on type

### DIFF
--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -48,11 +48,14 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
       hoverValue = `**${found.name}**\n___\n${found.definition}`
     }
 
+    const lastScannedSymbolInfo = analyzer.getLastScannedSymbolInfo(textDocument.uri)
     // Find the exact variable with the same name and overrides
     const exactSymbol = analyzer.getGlobalDeclarationSymbols(textDocument.uri).find((symbol) => symbol.name === word && analyzer.positionIsInRange(position.line, position.character, symbol.location.range))
-
-    if (exactSymbol?.finalValue !== undefined) {
-      hoverValue += `**Final Value**\n___\n\t'${exactSymbol.finalValue}'`
+    if (lastScannedSymbolInfo !== undefined && exactSymbol !== undefined) {
+      const foundSymbol = lastScannedSymbolInfo.find((symbol) => analyzer.symbolsAreTheSame(symbol, exactSymbol))
+      if (foundSymbol?.finalValue !== undefined) {
+        hoverValue += `**Final Value**\n___\n\t'${foundSymbol.finalValue}'`
+      }
     }
   }
 

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -43,6 +43,7 @@ export interface AnalyzedDocument {
 export default class Analyzer {
   private parser?: Parser
   private uriToAnalyzedDocument: Record<string, AnalyzedDocument | undefined> = {}
+  private readonly uriToScannedRecipeSymbolInfo: Record<string, BitbakeSymbolInformation[] | undefined> = {} // Store the results of the last scan for each recipe
 
   public getDocumentTexts (uri: string): string[] | undefined {
     return this.uriToAnalyzedDocument[uri]?.document.getText().split(/\r?\n/g)
@@ -50,6 +51,10 @@ export default class Analyzer {
 
   public getAnalyzedDocument (uri: string): AnalyzedDocument | undefined {
     return this.uriToAnalyzedDocument[uri]
+  }
+
+  public getLastScannedSymbolInfo (uri: string): BitbakeSymbolInformation[] | undefined {
+    return this.uriToScannedRecipeSymbolInfo[uri]
   }
 
   public getExtraSymbolsForUri (uri: string): GlobalDeclarations[] {
@@ -793,6 +798,7 @@ export default class Analyzer {
     const scanResultDocSymbols = this.getAllSymbolsFromGlobalDeclarations(scanResultDocGlobalDeclarations)
     const { globalDeclarations: analyzedOriginalDocGlobalDeclarations } = analyzedOriginalDoc
 
+    const symbolsInScannedRecipe: BitbakeSymbolInformation[] = []
     // Process and apply the scan results to the original document
     Object.values(analyzedOriginalDocGlobalDeclarations).forEach((symbolArray) => {
       symbolArray.forEach((symbol) => {
@@ -801,9 +807,9 @@ export default class Analyzer {
             return this.symbolsAreTheSame(scanResultDocumentSymbol, symbol)
           })
           if (sameSymbolInScanResultDocument !== undefined) {
-            // Replace final values
-            symbol.finalValue = sameSymbolInScanResultDocument.finalValue
+            symbolsInScannedRecipe.push(sameSymbolInScanResultDocument)
 
+            // TODO: refactor the comments to be part of the bitbakeSymbolInformation so it can be stored along with the symbol in the lastScannedSymbolInfo
             const commentsForTheSameSymbol = scanResultDocGlobalDeclarationComments[symbol.name].find(item => this.symbolsAreTheSame(item.symbolInfo, symbol))?.comments
 
             // Extract the modification history of the symbol
@@ -834,6 +840,8 @@ export default class Analyzer {
         }
       })
     })
+
+    this.uriToScannedRecipeSymbolInfo[originalDocUri] = symbolsInScannedRecipe
   }
 
   /**


### PR DESCRIPTION
Fixed the issue that the scan results were lost after changing the documents. I still want the `analyze()` to be called on every keystroke so the document gets the correct tree-sitter parsing right away, so I stored the results of the previous scan and read them on request to fix this. Now only the final values are fixed, the history will be fixed after I refactor it so it becomes part of the `bitbakeSymbolInformation` and I don't have to duplicate the logic.