### PR TITLE
Refactor: Simplify embedded language documents

### DIFF
--- a/client/TROUBLESHOOTING.md
+++ b/client/TROUBLESHOOTING.md
@@ -3,12 +3,12 @@
 ## Known Issues
 
 ### Problems from Unknown Files Appear in the Problems Tab
-Errors and warnings appear twice in the "PROBLEMS" tab. They first appear for the BitBake files to which they belong, and then again for Bash or Python files with UUID names (ex. 9ad23ed5-9278-41e0-98cd-349750c1e2c0.py). As the first one is expected and desired, the second is not. This issue arises from the way we handle diagnostics (errors and warnings). See [Trade-offs on Diagnostics](TROUBLESHOOTING.md#trade-offs-on-diagnostics).
+Errors and warnings appear twice in the "PROBLEMS" tab. They first appear for the BitBake files to which they belong, and then again for Bash or Python files with hash names (ex. 9dab97ca1ef2b71ea07d42d4609e9e54.py). As the first one is expected and desired, the second is not. This issue arises from the way we handle diagnostics (errors and warnings). See [Trade-offs on Diagnostics](TROUBLESHOOTING.md#trade-offs-on-diagnostics).
 
 Unfortunately, the VS Code API does not offer a way to programmatically filter the "PROBLEMS" tab. However, manual filtering is still possible. Typing `!workspaceStorage` or `!workspaceStorage/**/yocto-project.yocto-bitbake/embedded-documents` (if more precision is needed) should filter out all these unwanted problems.
 
 ### Tabs from Unknown Files Open and Close Quickly
-While typing, tabs with UUID names (ex. aa2a3ba2-769c-4900-8f5f-31ea16bfbc8f.sh) might occasionally open in the tabs bar and then close shortly thereafter.  This occurs as a result of our method for handling diagnostics (errors and warnings). See [Trade-offs on Diagnostics](TROUBLESHOOTING.md#trade-offs-on-diagnostics).
+While typing, tabs with hash names (ex. 9dab97ca1ef2b71ea07d42d4609e9e54.sh) might occasionally open in the tabs bar and then close shortly thereafter.  This occurs as a result of our method for handling diagnostics (errors and warnings). See [Trade-offs on Diagnostics](TROUBLESHOOTING.md#trade-offs-on-diagnostics).
 
 We haven't found a way to prevent these tabs from opening, but we try to close them as quickly as possible.
 

--- a/client/src/language/EmbeddedLanguageDocsManager.ts
+++ b/client/src/language/EmbeddedLanguageDocsManager.ts
@@ -3,13 +3,13 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { randomUUID } from 'crypto'
 import path from 'path'
 import fs from 'fs'
 
 import { type EmbeddedLanguageDoc, type EmbeddedLanguageType } from '../lib/src/types/embedded-languages'
 import { logger } from '../lib/src/utils/OutputLogger'
 import { Range, Uri, WorkspaceEdit, workspace } from 'vscode'
+import { hashString } from '../lib/src/utils/hash'
 
 const EMBEDDED_DOCUMENTS_FOLDER = 'embedded-documents'
 
@@ -93,9 +93,9 @@ export default class EmbeddedLanguageDocsManager {
     if (this.embeddedLanguageDocsFolder === undefined) {
       return undefined
     }
-    const randomName = randomUUID()
+    const hashedName = hashString(embeddedLanguageDoc.originalUri)
     const fileExtension = fileExtensionsMap[embeddedLanguageDoc.language]
-    const embeddedLanguageDocFilename = randomName + fileExtension
+    const embeddedLanguageDocFilename = hashedName + fileExtension
     const pathToEmbeddedLanguageDocsFolder = this.embeddedLanguageDocsFolder
     return Uri.parse(`file://${pathToEmbeddedLanguageDocsFolder}/${embeddedLanguageDocFilename}`)
   }

--- a/client/src/language/codeActionProvider.ts
+++ b/client/src/language/codeActionProvider.ts
@@ -37,7 +37,7 @@ const buildActionFromEmbeddedLanguageDiagnostic = async (
   originalRange: vscode.Range,
   embeddedLanguageType: EmbeddedLanguageType
 ): Promise<vscode.CodeAction[]> => {
-  const embeddedLanguageDocInfos = embeddedLanguageDocsManager.getEmbeddedLanguageDocInfos(document.uri.toString(), embeddedLanguageType)
+  const embeddedLanguageDocInfos = embeddedLanguageDocsManager.getEmbeddedLanguageDocInfos(document.uri, embeddedLanguageType)
   if (embeddedLanguageDocInfos === undefined || embeddedLanguageDocInfos === null) {
     return []
   }

--- a/client/src/language/diagnosticsSupport.ts
+++ b/client/src/language/diagnosticsSupport.ts
@@ -43,7 +43,7 @@ const setEmbeddedLanguageDocDiagnostics = async (
   embeddedLanguageType: EmbeddedLanguageType
 ): Promise<void> => {
   const embeddedLanguageDocInfos = embeddedLanguageDocsManager.getEmbeddedLanguageDocInfos(
-    originalTextDocument.uri.toString(),
+    originalTextDocument.uri,
     embeddedLanguageType
   )
   if (embeddedLanguageDocInfos?.uri === undefined) {

--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -47,18 +47,6 @@ export async function activateLanguageServer (context: ExtensionContext, bitBake
     debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
   }
 
-  workspace.onDidRenameFiles((params) => {
-    params.files.forEach((file) => {
-      embeddedLanguageDocsManager.renameEmbeddedLanguageDocs(file.oldUri.toString(), file.newUri.toString())
-    })
-  })
-
-  workspace.onDidDeleteFiles((params) => {
-    params.files.forEach((file) => {
-      void embeddedLanguageDocsManager.deleteEmbeddedLanguageDocs(file.toString())
-    })
-  })
-
   const sendSettings = async (): Promise<void> => {
     const settings = workspace.getConfiguration()
     await client.sendNotification('workspace/didChangeConfiguration', { settings })
@@ -96,7 +84,7 @@ export async function activateLanguageServer (context: ExtensionContext, bitBake
   if (context.storageUri?.fsPath === undefined) {
     logger.error('Failed to get storage path')
   } else {
-    void embeddedLanguageDocsManager.setStoragePath(context.storageUri.fsPath)
+    await embeddedLanguageDocsManager.setStoragePath(context.storageUri.fsPath)
   }
 
   // Create the language client and start the client.

--- a/client/src/language/middlewareCompletion.ts
+++ b/client/src/language/middlewareCompletion.ts
@@ -18,7 +18,7 @@ export const middlewareProvideCompletion: CompletionMiddleware['provideCompletio
   if (embeddedLanguageType === undefined || embeddedLanguageType === null) {
     return nextResult
   }
-  const embeddedLanguageDocInfos = embeddedLanguageDocsManager.getEmbeddedLanguageDocInfos(document.uri.toString(), embeddedLanguageType)
+  const embeddedLanguageDocInfos = embeddedLanguageDocsManager.getEmbeddedLanguageDocInfos(document.uri, embeddedLanguageType)
   if (embeddedLanguageDocInfos === undefined || embeddedLanguageDocInfos === null) {
     return
   }

--- a/client/src/language/middlewareDefinition.ts
+++ b/client/src/language/middlewareDefinition.ts
@@ -22,7 +22,7 @@ export const middlewareProvideDefinition: DefinitionMiddleware['provideDefinitio
   if (embeddedLanguageType === undefined || embeddedLanguageType === null) {
     return
   }
-  const embeddedLanguageDocInfos = embeddedLanguageDocsManager.getEmbeddedLanguageDocInfos(document.uri.toString(), embeddedLanguageType)
+  const embeddedLanguageDocInfos = embeddedLanguageDocsManager.getEmbeddedLanguageDocInfos(document.uri, embeddedLanguageType)
   logger.debug(`[middlewareProvideDefinition] embeddedLanguageDoc ${embeddedLanguageDocInfos?.uri as any}`)
   if (embeddedLanguageDocInfos === undefined || embeddedLanguageDocInfos === null) {
     return

--- a/client/src/language/middlewareHover.ts
+++ b/client/src/language/middlewareHover.ts
@@ -20,7 +20,7 @@ export const middlewareProvideHover: HoverMiddleware['provideHover'] = async (do
   if (embeddedLanguageType === undefined || embeddedLanguageType === null) {
     return
   }
-  const embeddedLanguageDocInfos = embeddedLanguageDocsManager.getEmbeddedLanguageDocInfos(document.uri.toString(), embeddedLanguageType)
+  const embeddedLanguageDocInfos = embeddedLanguageDocsManager.getEmbeddedLanguageDocInfos(document.uri, embeddedLanguageType)
   if (embeddedLanguageDocInfos === undefined || embeddedLanguageDocInfos === null) {
     return
   }

--- a/client/src/lib/src/utils/hash.ts
+++ b/client/src/lib/src/utils/hash.ts
@@ -1,0 +1,11 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as crypto from 'crypto'
+
+export const hashString = (text: string, length: number = 32): string => {
+  const hash = crypto.createHash('sha256')
+  return hash.update(text).digest('hex').slice(0, length)
+}


### PR DESCRIPTION
These are a bunch of small refactors I've wanted to do for a while for the embedded language documents
- Remove functionalities that are not used anymore since we deactivated the "watch" files
- Use hashes instead of uuids for filenames. It simplifies debugging, since both embedded language documents have the same name, and these names never change. It also reduces the speed the embedded language documents folder will grow. 
- Avoid updating Bash and Python diagnostics at the same time. Prior to these changes, new Python diagnostics would always update both Python and Bash diagnostics, and vice versa. 