### PR TITLE
Fix: Random definitions integration test failure

### DIFF
--- a/integration-tests/src/tests/definition.test.ts
+++ b/integration-tests/src/tests/definition.test.ts
@@ -28,10 +28,10 @@ suite('Bitbake Definition Test Suite', () => {
     expectedPathEnding: string,
     expectedRange?: vscode.Range
   ): Promise<void> => {
-    let definitionResult: vscode.Location[] | vscode.Location[] = []
+    let definitionResult: vscode.Location[] | vscode.LocationLink[] = []
 
     await assertWillComeTrue(async () => {
-      definitionResult = await vscode.commands.executeCommand<vscode.Location[] | vscode.Location[]>(
+      definitionResult = await vscode.commands.executeCommand<vscode.Location[] | vscode.LocationLink[]>(
         'vscode.executeDefinitionProvider',
         docUri,
         position
@@ -42,7 +42,11 @@ suite('Bitbake Definition Test Suite', () => {
       const receivedUri = getDefinitionUri(definition)
       assert.equal(receivedUri.fsPath.endsWith(expectedPathEnding), true)
       if (expectedRange !== undefined) {
-        checkIsRangeEqual(definition.range, expectedRange)
+        if (definition instanceof vscode.Location) {
+          checkIsRangeEqual(definition?.range, expectedRange)
+        } else {
+          checkIsRangeEqual(definition.targetRange, expectedRange)
+        }
       }
     })
   }

--- a/integration-tests/src/tests/definition.test.ts
+++ b/integration-tests/src/tests/definition.test.ts
@@ -43,9 +43,9 @@ suite('Bitbake Definition Test Suite', () => {
       assert.equal(receivedUri.fsPath.endsWith(expectedPathEnding), true)
       if (expectedRange !== undefined) {
         if (definition instanceof vscode.Location) {
-          checkIsRangeEqual(definition?.range, expectedRange)
+          assert.equal(checkIsRangeEqual(definition?.range, expectedRange), true)
         } else {
-          checkIsRangeEqual(definition.targetRange, expectedRange)
+          assert.equal(checkIsRangeEqual(definition.targetRange, expectedRange), true)
         }
       }
     })
@@ -90,7 +90,7 @@ suite('Bitbake Definition Test Suite', () => {
   test('Definition appears properly on Bash variable', async () => {
     const position = new vscode.Position(15, 3)
     const expectedPathEnding = filePath
-    const expectedRange = new vscode.Range(13, 2, 13, 8)
+    const expectedRange = new vscode.Range(14, 2, 14, 8)
     await testDefinition(position, expectedPathEnding, expectedRange)
   }).timeout(300000)
 })


### PR DESCRIPTION
According to the documentation, the `vscode.executeDefinitionProvider` command returns an array of `Location` or `LocationLink` objects. In the case a `LocationLink` object is returned, the test probably waited infinitely.