### PR TITLE
Fix: Also disable saving on parse from the commands

### DIFF
--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -110,22 +110,12 @@ export async function activateLanguageServer (context: ExtensionContext): Promis
   })
 
   client.onRequest('bitbake/parseAllRecipes', async () => {
-    // Temporarily disable task.saveBeforeRun
-    // This request happens on bitbake document save. We don't want to save all files when any bitbake file is saved.
-    const saveBeforeRun = await workspace.getConfiguration('task').get('saveBeforeRun')
-    await workspace.getConfiguration('task').update('saveBeforeRun', 'never', undefined, true)
     await commands.executeCommand('bitbake.parse-recipes')
-    await workspace.getConfiguration('task').update('saveBeforeRun', saveBeforeRun, undefined, true)
   })
 
   client.onRequest('bitbake/scanRecipe', async (param) => {
     if (typeof param.uri === 'string') {
-      // Temporarily disable task.saveBeforeRun
-      // This request happens on bitbake document save. We don't want to save all files when any bitbake file is saved.
-      const saveBeforeRun = await workspace.getConfiguration('task').get('saveBeforeRun')
-      await workspace.getConfiguration('task').update('saveBeforeRun', 'never', undefined, true)
       await commands.executeCommand('bitbake.scan-recipe-env', Uri.parse(param.uri))
-      await workspace.getConfiguration('task').update('saveBeforeRun', saveBeforeRun, undefined, true)
     }
     logger.error(`[OnRequest] <bitbake/scanRecipe>: Invalid uri: ${JSON.stringify(param.uri)}`)
   })

--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -91,7 +91,13 @@ async function parseAllrecipes (bitbakeWorkspace: BitbakeWorkspace, taskProvider
     parsingPending = true
     return
   }
+
+  // Temporarily disable task.saveBeforeRun
+  // This request happens on bitbake document save. We don't want to save all files when any bitbake file is saved.
+  const saveBeforeRun = await vscode.workspace.getConfiguration('task').get('saveBeforeRun')
+  await vscode.workspace.getConfiguration('task').update('saveBeforeRun', 'never', undefined, true)
   await runBitbakeTask(parseAllRecipesTask, taskProvider)
+  await vscode.workspace.getConfiguration('task').update('saveBeforeRun', saveBeforeRun, undefined, true)
 }
 
 async function buildRecipeCommand (bitbakeWorkspace: BitbakeWorkspace, bitbakeDriver: BitbakeDriver, uri?: any): Promise<void> {
@@ -140,7 +146,12 @@ async function scanRecipeCommand (bitbakeWorkspace: BitbakeWorkspace, taskProvid
 
   bitbakeSanity = true
 
+  // Temporarily disable task.saveBeforeRun
+  // This request happens on bitbake document save. We don't want to save all files when any bitbake file is saved.
+  const saveBeforeRun = await vscode.workspace.getConfiguration('task').get('saveBeforeRun')
+  await vscode.workspace.getConfiguration('task').update('saveBeforeRun', 'never', undefined, true)
   await bitbakeRecipeScanner.scan(chosenRecipe, taskProvider, uri)
+  await vscode.workspace.getConfiguration('task').update('saveBeforeRun', saveBeforeRun, undefined, true)
 }
 
 async function runTaskCommand (bitbakeWorkspace: BitbakeWorkspace, bitbakeDriver: BitbakeDriver, uri?: any, task?: any): Promise<void> {


### PR DESCRIPTION
We want to avoid saving all files when running the parsing or recipe scan tasks. Otherwise, all documents get saved and the commands fire again. This was done at the server level on save but missed the commands started from the pallet or context menu.