### PR TITLE
Feat: Provide go-to-definition for include path that contain ${} syntax

### DIFF
--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -435,7 +435,7 @@ describe('getVariableExpansionSymbols', () => {
 })
 
 describe('resolveSymbol', () => {
-  it('resolves symbol overrides', async () => {
+  it('resolves symbols with variable expansion syntax', async () => {
     /**
      * Resolve the overrides first, then the symbol
      * VAR:${PN} = "foo"
@@ -445,6 +445,7 @@ describe('resolveSymbol', () => {
     const uri = FIXTURE_URI.HOVER
 
     const PN = '1'
+    const PV = '1.0+git'
 
     const symbol1: BitbakeSymbolInformation = {
       name: 'symbol1',
@@ -465,6 +466,9 @@ describe('resolveSymbol', () => {
       overrides: []
     }
 
+    // eslint-disable-next-line no-template-curly-in-string
+    const symbol3 = 'recipe_${PV}.bb'
+
     const lookUpSymbolList: BitbakeSymbolInformation[] = [
       {
         name: 'PN',
@@ -479,6 +483,20 @@ describe('resolveSymbol', () => {
         commentsAbove: [],
         overrides: [],
         finalValue: PN
+      },
+      {
+        name: 'PV',
+        location: {
+          uri,
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 }
+          }
+        },
+        kind: 13,
+        commentsAbove: [],
+        overrides: [],
+        finalValue: PV
       },
       {
         name: 'symbol1',
@@ -497,8 +515,10 @@ describe('resolveSymbol', () => {
 
     const resolvedSymbol1 = analyzer.resolveSymbol(symbol1, lookUpSymbolList)
     const resolvedSymbol2 = analyzer.resolveSymbol(symbol2, lookUpSymbolList)
+    const resolvedSymbol3 = analyzer.resolveSymbol(symbol3, lookUpSymbolList)
 
-    expect(resolvedSymbol1).toEqual(lookUpSymbolList[1])
+    expect(resolvedSymbol1).toEqual(lookUpSymbolList[2])
     expect(resolvedSymbol2).toEqual(symbol2) // not found in the look up list, resolve to itself
+    expect(resolvedSymbol3).toEqual('recipe_1.0.bb')
   })
 })

--- a/server/src/__tests__/definition.test.ts
+++ b/server/src/__tests__/definition.test.ts
@@ -91,6 +91,21 @@ describe('on definition', () => {
       }
     })
 
+    // Resolve the directive path with ${} and provide go-to-definition
+    const scanResults = '#INCLUDE HISTORY\n#some operation history for PN\nPN = \'foo\'\n'
+
+    analyzer.processRecipeScanResults(scanResults, FIXTURE_URI.DIRECTIVE, undefined)
+
+    const definition3 = onDefinitionHandler({
+      textDocument: {
+        uri: FIXTURE_URI.DIRECTIVE
+      },
+      position: {
+        line: 30,
+        character: 9
+      }
+    })
+
     expect(definition).toEqual(
       expect.arrayContaining([
         {
@@ -113,6 +128,24 @@ describe('on definition', () => {
       expect.arrayContaining([
         {
           uri: FIXTURE_URI.BITBAKE_CONF,
+          range: {
+            start: {
+              line: 0,
+              character: 0
+            },
+            end: {
+              line: 0,
+              character: 0
+            }
+          }
+        }
+      ])
+    )
+
+    expect(definition3).toEqual(
+      expect.arrayContaining([
+        {
+          uri: FIXTURE_URI.FOO_INC,
           range: {
             start: {
               line: 0,

--- a/server/src/__tests__/fixtures/directive.bb
+++ b/server/src/__tests__/fixtures/directive.bb
@@ -27,3 +27,5 @@ my_func(){
 RDEPENDS:${PN} += 'some-package some-package-2.0'
 # package names that follow '--enable-' or '--disable-', and when + is part of the name
 PACKAGECONFIG[some-package3] = "--enable-some-package,--disable-some-package,some-package+1"
+
+require inc/${PN}.inc

--- a/server/src/connectionHandlers/onDefinition.ts
+++ b/server/src/connectionHandlers/onDefinition.ts
@@ -42,7 +42,7 @@ export function onDefinitionHandler (textDocumentPositionParams: TextDocumentPos
     logger.debug(`[onDefinition] Found directive: ${directiveStatementKeyword}`)
     let resolvedDirectivePath = directivePath
     if (lastScanResult !== undefined) {
-      resolvedDirectivePath = analyzer.resolveSymbol(directivePath, lastScanResult) as string
+      resolvedDirectivePath = analyzer.resolveSymbol(directivePath, lastScanResult)
     }
     definitions.push(...getDefinitionForDirectives(directiveStatementKeyword, resolvedDirectivePath))
     logger.debug(`[onDefinition] definition item: ${JSON.stringify(definitions)}`)

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -54,7 +54,7 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
     const lastScanResult = analyzer.getLastScanResult(textDocument.uri)
     if (lastScanResult !== undefined && exactSymbol !== undefined) {
       const resolvedSymbol = analyzer.resolveSymbol(exactSymbol, lastScanResult)
-      const foundSymbol = lastScanResult.find((symbol) => analyzer.symbolsAreTheSame(symbol, resolvedSymbol))
+      const foundSymbol = lastScanResult.find((symbol) => analyzer.symbolsAreTheSame(symbol, resolvedSymbol as BitbakeSymbolInformation))
       if (foundSymbol?.finalValue !== undefined) {
         hoverValue += `**Final Value**\n___\n\t'${foundSymbol.finalValue}'`
       }

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -54,7 +54,7 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
     const lastScanResult = analyzer.getLastScanResult(textDocument.uri)
     if (lastScanResult !== undefined && exactSymbol !== undefined) {
       const resolvedSymbol = analyzer.resolveSymbol(exactSymbol, lastScanResult)
-      const foundSymbol = lastScanResult.find((symbol) => analyzer.symbolsAreTheSame(symbol, resolvedSymbol as BitbakeSymbolInformation))
+      const foundSymbol = lastScanResult.find((symbol) => analyzer.symbolsAreTheSame(symbol, resolvedSymbol))
       if (foundSymbol?.finalValue !== undefined) {
         hoverValue += `**Final Value**\n___\n\t'${foundSymbol.finalValue}'`
       }

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -895,7 +895,14 @@ export default class Analyzer {
     const variableToResolve: string[] = []
 
     if (typeof symbol !== 'string') {
-      variableToResolve.push(...symbol.overrides.filter((override) => typeof override !== 'string').map((override) => (override as { variableName: string, value?: string }).variableName))
+      const toResolve = symbol.overrides.reduce<string[]>((acc, override) => {
+        if (typeof override !== 'string') {
+          acc.push(override.variableName)
+        }
+        return acc
+      }, [])
+
+      variableToResolve.push(...toResolve)
 
       const resolvedVariable: string[] = []
       variableToResolve.forEach((override) => {

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -870,7 +870,7 @@ export default class Analyzer {
       const resolvedSymbol = this.resolveSymbol(symbol, scannedResultSymbolInfo)
 
       const foundSymbol = scanResultDocSymbols.find((scanResultDocSymbol) => {
-        return this.symbolsAreTheSame(scanResultDocSymbol, resolvedSymbol as BitbakeSymbolInformation)
+        return this.symbolsAreTheSame(scanResultDocSymbol, resolvedSymbol)
       })
 
       if (foundSymbol !== undefined) {
@@ -881,6 +881,9 @@ export default class Analyzer {
     this.uriToLastScanResult[originalDocUri] = scannedResultSymbolInfo
   }
 
+  // overload
+  public resolveSymbol (symbol: BitbakeSymbolInformation, lookUpSymbolList: BitbakeSymbolInformation[]): BitbakeSymbolInformation
+  public resolveSymbol (symbol: string, lookUpSymbolList: BitbakeSymbolInformation[]): string
   /**
    *
    * @param symbol A symbol that contains variable expansion syntax. e.g. VAR:${PN} or require ${PN}.inc


### PR DESCRIPTION
The directive paths will be resolved first before they are used to create the definition item.

Working example:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/c4a1c55f-daeb-45d4-b328-4a1441a4ce8d)

Note that even if the resolved path is obtained, if the results from the project scan don't have the corresponding file, no definition will be provided.

Ticket: 14024