### PR TITLE
Feat: extra definition for functions using scan results

### DIFF
--- a/server/src/__tests__/definition.test.ts
+++ b/server/src/__tests__/definition.test.ts
@@ -441,6 +441,7 @@ describe('on definition', () => {
     const fakeFilePath = FIXTURE_URI.BAR_INC.replace('file://', '')
     const fakeLineNumber = 1
     const variable = 'FINAL_VALUE'
+    const funcName = 'do_build'
 
     const scanResults = `#INCLUDE HISTORY\n#   set ${fakeFilePath}:${fakeLineNumber}\n${variable} = 'this is the final value for FINAL_VALUE'\n${variable}:o1 = 'this is the final value for FINAL_VALUE with override o1'\n`
 
@@ -494,6 +495,57 @@ describe('on definition', () => {
             end: {
               line: 0,
               character: 11
+            }
+          }
+        }
+      ])
+    )
+
+    // Functions
+    analyzer.analyze({
+      uri: FIXTURE_URI.DIRECTIVE,
+      document: FIXTURE_DOCUMENT.BAR_INC
+    })
+
+    const scanResults2 = `#INCLUDE HISTORY\n# line: ${fakeLineNumber}, file: ${fakeFilePath}\n${funcName}(){\n\techo '123'\n}`
+
+    analyzer.processRecipeScanResults(scanResults2, extractRecipeName(FIXTURE_URI.DIRECTIVE))
+
+    const shouldWork2 = onDefinitionHandler({
+      textDocument: {
+        uri: FIXTURE_URI.DIRECTIVE
+      },
+      position: {
+        line: 6,
+        character: 1
+      }
+    })
+
+    expect(shouldWork2).toEqual(
+      expect.arrayContaining([
+        {
+          uri: FIXTURE_URI.DIRECTIVE, // symbol itself
+          range: {
+            start: {
+              line: 6,
+              character: 0
+            },
+            end: {
+              line: 6,
+              character: 8
+            }
+          }
+        },
+        {
+          uri: 'file://' + fakeFilePath, // symbol from the scan result
+          range: {
+            start: {
+              line: 0,
+              character: 0
+            },
+            end: {
+              line: 0,
+              character: 8
             }
           }
         }

--- a/server/src/__tests__/fixtures/inc/bar.inc
+++ b/server/src/__tests__/fixtures/inc/bar.inc
@@ -3,3 +3,7 @@ export PYTHON = 'python3'
 APPEND = 'append bar'
 # comment 1 for MYVAR in bar.inc
 MYVAR = '456'
+
+do_build:append(){
+
+}

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -899,15 +899,28 @@ export default class Analyzer {
   public extractModificationHistoryFromComments (symbol: BitbakeSymbolInformation): Location[] {
     const comments = symbol.commentsAbove
     const history: Location[] = []
+    let regex = /()?/g // dummy regex
+
+    if (symbol.kind === SymbolKind.Variable) {
+      regex = /(?<=#\s{3}set\??\s)(?<filePath>\/.*):(?<lineNumber>\d+)/g
+    } else if (symbol.kind === SymbolKind.Function) {
+      regex = /(?<=#\s)line:\s(?<lineNumber>\d+),\sfile:\s(?<filePath>\/.*)/g
+    }
 
     comments?.forEach((comment) => {
       /**
-       *  Example:
+       *  Examples:
+       *  Variable:
        *  #   set /home/projects/poky/meta/conf/bitbake.conf:396
           #     [_defaultval] "gnu"
           TC_CXX_RUNTIME="gnu"
+
+          Function:
+          # line: 331, file: /home/projects/poky/meta/classes-global/base.bbclass
+          base_do_configure(){
+
+          }
        */
-      const regex = /(?<=#\s{3}set\??\s)(?<filePath>\/.*):(?<lineNumber>\d+)/g
       for (const match of comment.matchAll(regex)) {
         const filePath = match.groups?.filePath
         const lineNumber = match.groups?.lineNumber

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -807,11 +807,11 @@ export default class Analyzer {
     const scanResultText = lines.slice(index).join('\n')
     const scanResultParsedTree = this.parser.parse(scanResultText)
 
-    const scanResultDocGlobalDeclarations = getGlobalDeclarations({ tree: scanResultParsedTree, uri: 'scanResultDummyUri', getFinalValue: true })
-    const scanResultSymbols = this.getAllSymbolsFromGlobalDeclarations(scanResultDocGlobalDeclarations)
+    const scanResultGlobalDeclarations = getGlobalDeclarations({ tree: scanResultParsedTree, uri: 'scanResultDummyUri', getFinalValue: true })
+    const scanResultSymbols = this.getAllSymbolsFromGlobalDeclarations(scanResultGlobalDeclarations)
 
     this.uriToLastScanResult[chosenRecipe] = {
-      symbols: scanResultSymbols.filter((symbol) => symbol.kind === SymbolKind.Variable),
+      symbols: scanResultSymbols,
       includeHistory: this.extractIncludeHistory(scanResult, index)
     }
   }


### PR DESCRIPTION
This PR gives the extra definitions for functions using the scan results.
Dummy example:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/bda955ed-ae60-4f9b-9d00-920b34716468)

In the example above, the function in the `inc` file shows the definitions from the recipe `bb` file which includes this `inc` file.

What is like in the scan results:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/68b2fe19-02e8-4364-b5b1-4cadfd1d97f4)

Ticket: 14072