### PR TITLE
Detect PREFERRED_VERSION and optimize recipe paths scan

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -87,7 +87,8 @@
         "bitbake.shouldDeepExamine": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Activate deep examination. If a recipe exports an additional package with a different name than the recipe file, the normal scan will not detect these packages. To find these packages, you need to activate this option.\n\n`Attention`: This takes extra time which scales with the number of recipes that weren't detected by the normal scan"
+          "markdownDescription": "Activate deep examination. If a recipe exports an additional package with a different name than the recipe file, the normal scan will not detect these packages. To find these packages, you need to activate this option.\n\n`Attention`: This takes extra time which scales with the number of recipes that weren't detected by the normal scan",
+          "deprecationMessage": "The algorithm for finding recipes has been optimized, making this the default"
         },
         "bitbake.parseOnSave": {
           "type": "boolean",

--- a/client/src/__tests__/unit-tests/driver/scanner.test.ts
+++ b/client/src/__tests__/unit-tests/driver/scanner.test.ts
@@ -129,11 +129,19 @@ describe('BitBakeProjectScanner', () => {
         })
       })
     )
-    const goCrossRecipe = recipes.find((recipe) => recipe.name.includes('go-cross-'))
+    const goCrossCanadianRecipe = recipes.find((recipe) => recipe.name.includes('go-cross-canadian'))
+    expect(goCrossCanadianRecipe).toEqual(
+      expect.objectContaining({
+        path: expect.objectContaining({
+          base: expect.stringContaining('go-cross-canadian')
+        })
+      })
+    )
+    const goCrossRecipe = recipes.find((recipe) => recipe.name.includes('go-cross-core2-64'))
     expect(goCrossRecipe).toEqual(
       expect.objectContaining({
         path: expect.objectContaining({
-          base: expect.stringContaining('.bb')
+          base: expect.stringContaining('go-cross_')
         })
       })
     )

--- a/client/src/__tests__/unit-tests/driver/scanner.test.ts
+++ b/client/src/__tests__/unit-tests/driver/scanner.test.ts
@@ -83,6 +83,55 @@ describe('BitBakeProjectScanner', () => {
     )
   })
 
+  it('can get recipes appends', async () => {
+    const recipes = bitBakeProjectScanner.scanResult._recipes
+    const busyboxRecipe = recipes.find((recipe) => recipe.name === 'busybox')
+    expect(busyboxRecipe).toEqual(
+      expect.objectContaining(
+        {
+          appends: expect.arrayContaining([
+            expect.objectContaining({
+              base: expect.stringContaining('busybox_%.bbappend')
+            })
+          ])
+        }
+      )
+    )
+  })
+
+  it('can get recipes paths', async () => {
+    const recipes = bitBakeProjectScanner.scanResult._recipes
+    const busyboxRecipe = recipes.find((recipe) => recipe.name === 'busybox')
+    expect(busyboxRecipe).toEqual(
+      expect.objectContaining({
+        path: expect.objectContaining({
+          base: expect.stringContaining('.bb')
+        })
+      })
+    )
+  })
+
+  it('can get tricky recipes paths', async () => {
+    // These recipes change their PN and require the recipesWithoutPaths code
+    const recipes = bitBakeProjectScanner.scanResult._recipes
+    const gccSourceRecipe = recipes.find((recipe) => recipe.name.includes('gcc-source-'))
+    expect(gccSourceRecipe).toEqual(
+      expect.objectContaining({
+        path: expect.objectContaining({
+          base: expect.stringContaining('.bb')
+        })
+      })
+    )
+    const goCrossRecipe = recipes.find((recipe) => recipe.name.includes('go-cross-'))
+    expect(goCrossRecipe).toEqual(
+      expect.objectContaining({
+        path: expect.objectContaining({
+          base: expect.stringContaining('.bb')
+        })
+      })
+    )
+  })
+
   it('can get a list of classes', async () => {
     const classes = bitBakeProjectScanner.scanResult._classes
     expect(classes.length).toBeGreaterThan(50)

--- a/client/src/__tests__/utils/bitbake.ts
+++ b/client/src/__tests__/utils/bitbake.ts
@@ -1,0 +1,25 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import path from 'path'
+import fs from 'fs'
+
+// This is similar to the integration-tests addLayer() but doesn't use the VSCode API
+export function addLayer (layer: string, buildFolder: string): void {
+  const bblayersConf = path.resolve(buildFolder, 'conf/bblayers.conf')
+  const bblayersConfContent = fs.readFileSync(bblayersConf)
+  let fileContent = bblayersConfContent.toString()
+  fileContent += `\nBBLAYERS+="${layer}"\n`
+  fs.writeFileSync(bblayersConf, fileContent)
+}
+
+// This is similar to the integration-tests removeLayer() but doesn't use the VSCode API
+export function removeLayer (layer: string, buildFolder: string): void {
+  const bblayersConf = path.resolve(buildFolder, 'conf/bblayers.conf')
+  const bblayersConfContent = fs.readFileSync(bblayersConf)
+  let fileContent = bblayersConfContent.toString()
+  fileContent = fileContent.replace(`\nBBLAYERS+="${layer}"`, '')
+  fs.writeFileSync(bblayersConf, fileContent)
+}

--- a/client/src/driver/BitBakeProjectScanner.ts
+++ b/client/src/driver/BitBakeProjectScanner.ts
@@ -24,7 +24,7 @@ import fs from 'fs'
 import { runBitbakeTerminalCustomCommand } from '../ui/BitbakeTerminal'
 import { bitbakeESDKMode } from './BitbakeESDK'
 import { finishProcessExecution } from '../utils/ProcessUtils'
-import { extractRecipeName } from '../lib/src/utils/files'
+import { extractRecipeName, extractRecipeVersion } from '../lib/src/utils/files'
 
 interface ScannStatus {
   scanIsRunning: boolean
@@ -42,7 +42,6 @@ export class BitBakeProjectScanner {
   onChange: EventEmitter = new EventEmitter()
 
   private readonly _bitbakeScanResult: BitbakeScanResult = { _classes: [], _includes: [], _layers: [], _overrides: [], _recipes: [], _workspaces: [], _confFiles: [] }
-  private _shouldDeepExamine: boolean = false
   private readonly _bitbakeDriver: BitbakeDriver
   private _languageClient: LanguageClient | undefined
 
@@ -65,14 +64,6 @@ export class BitBakeProjectScanner {
 
   get scanResult (): BitbakeScanResult {
     return this._bitbakeScanResult
-  }
-
-  get shouldDeepExamine (): boolean {
-    return this._shouldDeepExamine
-  }
-
-  set shouldDeepExamine (shouldDeepExamine: boolean) {
-    this._shouldDeepExamine = shouldDeepExamine
   }
 
   get bitbakeDriver (): BitbakeDriver {

--- a/client/src/driver/BitBakeProjectScanner.ts
+++ b/client/src/driver/BitBakeProjectScanner.ts
@@ -198,6 +198,10 @@ export class BitBakeProjectScanner {
 
     const layersStartRegex = /^layer *path *priority$/
     const layersFirstLine = outputLines.findIndex(line => layersStartRegex.test(line))
+    if (layersFirstLine === -1) {
+      logger.error('Failed to find layers in bitbake-layers output')
+      throw new Error('Failed to find layers in bitbake-layers output')
+    }
 
     for (const element of outputLines.slice(layersFirstLine + 2)) {
       const tempElement = element.split(/\s+/)
@@ -309,6 +313,7 @@ You should adjust your docker volumes to use the same URIs as those present on y
     let outputRecipeSection = ''
     if (startingIndex === -1) {
       logger.error('Failed to find available recipes')
+      throw new Error('Failed to find available recipes')
     } else {
       outputRecipeSection = splittedOutput.slice(startingIndex).join('\n')
     }

--- a/client/src/driver/BitBakeProjectScanner.ts
+++ b/client/src/driver/BitBakeProjectScanner.ts
@@ -197,12 +197,7 @@ export class BitBakeProjectScanner {
     const outputLines = output.split(/\r?\n/g)
 
     const layersStartRegex = /^layer *path *priority$/
-    let layersFirstLine = 0
-    for (; layersFirstLine < outputLines.length; layersFirstLine++) {
-      if (layersStartRegex.test(outputLines[layersFirstLine])) {
-        break
-      }
-    }
+    const layersFirstLine = outputLines.findIndex(line => layersStartRegex.test(line))
 
     for (const element of outputLines.slice(layersFirstLine + 2)) {
       const tempElement = element.split(/\s+/)

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -153,9 +153,6 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
   context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async (event) => {
     const currentSettings = vscode.workspace.getConfiguration('bitbake')
     bitbakeDriver.loadSettings(currentSettings, vscode.workspace.workspaceFolders?.[0].uri.fsPath)
-    if (event.affectsConfiguration('bitbake.shouldDeepExamine')) {
-      bitBakeProjectScanner.shouldDeepExamine = currentSettings.get('shouldDeepExamine') ?? false
-    }
     if (event.affectsConfiguration('bitbake.shellEnv') ||
         event.affectsConfiguration('bitbake.workingDirectory') ||
         event.affectsConfiguration('bitbake.pathToEnvScript') ||

--- a/client/src/lib/src/utils/files.ts
+++ b/client/src/lib/src/utils/files.ts
@@ -9,9 +9,22 @@ export const bitbakeFileExtensions = ['.bb', '.bbappend', '.bbclass', '.conf', '
 
 export function extractRecipeName (filePath: string): string {
   // Ex: gst1.0-plugins-bad_1.18.4.bb -> gst1.0-plugins-bad
-  const baseName = path.parse(filePath).base
-  const stringRegex = '(' + bitbakeFileExtensions.map(ext => `\\${ext}`).join('|') + ')$'
-  const fileName = baseName.replace(new RegExp(stringRegex, 'g'), '')
+  const fileName = extractRecipeFileName(filePath)
   const recipeName = fileName.split('_')[0]
   return recipeName
+}
+
+export function extractRecipeVersion (filePath: string): string {
+  // Ex: gst1.0-plugins-bad_1.18.4.bb -> 1.18.4
+  const fileName = extractRecipeFileName(filePath)
+  const version = fileName.split('_')[1]
+  return version
+}
+
+function extractRecipeFileName (filePath: string): string {
+  // Ex: gst1.0-plugins-bad_1.18.4.bb -> gst1.0-plugins-bad_1.18.4
+  const FileName = path.parse(filePath).base
+  const stringRegex = '(' + bitbakeFileExtensions.map(ext => `\\${ext}`).join('|') + ')$'
+  const fileName = FileName.replace(new RegExp(stringRegex, 'g'), '')
+  return fileName
 }

--- a/integration-tests/project-folder/sources/meta-fixtures-versions/conf/layer.conf
+++ b/integration-tests/project-folder/sources/meta-fixtures-versions/conf/layer.conf
@@ -1,0 +1,16 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have a recipes directory, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+	${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "fixture-versions"
+BBFILE_PATTERN_fixture-versions := "^${LAYERDIR}/"
+BBFILE_PRIORITY_fixture-versions = "6"
+
+LAYERSERIES_COMPAT_fixture-versions = "mickledore nanbield"
+
+LAYERDEPENDS_fixture-versions = ""
+
+PREFERRED_VERSION_fixture-version = "0.2.0"

--- a/integration-tests/project-folder/sources/meta-fixtures-versions/recipes-fixtures/fixture-version/fixture-version_%.bbappend
+++ b/integration-tests/project-folder/sources/meta-fixtures-versions/recipes-fixtures/fixture-version/fixture-version_%.bbappend
@@ -1,0 +1,3 @@
+do_install:append() {
+    echo "generic version append"
+}

--- a/integration-tests/project-folder/sources/meta-fixtures-versions/recipes-fixtures/fixture-version/fixture-version_0.1.0.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures-versions/recipes-fixtures/fixture-version/fixture-version_0.1.0.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Dummy recipe for testing recipe versions"
+LICENSE = "MIT"
+
+SRC_URI = ""
+
+do_install() {
+    echo "hello"
+}

--- a/integration-tests/project-folder/sources/meta-fixtures-versions/recipes-fixtures/fixture-version/fixture-version_0.1.0.bbappend
+++ b/integration-tests/project-folder/sources/meta-fixtures-versions/recipes-fixtures/fixture-version/fixture-version_0.1.0.bbappend
@@ -1,0 +1,3 @@
+do_install:append() {
+    echo "specific version append"
+}

--- a/integration-tests/project-folder/sources/meta-fixtures-versions/recipes-fixtures/fixture-version/fixture-version_0.2.0.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures-versions/recipes-fixtures/fixture-version/fixture-version_0.2.0.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Dummy recipe for testing recipe versions"
+LICENSE = "MIT"
+
+SRC_URI = ""
+
+do_install() {
+    echo "hello"
+}

--- a/integration-tests/project-folder/sources/meta-fixtures-versions/recipes-fixtures/fixture-version/fixture-version_0.2.0.bbappend
+++ b/integration-tests/project-folder/sources/meta-fixtures-versions/recipes-fixtures/fixture-version/fixture-version_0.2.0.bbappend
@@ -1,0 +1,3 @@
+do_install:append() {
+    echo "specific version append"
+}

--- a/integration-tests/project-folder/sources/meta-fixtures-versions/recipes-fixtures/fixture-version/fixture-version_0.3.0.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures-versions/recipes-fixtures/fixture-version/fixture-version_0.3.0.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Dummy recipe for testing recipe versions"
+LICENSE = "MIT"
+
+SRC_URI = ""
+
+do_install() {
+    echo "hello"
+}

--- a/integration-tests/project-folder/sources/meta-fixtures-versions/recipes-fixtures/fixture-version/fixture-version_0.3.0.bbappend
+++ b/integration-tests/project-folder/sources/meta-fixtures-versions/recipes-fixtures/fixture-version/fixture-version_0.3.0.bbappend
@@ -1,0 +1,3 @@
+do_install:append() {
+    echo "specific version append"
+}


### PR DESCRIPTION
When multiple version of a recipe existed, PREFERRED_VERSION wasn't necesseraly the one showed in the bitbake recipe view