### PR TITLE
Chore: Update script for tree-sitter

### DIFF
--- a/scripts/update-tree-sitter-wasm.sh
+++ b/scripts/update-tree-sitter-wasm.sh
@@ -6,10 +6,10 @@
 set -euox pipefail
 
 cd client
-npm install -D tree-sitter-cli https://github.com/amaanq/tree-sitter-bitbake
+npm install -D tree-sitter-cli https://github.com/tree-sitter-grammars/tree-sitter-bitbake
 npx tree-sitter build-wasm node_modules/tree-sitter-bitbake
 
-curl 'https://api.github.com/repos/amaanq/tree-sitter-bitbake/commits/master' | jq .commit.url > parser.info
+curl 'https://api.github.com/repos/tree-sitter-grammars/tree-sitter-bitbake/commits/master' | jq .commit.url > parser.info
 echo "tree-sitter-cli $(cat package.json | jq '.devDependencies["tree-sitter-cli"]')" >> parser.info
 
 npm uninstall tree-sitter-cli tree-sitter-bitbake


### PR DESCRIPTION
The repo has been moved to different account, hence the API URI changed.

https://github.com/tree-sitter-grammars/tree-sitter-bitbake

How to verify:
Run the script in the project root and it should update the `parser.info` with the latest commit of the `tree-sitter-bitbake` and the latest version of [tree-sitter-cli](https://github.com/tree-sitter/tree-sitter)

Example:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/9cfa0349-9cd9-4432-9d6e-7d3a79cbb7fa)

Let the bot create a new PR for the update next time for validation.