### PR TITLE
UI: Add tooltip to config picker

### DIFF
--- a/client/src/ui/BitbakeConfigPicker.ts
+++ b/client/src/ui/BitbakeConfigPicker.ts
@@ -31,6 +31,7 @@ export class BitbakeConfigPicker {
     this.activeBuildConfiguration = this.memento?.get('BitbakeConfigPicker.activeBuildConfiguration', 'No BitBake configuration') as string
 
     this.statusBarItem.command = 'bitbake.pick-configuration'
+    this.statusBarItem.tooltip = 'Select BitBake buildConfiguration'
     context.subscriptions.push(vscode.commands.registerCommand('bitbake.pick-configuration', this.pickConfiguration, this))
     this.updateStatusBar(bitbakeSettings)
   }


### PR DESCRIPTION
A very trivial improvment to the UI. Adds a hover description on the bottom right config picker
![image](https://github.com/yoctoproject/vscode-bitbake/assets/19970889/047c7542-92eb-4375-8c29-d9548b51beda)
