### PR TITLE
Chore: Use scan result to validate diagnostics of undefined variables

### DIFF
--- a/client/src/driver/BitbakeRecipeScanner.ts
+++ b/client/src/driver/BitbakeRecipeScanner.ts
@@ -18,7 +18,7 @@ export class BitbakeRecipeScanner implements vscode.Disposable {
   private _languageClient: LanguageClient | undefined
   private _pendingRecipeScanTasks: vscode.Task | null = null
 
-  private readonly serverScanRequest = new vscode.EventEmitter<vscode.Uri>()
+  private readonly serverScanRequest = new vscode.EventEmitter<vscode.Uri | undefined>()
   private readonly serverScanRequestListeners: ServerScanRequestListener[] = []
 
   private readonly disposables: vscode.Disposable[] = []
@@ -26,7 +26,10 @@ export class BitbakeRecipeScanner implements vscode.Disposable {
   constructor () {
     this.disposables.push(this.serverScanRequest)
     this.disposables.push(this.serverScanRequest.event(async (uri) => {
-      logger.debug(`[BitbakeRecipeScanner] Call listeners of serverScanRequest with ${uri.fsPath}`)
+      logger.debug(`[BitbakeRecipeScanner] Call listeners of serverScanRequest with ${uri?.fsPath}`)
+      if (uri === undefined) {
+        return
+      }
       const recipeName = extractRecipeName(uri.fsPath)
       await Promise.all(
         this.serverScanRequestListeners.map(async (listener) => { await listener(recipeName) })

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -130,7 +130,9 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
   context.subscriptions.push(bitbakeRecipeScanner)
   bitbakeRecipeScanner.setLanguageClient(client)
   bitbakeRecipeScanner.subscribeToTaskEnd(context, bitbakeTaskProvider)
-  bitbakeRecipeScanner.subscribeToServerScanRequestEvent(reviewDiagnostics)
+  context.subscriptions.push(
+    bitbakeRecipeScanner.serverRecipeScanComplete.event(reviewDiagnostics)
+  )
 
   clientNotificationManager.setMemento(context.workspaceState)
   bitbakeRecipesView = new BitbakeRecipesView(bitbakeWorkspace, bitBakeProjectScanner)

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -25,7 +25,7 @@ import { BitbakeTerminalLinkProvider } from './ui/BitbakeTerminalLinkProvider'
 import { extractRecipeName } from './lib/src/utils/files'
 import { BitbakeConfigPicker } from './ui/BitbakeConfigPicker'
 import { scanContainsData } from './lib/src/types/BitbakeScanResult'
-import { reviewRecipeDiagnostics } from './language/diagnosticsSupport'
+import { reviewDiagnostics } from './language/diagnosticsSupport'
 
 let client: LanguageClient
 const bitbakeDriver: BitbakeDriver = new BitbakeDriver()
@@ -130,7 +130,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
   context.subscriptions.push(bitbakeRecipeScanner)
   bitbakeRecipeScanner.setLanguageClient(client)
   bitbakeRecipeScanner.subscribeToTaskEnd(context, bitbakeTaskProvider)
-  bitbakeRecipeScanner.subscribeToServerScanRequestEvent(reviewRecipeDiagnostics)
+  bitbakeRecipeScanner.subscribeToServerScanRequestEvent(reviewDiagnostics)
 
   clientNotificationManager.setMemento(context.workspaceState)
   bitbakeRecipesView = new BitbakeRecipesView(bitbakeWorkspace, bitBakeProjectScanner)

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -25,6 +25,7 @@ import { BitbakeTerminalLinkProvider } from './ui/BitbakeTerminalLinkProvider'
 import { extractRecipeName } from './lib/src/utils/files'
 import { BitbakeConfigPicker } from './ui/BitbakeConfigPicker'
 import { scanContainsData } from './lib/src/types/BitbakeScanResult'
+import { reviewRecipeDiagnostics } from './language/diagnosticsSupport'
 
 let client: LanguageClient
 const bitbakeDriver: BitbakeDriver = new BitbakeDriver()
@@ -128,6 +129,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
 
   bitbakeRecipeScanner.setLanguageClient(client)
   bitbakeRecipeScanner.subscribeToTaskEnd(context, bitbakeTaskProvider)
+  bitbakeRecipeScanner.subscribeToScanDone(reviewRecipeDiagnostics)
 
   clientNotificationManager.setMemento(context.workspaceState)
   bitbakeRecipesView = new BitbakeRecipesView(bitbakeWorkspace, bitBakeProjectScanner)

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -127,9 +127,10 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
 
   taskProvider = vscode.tasks.registerTaskProvider('bitbake', bitbakeTaskProvider)
 
+  context.subscriptions.push(bitbakeRecipeScanner)
   bitbakeRecipeScanner.setLanguageClient(client)
   bitbakeRecipeScanner.subscribeToTaskEnd(context, bitbakeTaskProvider)
-  bitbakeRecipeScanner.subscribeToScanDone(reviewRecipeDiagnostics)
+  bitbakeRecipeScanner.subscribeToServerScanRequestEvent(reviewRecipeDiagnostics)
 
   clientNotificationManager.setMemento(context.workspaceState)
   bitbakeRecipesView = new BitbakeRecipesView(bitbakeWorkspace, bitBakeProjectScanner)

--- a/client/src/language/RequestManager.ts
+++ b/client/src/language/RequestManager.ts
@@ -7,6 +7,7 @@ import { type Position } from 'vscode'
 import { type LanguageClient } from 'vscode-languageclient/node'
 
 import { RequestMethod, type RequestParams, type RequestResult } from '../lib/src/types/requests'
+import { getAllVariableValues } from './languageClient'
 
 export class RequestManager {
   client: LanguageClient | undefined
@@ -19,12 +20,13 @@ export class RequestManager {
     return await this.client?.sendRequest(RequestMethod.EmbeddedLanguageTypeOnPosition, params)
   }
 
-  checkIsSymbolDefinedInRecipe = async (
-    recipeName: string,
-    symbolName: string
-  ): RequestResult['IsSymbolDefinedInRecipe'] => {
-    const params: RequestParams['IsSymbolDefinedInRecipe'] = { recipeName, symbolName }
-    return await this.client?.sendRequest(RequestMethod.IsSymbolDefinedInRecipe, params)
+  getAllVariableValues = async (
+    recipe: string
+  ): Promise<ReturnType<typeof getAllVariableValues>> => {
+    if (this.client === undefined) {
+      return
+    }
+    return await getAllVariableValues(this.client, recipe, false)
   }
 }
 

--- a/client/src/language/RequestManager.ts
+++ b/client/src/language/RequestManager.ts
@@ -18,6 +18,14 @@ export class RequestManager {
     const params: RequestParams['EmbeddedLanguageTypeOnPosition'] = { uriString, position }
     return await this.client?.sendRequest(RequestMethod.EmbeddedLanguageTypeOnPosition, params)
   }
+
+  checkIsSymbolDefinedInRecipe = async (
+    recipeName: string,
+    symbolName: string
+  ): RequestResult['IsSymbolDefinedInRecipe'] => {
+    const params: RequestParams['IsSymbolDefinedInRecipe'] = { recipeName, symbolName }
+    return await this.client?.sendRequest(RequestMethod.IsSymbolDefinedInRecipe, params)
+  }
 }
 
 export const requestsManager = new RequestManager()

--- a/client/src/language/diagnosticsSupport.ts
+++ b/client/src/language/diagnosticsSupport.ts
@@ -18,8 +18,10 @@ const diagnosticCollections = {
   python: vscode.languages.createDiagnosticCollection('bitbake-python')
 }
 
-export const updateDiagnostics = async (uri: vscode.Uri): Promise<void> => {
-  logger.debug(`[updateDiagnostics] for uri: ${uri.toString()}`)
+// Create diagnostics for an "original document" from the diagnostics of its "embedded language documents"
+// This is intended to be called when the diagnostics of the "embedded language documents" are updated
+export const handleEmbeddedLanguageDocumentDiagnostics = async (uri: vscode.Uri): Promise<void> => {
+  logger.debug(`[handleEmbeddedLanguageDocumentDiagnostics] for uri: ${uri.toString()}`)
   const embeddedLanguageType = getEmbeddedLanguageType(uri)
   if (embeddedLanguageType === undefined) {
     return

--- a/client/src/language/diagnosticsSupport.ts
+++ b/client/src/language/diagnosticsSupport.ts
@@ -12,6 +12,7 @@ import { requestsManager } from '../language/RequestManager'
 import path from 'path'
 import { extractRecipeName } from '../lib/src/utils/files'
 import { logger } from '../lib/src/utils/OutputLogger'
+import { commonDirectoriesVariables } from '../lib/src/availableVariables'
 
 const diagnosticCollections = {
   bash: vscode.languages.createDiagnosticCollection('bitbake-bash'),
@@ -108,9 +109,6 @@ const checkIsIgnoredShellcheckSc2154 = async (
   diagnostic: vscode.Diagnostic,
   variablevalues: Array<{ name: string, value: string }> | undefined
 ): Promise<boolean> => {
-  if (variablevalues === undefined) {
-    return false
-  }
   if (diagnostic.source?.includes('shellcheck') !== true && diagnostic.code !== 'SC2154') {
     return false
   }
@@ -121,5 +119,10 @@ const checkIsIgnoredShellcheckSc2154 = async (
     return false
   }
 
-  return variablevalues.find((variable) => variable.name === variableName) !== undefined
+  if (variablevalues === undefined) {
+    // We use a static list of common directories as fallback when the scan is not done
+    return commonDirectoriesVariables.has(variableName)
+  }
+
+  return variablevalues.some((variable) => variable.name === variableName)
 }

--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -28,7 +28,7 @@ import { middlewareProvideDefinition } from './middlewareDefinition'
 import { embeddedLanguageDocsManager } from './EmbeddedLanguageDocsManager'
 import { logger } from '../lib/src/utils/OutputLogger'
 import { NotificationMethod, type NotificationParams } from '../lib/src/types/notifications'
-import { updateDiagnostics } from './diagnosticsSupport'
+import { handleEmbeddedLanguageDocumentDiagnostics } from './diagnosticsSupport'
 import { getLanguageConfiguration } from './languageConfiguration'
 import { BitbakeCodeActionProvider } from './codeActionProvider'
 import { type BitBakeProjectScanner } from '../driver/BitBakeProjectScanner'
@@ -73,7 +73,7 @@ export async function activateLanguageServer (context: ExtensionContext, bitBake
 
   languages.onDidChangeDiagnostics(e => {
     e.uris.forEach(uri => {
-      void updateDiagnostics(uri)
+      void handleEmbeddedLanguageDocumentDiagnostics(uri)
     })
   })
 

--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -160,21 +160,46 @@ export async function deactivateLanguageServer (client: LanguageClient): Promise
   ])
 }
 
-export async function getVariableValue (client: LanguageClient, variable: string, recipe: string, canTriggerScan: boolean = false): Promise<string | undefined > {
-  let value: string | undefined | null = await client.sendRequest('bitbake/getVar', { variable, recipe })
+export async function getScanResult<
+  MethodName extends string,
+  ParamsType extends { recipe: string },
+  ReturnType
+> (
+  client: LanguageClient,
+  methodName: MethodName,
+  params: ParamsType,
+  canTriggerScan: boolean = false
+): Promise<ReturnType | undefined> {
+  let value: ReturnType = await client.sendRequest(methodName, params)
   if ((value === undefined || value === null) && canTriggerScan) {
     // We may not have scanned the recipe yet. Let's try again.
     const progressOptions: vscode.ProgressOptions = {
       location: vscode.ProgressLocation.Notification,
-      title: `Recipe ${recipe} has not been scanned yet. Scanning now...`,
+      title: `Recipe ${params.recipe} has not been scanned yet. Scanning now...`,
       cancellable: false
     }
     await vscode.window.withProgress(progressOptions, async (progress) => {
-      await vscode.commands.executeCommand('bitbake.scan-recipe-env', recipe)
+      await vscode.commands.executeCommand('bitbake.scan-recipe-env', params.recipe)
       progress.report({ increment: 100 })
     })
-    value = await client.sendRequest('bitbake/getVar', { variable, recipe })
+    value = await client.sendRequest(methodName, params)
   }
-  logger.debug(`getVariableValue: ${variable} = ${value}`)
+  logger.debug(`[getScanResult] (${methodName}): ${JSON.stringify(params)}, ${JSON.stringify(value)}`)
   return value ?? undefined
+}
+
+export async function getVariableValue (
+  client: LanguageClient,
+  variable: string, recipe: string,
+  canTriggerScan: boolean = false
+): Promise<string | undefined> {
+  return await getScanResult(client, 'bitbake/getVar', { variable, recipe }, canTriggerScan)
+}
+
+export async function getAllVariableValues (
+  client: LanguageClient,
+  recipe: string,
+  canTriggerScan: boolean = false
+): Promise<Array<{ name: string, value: string }> | undefined> {
+  return await getScanResult(client, 'bitbake/getAllVar', { recipe }, canTriggerScan)
 }

--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -28,7 +28,7 @@ import { middlewareProvideDefinition } from './middlewareDefinition'
 import { embeddedLanguageDocsManager } from './EmbeddedLanguageDocsManager'
 import { logger } from '../lib/src/utils/OutputLogger'
 import { NotificationMethod, type NotificationParams } from '../lib/src/types/notifications'
-import { handleEmbeddedLanguageDocumentDiagnostics } from './diagnosticsSupport'
+import { updateDiagnostics } from './diagnosticsSupport'
 import { getLanguageConfiguration } from './languageConfiguration'
 import { BitbakeCodeActionProvider } from './codeActionProvider'
 import { type BitBakeProjectScanner } from '../driver/BitBakeProjectScanner'
@@ -73,7 +73,7 @@ export async function activateLanguageServer (context: ExtensionContext, bitBake
 
   languages.onDidChangeDiagnostics(e => {
     e.uris.forEach(uri => {
-      void handleEmbeddedLanguageDocumentDiagnostics(uri)
+      void updateDiagnostics(uri)
     })
   })
 

--- a/client/src/lib/src/types/requests.ts
+++ b/client/src/lib/src/types/requests.ts
@@ -8,28 +8,24 @@ import { type EmbeddedLanguageType } from './embedded-languages'
 
 export enum RequestType {
   EmbeddedLanguageTypeOnPosition = 'EmbeddedLanguageTypeOnPosition',
-  IsSymbolDefinedInRecipe = 'IsSymbolDefinedInRecipe',
   getLinksInDocument = 'getLinksInDocument',
   ProcessRecipeScanResults = 'ProcessRecipeScanResults'
 }
 
 export const RequestMethod: Record<RequestType, string> = {
   [RequestType.EmbeddedLanguageTypeOnPosition]: 'bitbake/requestEmbeddedLanguageDocInfos',
-  [RequestType.IsSymbolDefinedInRecipe]: 'bitbake/isVariableDefined',
   [RequestType.getLinksInDocument]: 'bitbake/getLinksInDocument',
   [RequestType.ProcessRecipeScanResults]: 'bitbake/ProcessRecipeScanResults'
 }
 
 export interface RequestParams {
   [RequestType.EmbeddedLanguageTypeOnPosition]: { uriString: string, position: Position }
-  [RequestType.IsSymbolDefinedInRecipe]: { symbolName: string, recipeName: string }
   [RequestType.getLinksInDocument]: { documentUri: string }
   [RequestType.ProcessRecipeScanResults]: { scanResults: string, uri: any, chosenRecipe: string }
 }
 
 export interface RequestResult {
   [RequestType.EmbeddedLanguageTypeOnPosition]: Promise<EmbeddedLanguageType | undefined | null> // for unknown reasons, the client receives null instead of undefined
-  [RequestType.IsSymbolDefinedInRecipe]: Promise<boolean | undefined>
   [RequestType.getLinksInDocument]: Promise<Array<{ value: string, range: Range }>>
   [RequestType.ProcessRecipeScanResults]: Record<string, unknown> | undefined
 }

--- a/client/src/lib/src/types/requests.ts
+++ b/client/src/lib/src/types/requests.ts
@@ -8,24 +8,28 @@ import { type EmbeddedLanguageType } from './embedded-languages'
 
 export enum RequestType {
   EmbeddedLanguageTypeOnPosition = 'EmbeddedLanguageTypeOnPosition',
+  IsSymbolDefinedInRecipe = 'IsSymbolDefinedInRecipe',
   getLinksInDocument = 'getLinksInDocument',
   ProcessRecipeScanResults = 'ProcessRecipeScanResults'
 }
 
 export const RequestMethod: Record<RequestType, string> = {
   [RequestType.EmbeddedLanguageTypeOnPosition]: 'bitbake/requestEmbeddedLanguageDocInfos',
+  [RequestType.IsSymbolDefinedInRecipe]: 'bitbake/isVariableDefined',
   [RequestType.getLinksInDocument]: 'bitbake/getLinksInDocument',
   [RequestType.ProcessRecipeScanResults]: 'bitbake/ProcessRecipeScanResults'
 }
 
 export interface RequestParams {
   [RequestType.EmbeddedLanguageTypeOnPosition]: { uriString: string, position: Position }
+  [RequestType.IsSymbolDefinedInRecipe]: { symbolName: string, recipeName: string }
   [RequestType.getLinksInDocument]: { documentUri: string }
   [RequestType.ProcessRecipeScanResults]: { scanResults: string, uri: any, chosenRecipe: string }
 }
 
 export interface RequestResult {
   [RequestType.EmbeddedLanguageTypeOnPosition]: Promise<EmbeddedLanguageType | undefined | null> // for unknown reasons, the client receives null instead of undefined
+  [RequestType.IsSymbolDefinedInRecipe]: Promise<boolean | undefined>
   [RequestType.getLinksInDocument]: Promise<Array<{ value: string, range: Range }>>
   [RequestType.ProcessRecipeScanResults]: Record<string, unknown> | undefined
 }

--- a/integration-tests/src/tests/diagnostics.test.ts
+++ b/integration-tests/src/tests/diagnostics.test.ts
@@ -37,7 +37,7 @@ suite('Bitbake Diagnostics Test Suite', () => {
     await assertWillComeTrue(async () => {
       const diagnostics = vscode.languages.getDiagnostics(docUri)
       return diagnostics.length === 1 &&
-        diagnostics[0].source === 'Pylance' &&
+        diagnostics[0].source === 'Pylance, bitbake-python' &&
         diagnostics[0].range.isEqual(new vscode.Range(1, 4, 1, 9))
     })
   }).timeout(BITBAKE_TIMEOUT)

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -145,9 +145,9 @@ connection.onRequest('bitbake/getVar', async (params: { variable: string, recipe
   return scanResult?.symbols.find(symbolInfo => symbolInfo.name === params.variable)?.finalValue
 })
 
-connection.onRequest(RequestMethod.IsSymbolDefinedInRecipe, async (params: RequestParams['IsSymbolDefinedInRecipe']) => {
-  const scanResult = analyzer.getLastScanResult(params.recipeName)
-  return scanResult?.symbols.some(symbolInfo => symbolInfo.name === params.symbolName)
+connection.onRequest('bitbake/getAllVar', async (params: { recipe: string }) => {
+  const scanResult = analyzer.getLastScanResult(params.recipe)
+  return scanResult?.symbols.map(symbolInfo => ({ name: symbolInfo.name, value: symbolInfo.finalValue }))
 })
 
 connection.onNotification(NotificationMethod.RemoveScanResult, (param: NotificationParams['RemoveScanResult']) => {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -145,6 +145,11 @@ connection.onRequest('bitbake/getVar', async (params: { variable: string, recipe
   return scanResult?.symbols.find(symbolInfo => symbolInfo.name === params.variable)?.finalValue
 })
 
+connection.onRequest(RequestMethod.IsSymbolDefinedInRecipe, async (params: RequestParams['IsSymbolDefinedInRecipe']) => {
+  const scanResult = analyzer.getLastScanResult(params.recipeName)
+  return scanResult?.symbols.some(symbolInfo => symbolInfo.name === params.symbolName)
+})
+
 connection.onNotification(NotificationMethod.RemoveScanResult, (param: NotificationParams['RemoveScanResult']) => {
   logger.debug(`[onNotification] <${NotificationMethod.RemoveScanResult}> recipe: ${param.recipeName}`)
   analyzer.removeLastScanResultForRecipe(param.recipeName)


### PR DESCRIPTION
This uses the result of the scan in order to remove Shellcheck warnings of variables that are actually available

Before the scan of the recipe:
![Screenshot from 2024-03-05 18-27-29](https://github.com/yoctoproject/vscode-bitbake/assets/92585455/91984542-8d1b-4527-896f-1ca75cd3d00f)

After the scan of the recipe:
![Screenshot from 2024-03-05 18-27-04](https://github.com/yoctoproject/vscode-bitbake/assets/92585455/14e55abf-fb31-4333-b042-42b1948c925b)
