### PR TITLE
Feat: Web support with only highlighting

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,22 @@
 
 		},
 		{
+			"name": "Launch Web Client",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}/client",
+				"--extensionDevelopmentKind=web"
+			],
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceRoot}/client/out/**/*.js",
+			],
+			"preLaunchTask": "watch"
+
+		},
+		{
 			"name": "Attach to Server",
 			"type": "node",
 			"request": "attach",

--- a/client/package.json
+++ b/client/package.json
@@ -30,7 +30,7 @@
   ],
   "activationEvents": [],
   "main": "./out/extension",
-  "browser": "./out/extension",
+  "browser": "./out/extension-web",
   "contributes": {
     "languages": [
       {

--- a/client/package.json
+++ b/client/package.json
@@ -34,6 +34,7 @@
   ],
   "activationEvents": [],
   "main": "./out/extension",
+  "browser": "./out/extension",
   "contributes": {
     "languages": [
       {

--- a/client/package.json
+++ b/client/package.json
@@ -25,10 +25,6 @@
   "engines": {
     "vscode": "^1.75.0"
   },
-  "extensionDependencies": [
-    "mads-hartmann.bash-ide-vscode",
-    "ms-python.python"
-  ],
   "categories": [
     "Programming Languages"
   ],

--- a/client/package.json
+++ b/client/package.json
@@ -824,7 +824,7 @@
     "test:grammar": "vscode-tmgrammar-test ./test/grammars/test-cases/*.bb",
     "snap-grammar": "vscode-tmgrammar-snap ./test/grammars/snaps/*.bb -u",
     "vscode:prepublish": "npm install --omit=dev && cd ../server && npm install --omit=dev && npm run installServer",
-    "package": "npm run vscode:prepublish && vsce package --target linux-x64 && vsce package --target linux-arm64 && vsce package --target linux-armhf && vsce package --target win32-x64 && vsce package --target win32-arm64"
+    "package": "npm run vscode:prepublish && vsce package --target linux-x64 && vsce package --target linux-arm64 && vsce package --target linux-armhf && vsce package --target win32-x64 && vsce package --target win32-arm64 && vsce package --target web"
   },
   "dependencies": {
     "find": "^0.2.7",

--- a/client/src/extension-web.ts
+++ b/client/src/extension-web.ts
@@ -1,0 +1,15 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+// Temporary fix for the web extension
+// TODO: Remove this when the language server is ready
+export function activate (): void {
+  console.log('Congratulations, your extension "yocto-project.yocto-bitbake" for web is now active!')
+  console.log('Please note that this web extension only provides highlighting. We are working on adding more features in the future.')
+}
+
+export function deactivate (): void {
+  console.log('Your extension "yocto-project.yocto-bitbake" for web is now deactivated!')
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -75,19 +75,26 @@ async function disableInteferingSettings (): Promise<void> {
 }
 
 async function installExtensions (extensionId: string): Promise<void> {
-  await vscode.window.withProgress({
-    location: vscode.ProgressLocation.Notification,
-    title: ` yocto-project.yocto-bitbake depends on extension ${extensionId}, installing it...`,
-    cancellable: false
-  }, async (progress, token) => {
-    try {
-      await vscode.commands.executeCommand('workbench.extensions.installExtension', extensionId).then(() => {
-        progress.report({ message: `${extensionId} has been installed` })
-      })
-    } catch (error) {
-      await vscode.window.showErrorMessage(`Failed to install ${extensionId}: ${JSON.stringify(error)}`)
-    }
-  })
+  await vscode.window.showInformationMessage(`The extension ${extensionId} is required for yocto-project.yocto-bitbake to work properly. Do you want to install it?`, 'Install', 'Show extension page', 'Cancel')
+    .then((item) => {
+      if (item === 'Install') {
+        void vscode.window.withProgress({
+          location: vscode.ProgressLocation.Notification,
+          title: `Installing ${extensionId}...`,
+          cancellable: false
+        }, async (progress, token) => {
+          try {
+            await vscode.commands.executeCommand('workbench.extensions.installExtension', extensionId).then(() => {
+              progress.report({ message: `${extensionId} has been installed` })
+            })
+          } catch (error) {
+            await vscode.window.showErrorMessage(`Failed to install ${extensionId}: ${JSON.stringify(error)}`)
+          }
+        })
+      } else if (item === 'Show extension page') {
+        void vscode.commands.executeCommand('extension.open', extensionId)
+      }
+    })
 }
 
 export async function activate (context: vscode.ExtensionContext): Promise<void> {


### PR DESCRIPTION
Ticket: 13882

According to the docs: https://code.visualstudio.com/api/extension-guides/web-extensions#web-extension-main-file
~The web extension needs to be packaged into a single file because the `import/require` statements are not allowed. The docs recommend using the webpack.~

~Issues:~
~1. Dynamic import of node-pty in `client/src/utils/ProcessUtils.ts`~
~2. Webpack Can't resolve modules from node such as `fs`, `path` etc. Need to have substitutes.~
~3. Need to handle various scenarios when the extensions are absent when we remove them from the dependencies.~

This PR will only bring basic highlighting to the web.

To debug:
Launch the web client through the debug panel and bitbake files should have the syntax highlighting that `tmLanguage.json` provides.