### PR TITLE
Feat: Allow to kill bitbake terminals with Ctrl+C

### DIFF
--- a/client/src/ui/BitbakeTerminal.ts
+++ b/client/src/ui/BitbakeTerminal.ts
@@ -106,6 +106,13 @@ export class BitbakePseudoTerminal implements vscode.Pseudoterminal {
     if (this.process === undefined) {
       this.closeEmitter.fire(0)
       if (!this.isTaskTerminal()) { bitbakeTerminals.splice(bitbakeTerminals.indexOf(this.parentTerminal as BitbakeTerminal), 1) }
+    } else {
+      if (!this.isTaskTerminal()) {
+        if (data === '\x03') {
+          logger.info('Bitbake process killed by user')
+          void this.bitbakeDriver.killBitbake()
+        }
+      }
     }
   }
 


### PR DESCRIPTION
It is possible to stop a non interactive bitbake terminal by closing it.
Users may find it more intuitive to press Ctrl+C. We disable typing in those terminals but we could handle Ctrl+C specifically and call the appropriate kill function.