### PR TITLE
Feat: go to definition for overrides

### DIFF
--- a/server/src/__tests__/definition.test.ts
+++ b/server/src/__tests__/definition.test.ts
@@ -499,4 +499,49 @@ describe('on definition', () => {
       ])
     )
   })
+
+  it('provides go to definition for overrides', async () => {
+    const parsedConfFile = path.parse('/home/poky/layer/poky.conf')
+
+    bitBakeProjectScannerClient.bitbakeScanResult._confFiles = [
+      {
+        name: parsedConfFile.name,
+        path: parsedConfFile,
+        extraInfo: 'layer: core'
+      }
+    ]
+
+    analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.DIRECTIVE
+    })
+
+    const shouldWork = onDefinitionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 32,
+        character: 5
+      }
+    })
+
+    expect(shouldWork).toEqual(
+      expect.arrayContaining([
+        {
+          uri: 'file://' + parsedConfFile.dir + '/' + parsedConfFile.base,
+          range: {
+            start: {
+              line: 0,
+              character: 0
+            },
+            end: {
+              line: 0,
+              character: 0
+            }
+          }
+        }
+      ])
+    )
+  })
 })

--- a/server/src/__tests__/definition.test.ts
+++ b/server/src/__tests__/definition.test.ts
@@ -502,6 +502,7 @@ describe('on definition', () => {
 
   it('provides go to definition for overrides', async () => {
     const parsedConfFile = path.parse('/home/poky/layer/poky.conf')
+    const parsedConfFile2 = '/home/poky/layer-accurate/poky.conf'
 
     bitBakeProjectScannerClient.bitbakeScanResult._confFiles = [
       {
@@ -530,6 +531,39 @@ describe('on definition', () => {
       expect.arrayContaining([
         {
           uri: 'file://' + parsedConfFile.dir + '/' + parsedConfFile.base,
+          range: {
+            start: {
+              line: 0,
+              character: 0
+            },
+            end: {
+              line: 0,
+              character: 0
+            }
+          }
+        }
+      ])
+    )
+
+    // when recipe scan result is avaiable, prioritize the path found in the result
+    const scanResults = `#  INCLUDE HISTORY\n#\n# ${parsedConfFile2}\n`
+
+    analyzer.processRecipeScanResults(scanResults, DUMMY_URI, undefined)
+
+    const shouldWork2 = onDefinitionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 32,
+        character: 5
+      }
+    })
+
+    expect(shouldWork2).toEqual(
+      expect.arrayContaining([
+        {
+          uri: 'file://' + parsedConfFile2,
           range: {
             start: {
               line: 0,

--- a/server/src/__tests__/fixtures/directive.bb
+++ b/server/src/__tests__/fixtures/directive.bb
@@ -29,3 +29,5 @@ RDEPENDS:${PN} += 'some-package some-package-2.0'
 PACKAGECONFIG[some-package3] = "--enable-some-package,--disable-some-package,some-package+1"
 
 require inc/${PN}.inc
+# if there is a poky.conf, go-to-definition should be provided for override 'poky'
+VAR:poky = '123'

--- a/server/src/connectionHandlers/onDefinition.ts
+++ b/server/src/connectionHandlers/onDefinition.ts
@@ -106,15 +106,6 @@ export function onDefinitionHandler (textDocumentPositionParams: TextDocumentPos
     }
     // Overrides
     if (analyzer.isOverride(documentUri, position.line, position.character)) {
-      const overrideFile = bitBakeProjectScannerClient.bitbakeScanResult._confFiles.find((confFile) => {
-        return confFile.name === word
-      })
-
-      if (overrideFile?.path !== undefined) {
-        definitions.push(createDefinitionLocationForPathInfo(overrideFile.path))
-        return definitions
-      }
-
       if (lastScanResult !== undefined) {
         const targetPath = lastScanResult.includeHistory.find((includePath) => {
           return includePath.ext === '.conf' && includePath.name === word
@@ -124,6 +115,15 @@ export function onDefinitionHandler (textDocumentPositionParams: TextDocumentPos
           definitions.push(createDefinitionLocationForPathInfo(targetPath))
           return definitions
         }
+      }
+
+      const overrideFile = bitBakeProjectScannerClient.bitbakeScanResult._confFiles.find((confFile) => {
+        return confFile.name === word
+      })
+
+      if (overrideFile?.path !== undefined) {
+        definitions.push(createDefinitionLocationForPathInfo(overrideFile.path))
+        return definitions
       }
     }
   }

--- a/server/src/connectionHandlers/onDefinition.ts
+++ b/server/src/connectionHandlers/onDefinition.ts
@@ -104,6 +104,28 @@ export function onDefinitionHandler (textDocumentPositionParams: TextDocumentPos
       })
       return definitions
     }
+    // Overrides
+    if (analyzer.isOverride(documentUri, position.line, position.character)) {
+      const overrideFile = bitBakeProjectScannerClient.bitbakeScanResult._confFiles.find((confFile) => {
+        return confFile.name === word
+      })
+
+      if (overrideFile?.path !== undefined) {
+        definitions.push(createDefinitionLocationForPathInfo(overrideFile.path))
+        return definitions
+      }
+
+      if (lastScanResult !== undefined) {
+        const targetPath = lastScanResult.includeHistory.find((includePath) => {
+          return includePath.ext === '.conf' && includePath.name === word
+        })
+
+        if (targetPath !== undefined) {
+          definitions.push(createDefinitionLocationForPathInfo(targetPath))
+          return definitions
+        }
+      }
+    }
   }
 
   return []

--- a/server/src/connectionHandlers/onDefinition.ts
+++ b/server/src/connectionHandlers/onDefinition.ts
@@ -42,7 +42,7 @@ export function onDefinitionHandler (textDocumentPositionParams: TextDocumentPos
     logger.debug(`[onDefinition] Found directive: ${directiveStatementKeyword}`)
     let resolvedDirectivePath = directivePath
     if (lastScanResult !== undefined) {
-      resolvedDirectivePath = analyzer.resolveSymbol(directivePath, lastScanResult)
+      resolvedDirectivePath = analyzer.resolveSymbol(directivePath, lastScanResult.symbols)
     }
     definitions.push(...getDefinitionForDirectives(directiveStatementKeyword, resolvedDirectivePath))
     logger.debug(`[onDefinition] definition item: ${JSON.stringify(definitions)}`)
@@ -78,7 +78,7 @@ export function onDefinitionHandler (textDocumentPositionParams: TextDocumentPos
       const exactSymbol = analyzer.findExactSymbolAtPoint(documentUri, position, word)
 
       if (lastScanResult !== undefined && exactSymbol !== undefined) {
-        const foundSymbol = analyzer.matchSymbol(exactSymbol, lastScanResult)
+        const foundSymbol = analyzer.matchSymbol(exactSymbol, lastScanResult.symbols)
         if (foundSymbol !== undefined) {
           const modificationHistory = analyzer.extractModificationHistoryFromComments(foundSymbol)
           modificationHistory.forEach((location) => {

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -53,8 +53,8 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
 
     const lastScanResult = analyzer.getLastScanResult(textDocument.uri)
     if (lastScanResult !== undefined && exactSymbol !== undefined) {
-      const resolvedSymbol = analyzer.resolveSymbol(exactSymbol, lastScanResult)
-      const foundSymbol = analyzer.matchSymbol(resolvedSymbol, lastScanResult)
+      const resolvedSymbol = analyzer.resolveSymbol(exactSymbol, lastScanResult.symbols)
+      const foundSymbol = analyzer.matchSymbol(resolvedSymbol, lastScanResult.symbols)
       if (foundSymbol?.finalValue !== undefined) {
         hoverValue += `**Final Value**\n___\n\t'${foundSymbol.finalValue}'`
       }


### PR DESCRIPTION
If there is a `conf` file for the override, `go to definition` should be provided:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/0109a842-83d6-4b12-8984-debf48a80e0e)
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/83afa952-8509-4337-9fbf-87649aa2621d)

Ticket: 14091