### PR TITLE
Refactor: comment now is part of bitbakeSymbolInformation

### DIFF
--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -66,7 +66,8 @@ describe('analyze', () => {
             uri: DUMMY_URI
           },
           name: 'BAR',
-          overrides: ['o1', 'o2']
+          overrides: ['o1', 'o2'],
+          commentsAbove: []
         },
         {
           kind: 13,
@@ -84,7 +85,8 @@ describe('analyze', () => {
             uri: DUMMY_URI
           },
           name: 'FOO',
-          overrides: []
+          overrides: [],
+          commentsAbove: []
         },
         {
           kind: 12,
@@ -102,7 +104,8 @@ describe('analyze', () => {
             uri: DUMMY_URI
           },
           overrides: ['o1', 'o2'],
-          name: 'my_func'
+          name: 'my_func',
+          commentsAbove: []
         }
       ])
     )

--- a/server/src/connectionHandlers/onDefinition.ts
+++ b/server/src/connectionHandlers/onDefinition.ts
@@ -68,15 +68,20 @@ export function onDefinitionHandler (textDocumentPositionParams: TextDocumentPos
         })
       }
 
+      const lastScanResult = analyzer.getLastScanResult(documentUri)
       const exactSymbol = analyzer.getGlobalDeclarationSymbols(documentUri).find((symbol) => symbol.name === word && analyzer.positionIsInRange(position.line, position.character, symbol.location.range))
 
-      if (exactSymbol?.history !== undefined) {
-        exactSymbol.history.forEach((location) => {
-          definitions.push({
-            uri: location.uri,
-            range: location.range
+      if (lastScanResult !== undefined && exactSymbol !== undefined) {
+        const foundSymbol = lastScanResult.find((symbol) => analyzer.symbolsAreTheSame(symbol, exactSymbol))
+        if (foundSymbol !== undefined) {
+          const modificationHistory = analyzer.extractModificationHistoryFromComments(foundSymbol)
+          modificationHistory.forEach((location) => {
+            definitions.push({
+              uri: location.uri,
+              range: location.range
+            })
           })
-        })
+        }
       }
 
       return definitions

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -48,11 +48,11 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
       hoverValue = `**${found.name}**\n___\n${found.definition}`
     }
 
-    const lastScannedSymbolInfo = analyzer.getLastScannedSymbolInfo(textDocument.uri)
+    const lastScanResult = analyzer.getLastScanResult(textDocument.uri)
     // Find the exact variable with the same name and overrides
     const exactSymbol = analyzer.getGlobalDeclarationSymbols(textDocument.uri).find((symbol) => symbol.name === word && analyzer.positionIsInRange(position.line, position.character, symbol.location.range))
-    if (lastScannedSymbolInfo !== undefined && exactSymbol !== undefined) {
-      const foundSymbol = lastScannedSymbolInfo.find((symbol) => analyzer.symbolsAreTheSame(symbol, exactSymbol))
+    if (lastScanResult !== undefined && exactSymbol !== undefined) {
+      const foundSymbol = lastScanResult.find((symbol) => analyzer.symbolsAreTheSame(symbol, exactSymbol))
       if (foundSymbol?.finalValue !== undefined) {
         hoverValue += `**Final Value**\n___\n\t'${foundSymbol.finalValue}'`
       }

--- a/server/src/tree-sitter/declarations.ts
+++ b/server/src/tree-sitter/declarations.ts
@@ -22,7 +22,7 @@ const TREE_SITTER_TYPE_TO_LSP_KIND: Record<string, LSP.SymbolKind | undefined> =
 export interface BitbakeSymbolInformation extends LSP.SymbolInformation {
   overrides: string[]
   finalValue?: string // Only for variables extracted from the scan results
-  history?: LSP.Location[] // The modification history of a variable with flags and overrides taken into account.
+  commentsAbove?: string[]
 }
 
 /**
@@ -64,16 +64,18 @@ export function getGlobalDeclarationsAndComments ({
       if (globalDeclarations[word] === undefined) {
         globalDeclarations[word] = []
       }
-      globalDeclarations[word].push(symbol)
 
       const commentsAbove: string[] = []
       extractCommentsAbove(node, commentsAbove)
       if (commentsAbove.length > 0) {
+        symbol.commentsAbove = commentsAbove
         if (symbolComments[word] === undefined) {
           symbolComments[word] = []
         }
         symbolComments[word].push({ uri, line: node.startPosition.row, comments: commentsAbove, symbolInfo: symbol })
       }
+
+      globalDeclarations[word].push(symbol)
     }
 
     return followChildren

--- a/server/src/tree-sitter/declarations.ts
+++ b/server/src/tree-sitter/declarations.ts
@@ -22,7 +22,7 @@ const TREE_SITTER_TYPE_TO_LSP_KIND: Record<string, LSP.SymbolKind | undefined> =
 export interface BitbakeSymbolInformation extends LSP.SymbolInformation {
   overrides: string[]
   finalValue?: string // Only for variables extracted from the scan results
-  commentsAbove?: string[]
+  commentsAbove: string[]
 }
 
 /**
@@ -50,9 +50,8 @@ export function getGlobalDeclarationsAndComments ({
   tree: Parser.Tree
   uri: string
   getFinalValue?: boolean
-}): [GlobalDeclarations, GlobalSymbolComments] {
+}): GlobalDeclarations {
   const globalDeclarations: GlobalDeclarations = {}
-  const symbolComments: GlobalSymbolComments = {}
 
   TreeSitterUtil.forEach(tree.rootNode, (node) => {
     const followChildren = !GLOBAL_DECLARATION_NODE_TYPES.has(node.type)
@@ -69,10 +68,6 @@ export function getGlobalDeclarationsAndComments ({
       extractCommentsAbove(node, commentsAbove)
       if (commentsAbove.length > 0) {
         symbol.commentsAbove = commentsAbove
-        if (symbolComments[word] === undefined) {
-          symbolComments[word] = []
-        }
-        symbolComments[word].push({ uri, line: node.startPosition.row, comments: commentsAbove, symbolInfo: symbol })
       }
 
       globalDeclarations[word].push(symbol)
@@ -81,7 +76,7 @@ export function getGlobalDeclarationsAndComments ({
     return followChildren
   })
 
-  return [globalDeclarations, symbolComments]
+  return globalDeclarations
 }
 
 function nodeToSymbolInformation ({
@@ -138,6 +133,7 @@ function nodeToSymbolInformation ({
       uri,
       containerName
     ),
+    commentsAbove: [],
     overrides
   }
 


### PR DESCRIPTION
The tests related to this refactoring all passed. The only thing I added in the test is the `commentsAbove` field which is initialized every time a `bitbakeSymbolInformation` object is created.

Also fixed the history was lost on type. Now it is computed from the last scan results.

Expected results after triggering the command `scan recipe` from the menu. Typing should not remove or change the results:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/88d1025a-ae7d-4dec-9650-fbc63cfb212e)
