### PR TITLE
Feat: Resolve partial variable expansion in overrides

### DIFF
--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -430,7 +430,13 @@ describe('getVariableExpansionSymbols', () => {
 
     const symbols = analyzer.getVariableExpansionSymbols({ tree, uri })
 
-    expect(symbols.length).toEqual(2)
+    expect(symbols).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'DESCRIPTION'
+        })
+      ])
+    )
   })
 })
 

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -66,7 +66,8 @@ describe('analyze', () => {
             uri: DUMMY_URI
           },
           name: 'BAR',
-          overrides: ['o1', 'o2', { variableName: 'PN' }],
+          // eslint-disable-next-line no-template-curly-in-string
+          overrides: ['o1', 'o2', '${PN}'],
           commentsAbove: []
         },
         {
@@ -464,7 +465,8 @@ describe('resolveSymbol', () => {
       },
       kind: 13,
       commentsAbove: [],
-      overrides: ['override1', 'override2', { variableName: 'PN' }]
+      // eslint-disable-next-line no-template-curly-in-string
+      overrides: ['override1', 'override2', '${PN}', '${PN}-foo']
     }
 
     const symbol2: BitbakeSymbolInformation = {
@@ -515,7 +517,7 @@ describe('resolveSymbol', () => {
         },
         kind: 13,
         commentsAbove: [],
-        overrides: ['override1', 'override2', PN]
+        overrides: ['override1', 'override2', PN, PN + '-foo']
       }
     ]
 

--- a/server/src/__tests__/definition.test.ts
+++ b/server/src/__tests__/definition.test.ts
@@ -455,46 +455,48 @@ describe('on definition', () => {
       }
     })
 
-    expect(shouldWork).toEqual([
-      {
-        uri: DUMMY_URI,
-        range: {
-          start: {
-            line: 9,
-            character: 0
-          },
-          end: {
-            line: 9,
-            character: 11
+    expect(shouldWork).toEqual(
+      expect.arrayContaining([
+        {
+          uri: DUMMY_URI,
+          range: {
+            start: {
+              line: 9,
+              character: 0
+            },
+            end: {
+              line: 9,
+              character: 11
+            }
+          }
+        },
+        {
+          uri: DUMMY_URI,
+          range: {
+            start: {
+              line: 10,
+              character: 0
+            },
+            end: {
+              line: 10,
+              character: 11
+            }
+          }
+        },
+        {
+          uri: FIXTURE_URI.BAR_INC,
+          range: {
+            start: {
+              line: 0,
+              character: 0
+            },
+            end: {
+              line: 0,
+              character: 11
+            }
           }
         }
-      },
-      {
-        uri: DUMMY_URI,
-        range: {
-          start: {
-            line: 10,
-            character: 0
-          },
-          end: {
-            line: 10,
-            character: 11
-          }
-        }
-      },
-      {
-        uri: FIXTURE_URI.BAR_INC,
-        range: {
-          start: {
-            line: 0,
-            character: 0
-          },
-          end: {
-            line: 0,
-            character: 11
-          }
-        }
-      }
-    ])
+      ])
+    )
   })
 })

--- a/server/src/__tests__/fixtures/correct.bb
+++ b/server/src/__tests__/fixtures/correct.bb
@@ -11,3 +11,5 @@ FINAL_VALUE = 'this is the original value for FINAL_VALUE'
 FINAL_VALUE:o1 = 'this is the original value for FINAL_VALUE with override o1'
 # Variables other than SRC_URI shouldn't be used to extract links
 NOT_SRC_URI = 'file://foo.inc'
+
+FINAL_VALUE:o1:${PN}:${PN}-foo = 'this is the original value for FINAL_VALUE with override containing variable expansion'

--- a/server/src/__tests__/hover.test.ts
+++ b/server/src/__tests__/hover.test.ts
@@ -612,7 +612,7 @@ describe('on hover', () => {
       document: FIXTURE_DOCUMENT.CORRECT
     })
 
-    const scanResults = '#INCLUDE HISTORY\n# Some scan results here\nFINAL_VALUE = \'this is the final value for FINAL_VALUE\'\nFINAL_VALUE:o1 = \'this is the final value for FINAL_VALUE with override o1\'\n'
+    const scanResults = '#INCLUDE HISTORY\n# Some scan results here\nFINAL_VALUE = \'this is the final value for FINAL_VALUE\'\nFINAL_VALUE:o1 = \'this is the final value for FINAL_VALUE with override o1\'\nFINAL_VALUE:o1:pn:pn-foo = \'this is the final value for FINAL_VALUE with override containing variable expansion\'\nPN= \'pn\'\n'
 
     analyzer.processRecipeScanResults(scanResults, DUMMY_URI, undefined)
 
@@ -636,6 +636,16 @@ describe('on hover', () => {
       }
     })
 
+    const shouldShow3 = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 14,
+        character: 1
+      }
+    })
+
     expect(shouldShow1).toEqual(
       expect.objectContaining({
         contents: expect.objectContaining({
@@ -648,6 +658,14 @@ describe('on hover', () => {
       expect.objectContaining({
         contents: expect.objectContaining({
           value: expect.stringContaining('**Final Value**\n___\n\t\'this is the final value for FINAL_VALUE with override o1\'')
+        })
+      })
+    )
+
+    expect(shouldShow3).toEqual(
+      expect.objectContaining({
+        contents: expect.objectContaining({
+          value: expect.stringContaining('**Final Value**\n___\n\t\'this is the final value for FINAL_VALUE with override containing variable expansion\'')
         })
       })
     )

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -120,7 +120,7 @@ export default class Analyzer {
 
       if (isNonEmptyVariableExpansion) {
         const symbol = nodeToSymbolInformation({ node, uri, getFinalValue: false, isVariableExpansion: true })
-        symbol !== null && variableExpansionSymbols.push(symbol)
+        symbol !== null && variableExpansionSymbols.find(s => s.name === symbol.name) === undefined && variableExpansionSymbols.push(symbol)
       }
 
       return followChildren


### PR DESCRIPTION
Resolve overrides that are partially `${}` and provide final values on hover accordingly:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/bc232d17-f472-4efa-a1f8-7bfcfa672774)
Result:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/0d3427b6-e7b8-43b4-b73e-0aeb38e2ef26)

File in the example:
`poky/meta/recipes-kernel/dtc/dtc_1.7.0.bb` L: `31`

Ticket: 14140