### PR TITLE
Fix recipe scan in project scanner

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -90,7 +90,7 @@
         "bitbake.shouldDeepExamine": {
           "type": "boolean",
           "default": false,
-          "description": "Activate deep examination. If a recipe exports an additional package with a different name than the recipe file, the normal scan will not detect these packages. To find these packages, you need to activate this option."
+          "markdownDescription": "Activate deep examination. If a recipe exports an additional package with a different name than the recipe file, the normal scan will not detect these packages. To find these packages, you need to activate this option.\n\n`Attention`: This takes extra time which scales with the number of recipes that weren't detected by the normal scan"
         },
         "bitbake.parseOnSave": {
           "type": "boolean",

--- a/client/src/driver/BitBakeProjectScanner.ts
+++ b/client/src/driver/BitBakeProjectScanner.ts
@@ -43,7 +43,6 @@ export class BitBakeProjectScanner {
   onChange: EventEmitter = new EventEmitter()
 
   private readonly _bitbakeScanResult: BitbakeScanResult = { _classes: [], _includes: [], _layers: [], _overrides: [], _recipes: [], _workspaces: [], _confFiles: [] }
-  private _shouldDeepExamine: boolean = false
   private readonly _bitbakeDriver: BitbakeDriver
   private _languageClient: LanguageClient | undefined
 
@@ -66,14 +65,6 @@ export class BitBakeProjectScanner {
 
   get scanResult (): BitbakeScanResult {
     return this._bitbakeScanResult
-  }
-
-  get shouldDeepExamine (): boolean {
-    return this._shouldDeepExamine
-  }
-
-  set shouldDeepExamine (shouldDeepExamine: boolean) {
-    this._shouldDeepExamine = shouldDeepExamine
   }
 
   get bitbakeDriver (): BitbakeDriver {

--- a/client/src/driver/BitBakeProjectScanner.ts
+++ b/client/src/driver/BitBakeProjectScanner.ts
@@ -425,7 +425,7 @@ You should adjust your docker volumes to use the same URIs as those present on y
     const allFileNames: string[] = []
     if (startingIndex === -1) {
       logger.error('[scanForRecipesPath] Failed to find available recipes')
-      return
+      throw new Error('Failed to find available recipes')
     }
 
     const recipePathRegex = /(.*\.bb)/

--- a/client/src/driver/BitBakeProjectScanner.ts
+++ b/client/src/driver/BitBakeProjectScanner.ts
@@ -445,7 +445,7 @@ You should adjust your docker volumes to use the same URIs as those present on y
         return recipe.name === extractRecipeName(recipePath)
       })
       if (foundRecipe !== undefined) {
-        foundRecipe.path = path.parse(recipePath)
+        foundRecipe.path = path.parse(await this.resolveContainerPath(recipePath) as string)
       } else {
         notMatchedFileNames.push(fileName)
       }
@@ -463,7 +463,7 @@ You should adjust your docker volumes to use the same URIs as those present on y
       if (this._shouldDeepExamine) {
         await this.deepExamineRecipes(recipesWithOutPath, recipePathRegex)
       } else {
-        this.inferRecipePath(recipesWithOutPath, notMatchedFileNames)
+        await this.inferRecipePath(recipesWithOutPath, notMatchedFileNames)
       }
     }
 
@@ -499,7 +499,7 @@ You should adjust your docker volumes to use the same URIs as those present on y
     }
   }
 
-  private inferRecipePath (recipesWithOutPath: ElementInfo[], notMatchedFileNames: string[]): void {
+  private async inferRecipePath (recipesWithOutPath: ElementInfo[], notMatchedFileNames: string[]): Promise<void> {
     logger.info('[inferRecipePath] Deep examine is off, inferring the paths by comparing the recipe name and the unmatched file names.')
     for (const recipe of recipesWithOutPath) {
       /**
@@ -516,8 +516,9 @@ You should adjust your docker volumes to use the same URIs as those present on y
       if (possiblePaths.length > 0) {
         // longer file names are more likely to be the correct one
         possiblePaths.sort((a, b) => extractRecipeName(b).length - extractRecipeName(a).length)
-        logger.debug(`${possiblePaths[0]} is inferred as the path of recipe: ${recipe.name} .`)
-        recipe.path = path.parse(possiblePaths[0])
+        const resolvedPath = await this.resolveContainerPath(possiblePaths[0]) as string
+        logger.debug(`${resolvedPath} is inferred as the path of recipe: ${recipe.name} .`)
+        recipe.path = path.parse(resolvedPath)
       }
     }
   }

--- a/client/src/driver/BitBakeProjectScanner.ts
+++ b/client/src/driver/BitBakeProjectScanner.ts
@@ -422,7 +422,7 @@ You should adjust your docker volumes to use the same URIs as those present on y
     const recipePathRegex = /(.*\.bb)/
 
     // All lines after the '=== Available recipes: ===' line are file names, and only keep the valid ones
-    allFileNames.push(...splittedOutput.slice(startingIndex + 1).filter((line) => !line.includes('skipped') && recipePathRegex.exec(line) !== null))
+    allFileNames.push(...splittedOutput.slice(startingIndex + 1).filter((line) => !line.includes('(skipped') && recipePathRegex.exec(line) !== null))
 
     const notMatchedFileNames: string[] = []
     for (const fileName of allFileNames) {

--- a/client/src/driver/BitBakeProjectScanner.ts
+++ b/client/src/driver/BitBakeProjectScanner.ts
@@ -406,7 +406,7 @@ You should adjust your docker volumes to use the same URIs as those present on y
     const showRecipeFileNameOutput = await this.executeBitBakeCommand('bitbake-layers show-recipes -f')
     if (showRecipeFileNameOutput.status !== 0) {
       logger.error('Failed to scan recipes path')
-      return
+      throw new Error('Failed to scan recipes path')
     }
 
     const output = showRecipeFileNameOutput.output.toString()

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -116,7 +116,11 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
 
   // Handle settings change for bitbake driver
   context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async (event) => {
-    bitbakeDriver.loadSettings(vscode.workspace.getConfiguration('bitbake'), vscode.workspace.workspaceFolders?.[0].uri.fsPath)
+    const currentSettings = vscode.workspace.getConfiguration('bitbake')
+    bitbakeDriver.loadSettings(currentSettings, vscode.workspace.workspaceFolders?.[0].uri.fsPath)
+    if (event.affectsConfiguration('bitbake.shouldDeepExamine')) {
+      bitBakeProjectScanner.shouldDeepExamine = currentSettings.get('shouldDeepExamine') ?? false
+    }
     if (event.affectsConfiguration('bitbake.shellEnv') ||
         event.affectsConfiguration('bitbake.workingDirectory') ||
         event.affectsConfiguration('bitbake.pathToEnvScript') ||


### PR DESCRIPTION
Ticket: 14138

The project scanner runs `bitbake-layers show-recipes` to get the recipe names and the corresponding layer and version. But the path for the recipes can only be returned when the `-f` flag is passed because CLI doesn't support returning everything in one go.
Output of `bitbake-layers show-recipes`:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/3e9a682d-31c8-4f40-9125-3e6e6f7683f4)

Output of `bitbake-layers show-recipes -f`:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/29780915-4692-4804-83f3-92519446fbae)

So we execute the command twice to get the recipes and their matching path. However, some of the recipe names can have random strings at the end which can't be used easily to compare with the path.
Example:
```
name: gcc-source-13.2.0
path: /home/projects/poky/meta/recipes-devtools/gcc/gcc-source_13.2.bb
```

Before, we ran `bitbake-layers show-recipes -f <recipe-name>` to get the target path for a specific know recipe, but this is slow ~and we still had to compare the recipe name with the path.~

~Now, I get all the file names in one go and try to match them with the recipes. Those that can't be easily compared are inferred instead.~ Added extra infer logic when the deep examine is off: [How I infer](https://github.com/yoctoproject/vscode-bitbake/pull/142/commits/73a7656e7d2c656f4e0817c3b0a9bb79d69f7a8e#diff-dd9898b0e3f02562734cfb2d45cb2edf08061477609c4f81e29de81f579fb436R463)

~Therefore, all recipes found should have a path at the end of the scan and the `deep examine` should not be needed.~

Alternative: 
If the outputs from the command with/without the `-f` flag are guaranteed to have the same order, it will be a lot easier to match them. And the deep examine could be discarded.