### PR TITLE
Fix: Bash IDE line numbers

### DIFF
--- a/client/src/language/utils.ts
+++ b/client/src/language/utils.ts
@@ -19,7 +19,7 @@ export const getOriginalDocRange = (
   return new Range(start, end)
 }
 
-const getOriginalDocPosition = (
+export const getOriginalDocPosition = (
   originalTextDocument: TextDocument,
   embeddedLanguageTextDocument: TextDocument,
   characterIndexes: number[],

--- a/integration-tests/project-folder/sources/meta-fixtures/hover.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures/hover.bb
@@ -14,4 +14,5 @@ python do_build() {
 do_build() {
     bbwarn
     oe_runmake
+    do_bar
 }

--- a/integration-tests/src/tests/hover.test.ts
+++ b/integration-tests/src/tests/hover.test.ts
@@ -84,4 +84,10 @@ suite('Bitbake Hover Test Suite', () => {
     const expected = 'Function: **oe_runmake** - *defined in ../poky/meta/classes-global/base.bbclass*'
     await testHover(position, expected)
   }).timeout(BITBAKE_TIMEOUT)
+
+  test('Hover gives right line number in bash function declared in the same file', async () => {
+    const position = new vscode.Position(16, 7)
+    const expected = 'Function: **do_bar** - *defined on line 7*'
+    await testHover(position, expected)
+  }).timeout(BITBAKE_TIMEOUT)
 })


### PR DESCRIPTION
This fixes the line numbers on hover given by Bash IDE for variable and functions defined on the same file. Previously, it would give the line numbers from the "embedded language document" instead of the actual file.