### PR TITLE
Chore: Add timestamp and log level to log messages

### DIFF
--- a/client/src/lib/src/utils/OutputLogger.ts
+++ b/client/src/lib/src/utils/OutputLogger.ts
@@ -28,7 +28,8 @@ export class OutputLogger {
   public log (message: string, level: string = 'info'): void {
     if (this.shouldLog(level)) {
       this.outputChannel?.appendLine(message)
-      console.log(message)
+      const time = new Date().toISOString().substring(11, 23)
+      console.log(`${time} [${level[0].toUpperCase() + level.slice(1)}] ${message}`)
     }
   }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -66,7 +66,7 @@ connection.onInitialize(async (params: InitializeParams): Promise<InitializeResu
   analyzer.initialize(parser)
 
   bitBakeProjectScannerClient.onChange.on('scanReady', () => {
-    logger.debug('[On scanReady] Analyzing the current document again...')
+    logger.debug('Analyzing the current document again...')
     analyzer.analyze({ document: currentActiveTextDocument, uri: currentActiveTextDocument.uri })
   })
 
@@ -105,8 +105,7 @@ connection.onDidChangeConfiguration((change) => {
 connection.onCompletion(onCompletionHandler)
 
 connection.onCompletionResolve((item: CompletionItem): CompletionItem => {
-  logger.debug(`onCompletionResolve: ${JSON.stringify(item)}`)
-  // TODO: An alternative: Currently it just returns the completion items created when onCompletion fires. Maybe here can be good place to get the documentation for completion items instead of getting all of the documentation at startup.
+  logger.debug(`[onCompletionResolve]: ${JSON.stringify(item)}`)
   return item
 })
 


### PR DESCRIPTION
1. Prepend timestamp and level to the log messages.
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/70adfb8f-a490-40f0-96e2-bfe3480e0e05)
