### PR TITLE
Clean up embedded language documents on deactivate

### DIFF
--- a/client/src/__tests__/unit-tests/language/EmbeddedLanguageDocsManager.test.ts
+++ b/client/src/__tests__/unit-tests/language/EmbeddedLanguageDocsManager.test.ts
@@ -1,0 +1,22 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import fs from 'fs'
+import path from 'path'
+import { embeddedLanguageDocsManager } from '../../../language/EmbeddedLanguageDocsManager'
+
+describe('EmbeddedLanguageDocsManager', () => {
+  it('can create and delete embedded language documents folder', async () => {
+    const storagePath = path.join(__dirname, 'generated-content')
+    await embeddedLanguageDocsManager.setStoragePath(storagePath)
+    expect(embeddedLanguageDocsManager.embeddedLanguageDocsFolder).not.toBeUndefined()
+    if (embeddedLanguageDocsManager.embeddedLanguageDocsFolder === undefined) {
+      return
+    }
+    expect(fs.existsSync(embeddedLanguageDocsManager.embeddedLanguageDocsFolder)).toBeTruthy()
+    await embeddedLanguageDocsManager.deleteEmbeddedLanguageDocsFolder()
+    expect(fs.existsSync(embeddedLanguageDocsManager.embeddedLanguageDocsFolder)).toBeFalsy()
+  })
+})

--- a/client/src/__tests__/unit-tests/language/EmbeddedLanguageDocsManager.test.ts
+++ b/client/src/__tests__/unit-tests/language/EmbeddedLanguageDocsManager.test.ts
@@ -11,7 +11,7 @@ describe('EmbeddedLanguageDocsManager', () => {
   it('can create and delete embedded language documents folder', async () => {
     const storagePath = path.join(__dirname, 'generated-content')
     await embeddedLanguageDocsManager.setStoragePath(storagePath)
-    expect(embeddedLanguageDocsManager.embeddedLanguageDocsFolder).not.toBeUndefined()
+    expect(embeddedLanguageDocsManager.embeddedLanguageDocsFolder).toBeDefined()
     if (embeddedLanguageDocsManager.embeddedLanguageDocsFolder === undefined) {
       return
     }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -176,7 +176,11 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
 }
 
 export function deactivate (): Thenable<void> | undefined {
-  taskProvider.dispose()
-  logger.outputChannel?.dispose()
+  // The server has to be handled before the disposables.
+  // Otherwise it might attempt to use anything that has been disposed.
   return deactivateLanguageServer(client)
+    .then(() => {
+      taskProvider.dispose()
+      logger.outputChannel?.dispose()
+    })
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -176,7 +176,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
 }
 
 export function deactivate (): Thenable<void> | undefined {
-  taskProvider.dispose();
-  (logger.outputChannel as vscode.OutputChannel).dispose()
+  taskProvider.dispose()
+  logger.outputChannel?.dispose()
   return deactivateLanguageServer(client)
 }

--- a/client/src/language/EmbeddedLanguageDocsManager.ts
+++ b/client/src/language/EmbeddedLanguageDocsManager.ts
@@ -43,14 +43,15 @@ export default class EmbeddedLanguageDocsManager {
   async setStoragePath (newStoragePath: string | undefined): Promise<void> {
     logger.debug(`Set embedded language documents storage path. New: ${newStoragePath}. Old: ${this._storagePath}`)
     this._storagePath = newStoragePath // also changes the value of this.embeddedLanguageDocsFolder
-    await new Promise<void>((resolve) => {
+    await new Promise<void>((resolve, reject) => {
       if (this.embeddedLanguageDocsFolder === undefined) {
         resolve()
         return
       }
       fs.mkdir(this.embeddedLanguageDocsFolder, { recursive: true }, (err) => {
         if (err !== null) {
-          logger.error(`Failed to create embedded language documents folder: ${err as any}`)
+          reject(err)
+          return
         }
         resolve()
       })
@@ -59,14 +60,15 @@ export default class EmbeddedLanguageDocsManager {
 
   async deleteEmbeddedLanguageDocsFolder (): Promise<void> {
     logger.debug(`Delete embedded language documents folder: ${this.embeddedLanguageDocsFolder}.`)
-    await new Promise<void>((resolve) => {
+    await new Promise<void>((resolve, reject) => {
       if (this.embeddedLanguageDocsFolder === undefined) {
         resolve()
         return
       }
       fs.rm(this.embeddedLanguageDocsFolder, { recursive: true }, (err) => {
         if (err !== null) {
-          logger.error(`Failed to delete embedded language documents folder: ${err as any}`)
+          reject(err)
+          return
         }
         resolve()
       })

--- a/client/src/language/EmbeddedLanguageDocsManager.ts
+++ b/client/src/language/EmbeddedLanguageDocsManager.ts
@@ -45,6 +45,7 @@ export default class EmbeddedLanguageDocsManager {
     this._storagePath = newStoragePath // also changes the value of this.embeddedLanguageDocsFolder
     await new Promise<void>((resolve) => {
       if (this.embeddedLanguageDocsFolder === undefined) {
+        resolve()
         return
       }
       fs.mkdir(this.embeddedLanguageDocsFolder, { recursive: true }, (err) => {
@@ -60,6 +61,7 @@ export default class EmbeddedLanguageDocsManager {
     logger.debug(`Delete embedded language documents folder: ${this.embeddedLanguageDocsFolder}.`)
     await new Promise<void>((resolve) => {
       if (this.embeddedLanguageDocsFolder === undefined) {
+        resolve()
         return
       }
       fs.rm(this.embeddedLanguageDocsFolder, { recursive: true }, (err) => {

--- a/client/src/language/EmbeddedLanguageDocsManager.ts
+++ b/client/src/language/EmbeddedLanguageDocsManager.ts
@@ -56,6 +56,21 @@ export default class EmbeddedLanguageDocsManager {
     })
   }
 
+  async deleteEmbeddedLanguageDocsFolder (): Promise<void> {
+    logger.debug(`Delete embedded language documents folder: ${this.embeddedLanguageDocsFolder}.`)
+    await new Promise<void>((resolve) => {
+      if (this.embeddedLanguageDocsFolder === undefined) {
+        return
+      }
+      fs.rm(this.embeddedLanguageDocsFolder, { recursive: true }, (err) => {
+        if (err !== null) {
+          logger.error(`Failed to delete embedded language documents folder: ${err as any}`)
+        }
+        resolve()
+      })
+    })
+  }
+
   private registerEmbeddedLanguageDocInfos (embeddedLanguageDoc: EmbeddedLanguageDoc, uri: Uri): void {
     const embeddedLanguageDocInfos: EmbeddedLanguageDocInfos = {
       ...embeddedLanguageDoc,

--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -154,10 +154,10 @@ export async function activateLanguageServer (context: ExtensionContext, bitBake
 }
 
 export async function deactivateLanguageServer (client: LanguageClient): Promise<void> {
-  if (client === undefined) {
-    return undefined
-  }
-  await client.stop()
+  await Promise.all([
+    embeddedLanguageDocsManager.deleteEmbeddedLanguageDocsFolder(),
+    client.stop()
+  ])
 }
 
 export async function getVariableValue (client: LanguageClient, variable: string, recipe: string, canTriggerScan: boolean = false): Promise<string | undefined > {

--- a/client/src/lib/src/utils/OutputLogger.ts
+++ b/client/src/lib/src/utils/OutputLogger.ts
@@ -7,6 +7,7 @@ export interface OutputChannel {
   appendLine: (message: string) => void
   show: () => void
   clear: () => void
+  dispose: () => void
 }
 
 export class OutputLogger {

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -204,9 +204,9 @@ describe('sourceIncludeFiles', () => {
     expect(fsReadFileSyncMock).toHaveBeenCalledWith(FIXTURE_URI.BAR_INC.replace('file://', ''), 'utf8')
     expect(fsReadFileSyncMock).toHaveBeenCalledWith(FIXTURE_URI.BAR_INC.replace('file://', ''), 'utf8')
 
-    expect(analyzer.getAnalyzedDocument(FIXTURE_URI.FOO_INC)).not.toBeUndefined()
-    expect(analyzer.getAnalyzedDocument(FIXTURE_URI.BAR_INC)).not.toBeUndefined()
-    expect(analyzer.getAnalyzedDocument(FIXTURE_URI.BAZ_BBCLASS)).not.toBeUndefined()
+    expect(analyzer.getAnalyzedDocument(FIXTURE_URI.FOO_INC)).toBeDefined()
+    expect(analyzer.getAnalyzedDocument(FIXTURE_URI.BAR_INC)).toBeDefined()
+    expect(analyzer.getAnalyzedDocument(FIXTURE_URI.BAZ_BBCLASS)).toBeDefined()
   })
 
   it('does not read the files and parse the syntax tree when the documents were already analyzed ', async () => {
@@ -238,9 +238,9 @@ describe('sourceIncludeFiles', () => {
     // All 4 files were analyzed before, so the logger should be called 4 times
     expect(loggerDebugCalledTimes).toEqual(4)
 
-    expect(analyzer.getAnalyzedDocument(FIXTURE_URI.FOO_INC)).not.toBeUndefined()
-    expect(analyzer.getAnalyzedDocument(FIXTURE_URI.BAR_INC)).not.toBeUndefined()
-    expect(analyzer.getAnalyzedDocument(FIXTURE_URI.BAZ_BBCLASS)).not.toBeUndefined()
+    expect(analyzer.getAnalyzedDocument(FIXTURE_URI.FOO_INC)).toBeDefined()
+    expect(analyzer.getAnalyzedDocument(FIXTURE_URI.BAR_INC)).toBeDefined()
+    expect(analyzer.getAnalyzedDocument(FIXTURE_URI.BAZ_BBCLASS)).toBeDefined()
   })
 
   it('gets symbols from the include files', async () => {

--- a/server/src/__tests__/completions.test.ts
+++ b/server/src/__tests__/completions.test.ts
@@ -785,7 +785,7 @@ describe('On Completion', () => {
     // string_start has symbol among the completion items
     expect(
       resultOnStringStart.find((item) => item.label === 'DVAR')
-    ).not.toBeUndefined()
+    ).toBeDefined()
 
     // string_start does not have task among the completion items
     expect(resultOnStringStart).not.toEqual(
@@ -844,7 +844,7 @@ describe('On Completion', () => {
     // string_content has symbol among the completion items
     expect(
       resultOnStringContent.find((item) => item.label === 'DVAR')
-    ).not.toBeUndefined()
+    ).toBeDefined()
 
     // string_content does not have task among the completion items
     expect(resultOnStringContent).not.toEqual(
@@ -894,7 +894,7 @@ describe('On Completion', () => {
     })
     expect(
       resultOnVariableExpansion.find((item) => item.label === 'FULL_OPTIMIZATION')
-    ).not.toBeUndefined()
+    ).toBeDefined()
 
     const pnCompletionItems = resultOnVariableExpansion.filter((item) => item.label === 'PN')
     expect(pnCompletionItems.length).toBe(1) // not duplicated with common directories
@@ -911,7 +911,7 @@ describe('On Completion', () => {
     })
     expect(
       resultOnPythonDatastoreVariable.find((item) => item.label === 'DEBIAN_MIRROR')
-    ).not.toBeUndefined()
+    ).toBeDefined()
 
     const resultOnVariableAssignation = onCompletionHandler({
       textDocument: {


### PR DESCRIPTION
This deletes the folder containing "embedded language documents" when the extension is deactivated. It ensures that folder won't grow infinitely.

According to my experiments, when testing this change in "Extension Development Host", the window has to be closed with the "x" button in order to have "deactivate" to be called. Clicking on the red square stop button won't do.

Unfortunately, there seems to be no way to call "deactivate" from the integration test environment.