### PR TITLE
Fix: Incorrect highlighting on bitbake operators after function identifiers

### DIFF
--- a/server/src/semanticTokens.ts
+++ b/server/src/semanticTokens.ts
@@ -111,6 +111,14 @@ export function getParsedTokens (uri: string): ParsedToken[] {
       })
     }
 
+    if (TreeSitterUtils.isBitbakeOperator(node)) {
+      resultTokens.push({
+        ...nodeRange,
+        tokenType: TOKEN_LEGEND.types.keyword,
+        tokenModifiers: []
+      })
+    }
+
     if (TreeSitterUtils.isFunctionIdentifier(node)) {
       resultTokens.push({
         ...nodeRange,

--- a/server/src/tree-sitter/utils.ts
+++ b/server/src/tree-sitter/utils.ts
@@ -69,10 +69,37 @@ export function isVariableReference (n: SyntaxNode): boolean {
  * Check if the node is an override other than `append`, `prepend` or `remove`
  */
 export function isOverride (n: SyntaxNode): boolean {
+  /**
+   * Example:
+   * FOO:append:override1:${PN}:${PN}-foo () {}
+   *
+   * Tree node:
+   *    (function_definition [0, 0] - [0, 42]
+          (identifier [0, 0] - [0, 3])
+          (override [0, 3] - [0, 36]
+            (identifier [0, 11] - [0, 20])
+            (variable_expansion [0, 21] - [0, 26]
+              (identifier [0, 23] - [0, 25]))
+            (concatenation [0, 27] - [0, 36]
+              (variable_expansion [0, 27] - [0, 32]
+                (identifier [0, 29] - [0, 31]))
+              (identifier [0, 32] - [0, 36])))))
+   */
   const parentType = n?.parent?.type
   switch (n.type) {
     case 'identifier':
-      return parentType === 'override' // As per the tree-sitter grammar, an identifier which has a parent of type override is an override other than `append`, `prepend` or `remove`
+      return parentType === 'override' || parentType === 'concatenation'
+    default:
+      return false
+  }
+}
+
+export function isBitbakeOperator (n: SyntaxNode): boolean {
+  switch (n.type) {
+    case 'append':
+    case 'prepend':
+    case 'remove':
+      return true
     default:
       return false
   }


### PR DESCRIPTION
Ticket: 14170

Was:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/6a388095-fea4-475f-b490-7011c6f679ca)
append/prepend/remove were not in the color of keywords

Now:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/a5d43b8f-e2ba-4b54-8a28-ffe2c1d75429)

