### PR TITLE
Fix: Update regex for devtool update-recipe for node-pty

### DIFF
--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -385,7 +385,7 @@ async function devtoolUpdateCommand (bitbakeWorkspace: BitbakeWorkspace, bitBake
 async function openDevtoolUpdateBBAppend (res: SpawnSyncReturns<Buffer>, bitBakeProjectScanner: BitBakeProjectScanner): Promise<void> {
   const output = res.stdout.toString()
   // Regex to extract path from: NOTE: Writing append file .../meta-poky/recipes-core/busybox/busybox_1.36.1.bbappend
-  const regex = /NOTE: Writing append file (.*)/g
+  const regex = /Writing append file ([\w/._-]+)/g
   const match = regex.exec(output)
   if (match === null) {
     logger.error('Could not find bbappend file')


### PR DESCRIPTION
This is a small fix for a regression. The recipe wasn't automatically opened anymore.