### PR TITLE
Fix: EventEmitter mock

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -101,8 +101,10 @@ const languages = {
   const ThemeColor = jest.fn();
 
   const EventEmitter = jest.fn(() => {
-    fire: jest.fn()
-    event: jest.fn()
+    return {
+      fire: jest.fn(),
+      event: jest.fn()
+    }
   });
 
   const QuickPickItemKind = {


### PR DESCRIPTION
I noticed the mock for vscode.EventEmitter was broken. I don't need it anymore, but here's a fix before someone else spend time on it