### PR TITLE
Fix '?' in embedded language documents

### DIFF
--- a/server/src/embedded-languages/utils.ts
+++ b/server/src/embedded-languages/utils.ts
@@ -8,7 +8,7 @@ import { type TextDocument } from 'vscode-languageserver-textdocument'
 import { type EmbeddedLanguageDoc, type EmbeddedLanguageType } from '../lib/src/types/embedded-languages'
 
 const replaceTextForSpaces = (text: string): string => {
-  return text.replace(/[^\r?\n]+/g, (match) => ' '.repeat(match.length))
+  return text.replace(/[^\r\n]+/g, (match) => ' '.repeat(match.length))
 }
 
 const initCharactersOffsetArrays = (length: number): number[] => {


### PR DESCRIPTION
Previously, '?' would be added to "embedded language documents" instead of being replaced by a space. It would occasion such wrong diagnostics:
![clipboard-202402201441-yeqte](https://github.com/yoctoproject/vscode-bitbake/assets/26575562/b622c2ef-5364-41da-87b5-c3b1c432468c)
