### PR TITLE
Chore: Match exact symbol or symbol without override as fallback

### DIFF
--- a/server/src/connectionHandlers/onDefinition.ts
+++ b/server/src/connectionHandlers/onDefinition.ts
@@ -78,7 +78,7 @@ export function onDefinitionHandler (textDocumentPositionParams: TextDocumentPos
       const exactSymbol = analyzer.findExactSymbolAtPoint(documentUri, position, word)
 
       if (lastScanResult !== undefined && exactSymbol !== undefined) {
-        const foundSymbol = lastScanResult.find((symbol) => analyzer.symbolsAreTheSame(symbol, exactSymbol))
+        const foundSymbol = analyzer.matchSymbol(exactSymbol, lastScanResult)
         if (foundSymbol !== undefined) {
           const modificationHistory = analyzer.extractModificationHistoryFromComments(foundSymbol)
           modificationHistory.forEach((location) => {

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -54,7 +54,7 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
     const lastScanResult = analyzer.getLastScanResult(textDocument.uri)
     if (lastScanResult !== undefined && exactSymbol !== undefined) {
       const resolvedSymbol = analyzer.resolveSymbol(exactSymbol, lastScanResult)
-      const foundSymbol = lastScanResult.find((symbol) => analyzer.symbolsAreTheSame(symbol, resolvedSymbol))
+      const foundSymbol = analyzer.matchSymbol(resolvedSymbol, lastScanResult)
       if (foundSymbol?.finalValue !== undefined) {
         hoverValue += `**Final Value**\n___\n\t'${foundSymbol.finalValue}'`
       }

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -869,9 +869,7 @@ export default class Analyzer {
     originalDocDeclarationSymbols.forEach((symbol) => {
       const resolvedSymbol = this.resolveSymbol(symbol, scannedResultSymbolInfo)
 
-      const foundSymbol = scanResultDocSymbols.find((scanResultDocSymbol) => {
-        return this.symbolsAreTheSame(scanResultDocSymbol, resolvedSymbol)
-      })
+      const foundSymbol = this.matchSymbol(resolvedSymbol, scanResultDocSymbols)
 
       if (foundSymbol !== undefined) {
         scannedResultSymbolInfo.push(foundSymbol)
@@ -879,6 +877,22 @@ export default class Analyzer {
     })
 
     this.uriToLastScanResult[originalDocUri] = scannedResultSymbolInfo
+  }
+
+  /**
+   * @param symbol The symbol to match
+   * @param lookUpSymbolList The list of symbols to look up the symbol
+   * @returns The symbol that matches the symbol in the scan results
+   *
+   * Match the symbol in the scan results with the symbol in the original document. If the exact symbol is not found, it will try to find the symbol without 0 overrides as fallback
+   */
+  public matchSymbol (symbol: BitbakeSymbolInformation, lookUpSymbolList: BitbakeSymbolInformation[]): BitbakeSymbolInformation | undefined {
+    return lookUpSymbolList.find((scanResultDocSymbol) => {
+      return this.symbolsAreTheSame(scanResultDocSymbol, symbol)
+    }) ??
+    lookUpSymbolList.find((scanResultDocSymbol) => {
+      return scanResultDocSymbol.name === symbol.name && scanResultDocSymbol.overrides.length === 0
+    })
   }
 
   // overload


### PR DESCRIPTION
The symbols that can't match the exact result from the scan can now fall back to the one with no overrides.

In this example, the `SRC_URI:libc-musl` will take the final value of `SRC_URI` since there isn't any for the exact symbol.
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/f8789614-8b2a-4a18-a979-d610cd2b3d29)
