### PR TITLE
Chore: Replace parseAllRecipe with bitbake -e command on recipe files on save

### DIFF
--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -11,7 +11,8 @@ import {
   window,
   commands,
   languages,
-  TabInputText
+  TabInputText,
+  Uri
 } from 'vscode'
 
 import {
@@ -108,13 +109,16 @@ export async function activateLanguageServer (context: ExtensionContext): Promis
     }
   })
 
-  client.onRequest('bitbake/parseAllRecipes', async () => {
-    // Temporarily disable task.saveBeforeRun
-    // This request happens on bitbake document save. We don't want to save all files when any bitbake file is saved.
-    const saveBeforeRun = await workspace.getConfiguration('task').get('saveBeforeRun')
-    await workspace.getConfiguration('task').update('saveBeforeRun', 'never', undefined, true)
-    await commands.executeCommand('bitbake.parse-recipes')
-    await workspace.getConfiguration('task').update('saveBeforeRun', saveBeforeRun, undefined, true)
+  client.onRequest('bitbake/scanRecipe', async (param) => {
+    if (typeof param.uri === 'string') {
+      // Temporarily disable task.saveBeforeRun
+      // This request happens on bitbake document save. We don't want to save all files when any bitbake file is saved.
+      const saveBeforeRun = await workspace.getConfiguration('task').get('saveBeforeRun')
+      await workspace.getConfiguration('task').update('saveBeforeRun', 'never', undefined, true)
+      await commands.executeCommand('bitbake.scan-recipe-env', Uri.parse(param.uri))
+      await workspace.getConfiguration('task').update('saveBeforeRun', saveBeforeRun, undefined, true)
+    }
+    logger.error(`[OnRequest] <bitbake/scanRecipe>: Invalid uri: ${JSON.stringify(param.uri)}`)
   })
 
   client.onRequest('bitbake/rescanProject', async () => {


### PR DESCRIPTION
I only replaced the command executed on save and made it work on recipe files. The `parseAllRecipe` still runs after the initial project scan on launch. I think we should keep it so we know if there is any errors at the start.