### PR TITLE
Fix: final values should work on variables with variable expansion in the overrides

### DIFF
--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -410,3 +410,26 @@ describe('getLinksInStringContent', () => {
     expect(links).toEqual([])
   })
 })
+
+describe('getVariableExpansionSymbols', () => {
+  it('returns an array of BitbakeSymbolInformation for variable expansions', async () => {
+    const analyzer = await getAnalyzer()
+    const document = FIXTURE_DOCUMENT.HOVER
+    const uri = FIXTURE_URI.HOVER
+
+    analyzer.analyze({
+      document,
+      uri
+    })
+
+    const tree = analyzer.getAnalyzedDocument(uri)?.tree
+
+    if (tree === undefined) {
+      fail('Tree is undefined')
+    }
+
+    const symbols = analyzer.getVariableExpansionSymbols({ tree, uri })
+
+    expect(symbols.length).toEqual(2)
+  })
+})

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -66,7 +66,7 @@ describe('analyze', () => {
             uri: DUMMY_URI
           },
           name: 'BAR',
-          overrides: ['o1', 'o2'],
+          overrides: ['o1', 'o2', { variableName: 'PN' }],
           commentsAbove: []
         },
         {

--- a/server/src/__tests__/fixtures/declarations.bb
+++ b/server/src/__tests__/fixtures/declarations.bb
@@ -1,5 +1,5 @@
 FOO = '123'
-BAR:o1:o2 = '456'
+BAR:o1:o2:${PN} = '456'
 
 python my_func:o1:o2(){
     pass

--- a/server/src/connectionHandlers/onDefinition.ts
+++ b/server/src/connectionHandlers/onDefinition.ts
@@ -69,7 +69,7 @@ export function onDefinitionHandler (textDocumentPositionParams: TextDocumentPos
       }
 
       const lastScanResult = analyzer.getLastScanResult(documentUri)
-      const exactSymbol = analyzer.getGlobalDeclarationSymbols(documentUri).find((symbol) => symbol.name === word && analyzer.positionIsInRange(position.line, position.character, symbol.location.range))
+      const exactSymbol = analyzer.findExactSymbolAtPoint(documentUri, position, word)
 
       if (lastScanResult !== undefined && exactSymbol !== undefined) {
         const foundSymbol = lastScanResult.find((symbol) => analyzer.symbolsAreTheSame(symbol, exactSymbol))

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -53,7 +53,8 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
 
     const lastScanResult = analyzer.getLastScanResult(textDocument.uri)
     if (lastScanResult !== undefined && exactSymbol !== undefined) {
-      const foundSymbol = lastScanResult.find((symbol) => analyzer.symbolsAreTheSame(symbol, exactSymbol))
+      const resolvedSymbol = analyzer.resolveSymbol(exactSymbol, lastScanResult)
+      const foundSymbol = lastScanResult.find((symbol) => analyzer.symbolsAreTheSame(symbol, resolvedSymbol))
       if (foundSymbol?.finalValue !== undefined) {
         hoverValue += `**Final Value**\n___\n\t'${foundSymbol.finalValue}'`
       }

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -149,7 +149,7 @@ export default class Analyzer {
   }
 
   public findExactSymbolAtPoint (uri: string, position: Position, wordAtPoint: string): BitbakeSymbolInformation | undefined {
-    return analyzer.getGlobalDeclarationSymbols(uri).find((symbol) => symbol.name === wordAtPoint && analyzer.positionIsInRange(position.line, position.character, symbol.location.range))
+    return analyzer.getGlobalDeclarationSymbols(uri).find((symbol) => symbol.name === wordAtPoint && analyzer.positionIsInRange(position.line, position.character, symbol.location.range)) ?? analyzer.uriToAnalyzedDocument[uri]?.variableExpansionSymbols.find((symbol) => symbol.name === wordAtPoint && analyzer.positionIsInRange(position.line, position.character, symbol.location.range))
   }
 
   public getParsedTreeForUri (uri: string): Tree | undefined {

--- a/server/src/tree-sitter/declarations.ts
+++ b/server/src/tree-sitter/declarations.ts
@@ -30,7 +30,7 @@ export interface BitbakeSymbolInformation extends LSP.SymbolInformation {
  * Referenced by the symbol name
  */
 export type GlobalDeclarations = Record<string, BitbakeSymbolInformation[]>
-export type GlobalSymbolComments = Record<string, Array<{ uri: string, line: number, comments: string[], symbolInfo: BitbakeSymbolInformation }>>
+
 const GLOBAL_DECLARATION_NODE_TYPES = new Set([
   'function_definition',
   'python_function_definition',
@@ -66,10 +66,7 @@ export function getGlobalDeclarations ({
 
       const commentsAbove: string[] = []
       extractCommentsAbove(node, commentsAbove)
-      if (commentsAbove.length > 0) {
-        symbol.commentsAbove = commentsAbove
-      }
-
+      symbol.commentsAbove = commentsAbove
       globalDeclarations[word].push(symbol)
     }
 

--- a/server/src/tree-sitter/declarations.ts
+++ b/server/src/tree-sitter/declarations.ts
@@ -42,7 +42,7 @@ const GLOBAL_DECLARATION_NODE_TYPES = new Set([
  * This currently does not include global variables defined inside other code blocks (e.g. if statement & functions)
  *
  */
-export function getGlobalDeclarationsAndComments ({
+export function getGlobalDeclarations ({
   tree,
   uri,
   getFinalValue = false // Whether to get the final value from the scan results obtained from scan recipe command, which is the only use case as of now
@@ -79,17 +79,24 @@ export function getGlobalDeclarationsAndComments ({
   return globalDeclarations
 }
 
-function nodeToSymbolInformation ({
+export function nodeToSymbolInformation ({
   node,
   uri,
-  getFinalValue
+  getFinalValue,
+  isVariableExpansion = false
 }: {
   node: Parser.SyntaxNode
   uri: string
   getFinalValue?: boolean
+  isVariableExpansion?: boolean
 }): BitbakeSymbolInformation | null {
-  const firstNamedChild = node.firstNamedChild
-  if (firstNamedChild === null) {
+  let namedNode = node.firstNamedChild
+
+  if (isVariableExpansion) {
+    namedNode = node
+  }
+
+  if (namedNode === null) {
     return null
   }
 
@@ -127,9 +134,9 @@ function nodeToSymbolInformation ({
 
   let symbol: BitbakeSymbolInformation = {
     ...LSP.SymbolInformation.create(
-      firstNamedChild.text,
+      namedNode.text,
       kind ?? LSP.SymbolKind.Variable,
-      TreeSitterUtil.range(firstNamedChild),
+      TreeSitterUtil.range(namedNode),
       uri,
       containerName
     ),


### PR DESCRIPTION
In the example below, the final values and modification history should still apply to the variable `FILES`:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/0204ea5c-985d-4ae1-8f45-25fbc338339c)

This requires the values of the variables in the variable expansion to be resolved first.
