### PR TITLE
Misc: Move final values above the definition in the hover; Remove scan results on closing all files related to a recipe

### DIFF
--- a/client/src/lib/src/types/notifications.ts
+++ b/client/src/lib/src/types/notifications.ts
@@ -6,13 +6,16 @@
 import { type EmbeddedLanguageDoc } from './embedded-languages'
 
 enum NotificationType {
-  EmbeddedLanguageDocs = 'EmbeddedLanguageDocs'
+  EmbeddedLanguageDocs = 'EmbeddedLanguageDocs',
+  RemoveScanResult = 'RemoveScanResult'
 }
 
 export const NotificationMethod: Record<NotificationType, string> = {
-  [NotificationType.EmbeddedLanguageDocs]: 'bitbake/EmbeddedLanguageDocs'
+  [NotificationType.EmbeddedLanguageDocs]: 'bitbake/EmbeddedLanguageDocs',
+  [NotificationType.RemoveScanResult]: 'bitbake/removeScanResult'
 }
 
 export interface NotificationParams {
   [NotificationType.EmbeddedLanguageDocs]: EmbeddedLanguageDoc[]
+  [NotificationType.RemoveScanResult]: { recipeName: string }
 }

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -57,7 +57,13 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
       const resolvedSymbol = analyzer.resolveSymbol(exactSymbol, lastScanResult.symbols)
       const foundSymbol = analyzer.matchSymbol(resolvedSymbol, lastScanResult.symbols)
       if (foundSymbol?.finalValue !== undefined) {
-        hoverValue += `**Final Value**\n___\n\t'${foundSymbol.finalValue}'`
+        if (hoverValue.split('\n___\n').length === 2) { // when the variable has a definition obtained from above
+          const splitted = hoverValue.split('\n___\n')
+          splitted.splice(1, 0, `**Final Value**\n___\n\t'${foundSymbol.finalValue}'`) // Alternative: use the new array method toSplice() if the node env supports it
+          hoverValue = splitted.join('\n___\n')
+        } else {
+          hoverValue += `**Final Value**\n___\n\t'${foundSymbol.finalValue}'`
+        }
       }
     }
   }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -135,6 +135,11 @@ connection.onNotification(RequestMethod.ProcessRecipeScanResults, (param: Reques
   analyzer.processRecipeScanResults(param.scanResults, param.chosenRecipe)
 })
 
+connection.onNotification(NotificationMethod.RemoveScanResult, (param: NotificationParams['RemoveScanResult']) => {
+  logger.debug(`[onNotification] <${NotificationMethod.RemoveScanResult}> recipe: ${param.recipeName}`)
+  analyzer.removeLastScanResultForRecipe(param.recipeName)
+})
+
 connection.listen()
 
 const analyzeDocument = async (event: TextDocumentChangeEvent<TextDocument>): Promise<void> => {
@@ -183,12 +188,6 @@ documents.onDidSave(async (event) => {
     // saving other files or no recipe is resolved
     void connection.sendRequest('bitbake/parseAllRecipes')
   }
-})
-
-documents.onDidClose((event) => {
-  const uri = event.document.uri
-  logger.debug(`[onDidClose] Document closed: ${uri}`)
-  analyzer.removeLastScanResultForUri(uri)
 })
 
 documents.listen(connection)

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -69,8 +69,8 @@ export default class Analyzer {
     return this.uriToAnalyzedDocument[uri]?.variableExpansionSymbols ?? []
   }
 
-  public removeLastScanResultForUri (uri: string): void {
-    this.uriToLastScanResult[uri] = undefined
+  public removeLastScanResultForRecipe (recipe: string): void {
+    this.uriToLastScanResult[recipe] = undefined
   }
 
   public initialize (parser: Parser): void {


### PR DESCRIPTION
Note that vscode only provides the `visibleEditors` instead of all the opened editors. If a file related to a recipe is still opened but not visible in the current window, it loses its scan results as well.