### PR TITLE
Fix: Handle 'bitbake/parseAllRecipes' on client side

### DIFF
--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -109,6 +109,15 @@ export async function activateLanguageServer (context: ExtensionContext): Promis
     }
   })
 
+  client.onRequest('bitbake/parseAllRecipes', async () => {
+    // Temporarily disable task.saveBeforeRun
+    // This request happens on bitbake document save. We don't want to save all files when any bitbake file is saved.
+    const saveBeforeRun = await workspace.getConfiguration('task').get('saveBeforeRun')
+    await workspace.getConfiguration('task').update('saveBeforeRun', 'never', undefined, true)
+    await commands.executeCommand('bitbake.parse-recipes')
+    await workspace.getConfiguration('task').update('saveBeforeRun', saveBeforeRun, undefined, true)
+  })
+
   client.onRequest('bitbake/scanRecipe', async (param) => {
     if (typeof param.uri === 'string') {
       // Temporarily disable task.saveBeforeRun


### PR DESCRIPTION
This has been removed on commit 21fae6a8b1ce8bf48926890515301c7eab87229a. However there is still a call to it in server/src/server.ts and it throws the following error: `ResponseError: Unhandled method bitbake/parseAllRecipes`.