### PR TITLE
Feature: Forward references for embedded languages

### DIFF
--- a/client/src/language/codeActionProvider.ts
+++ b/client/src/language/codeActionProvider.ts
@@ -6,10 +6,11 @@
 import vscode from 'vscode'
 import { requestsManager } from './RequestManager'
 import { embeddedLanguageDocsManager } from './EmbeddedLanguageDocsManager'
-import { getEmbeddedLanguageDocRange, getIndentationOnLine, getOriginalDocPosition } from './utils'
+import { getEmbeddedLanguageDocRange, getOriginalDocPosition } from './utils/embeddedLanguagesUtils'
 import { logger } from '../lib/src/utils/OutputLogger'
 import { type Range } from 'vscode-languageclient'
 import { type EmbeddedLanguageType } from '../lib/src/types/embedded-languages'
+import { getIndentationOnLine } from './utils/textDocumentUtils'
 
 export class BitbakeCodeActionProvider implements vscode.CodeActionProvider {
   async provideCodeActions (document: vscode.TextDocument, range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext, token: vscode.CancellationToken): Promise<vscode.CodeAction[]> {

--- a/client/src/language/diagnosticsSupport.ts
+++ b/client/src/language/diagnosticsSupport.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 
-import { getOriginalDocRange } from './utils'
+import { getOriginalDocRange } from './utils/embeddedLanguagesUtils'
 import { embeddedLanguageDocsManager } from './EmbeddedLanguageDocsManager'
 import { type EmbeddedLanguageType } from '../lib/src/types/embedded-languages'
 import { commonDirectoriesVariables } from '../lib/src/availableVariables'

--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -33,6 +33,7 @@ import { getLanguageConfiguration } from './languageConfiguration'
 import { BitbakeCodeActionProvider } from './codeActionProvider'
 import { type BitBakeProjectScanner } from '../driver/BitBakeProjectScanner'
 import * as vscode from 'vscode'
+import { middlewareProvideReferences } from './middlewareReferences'
 
 export async function activateLanguageServer (context: ExtensionContext, bitBakeProjectScanner: BitBakeProjectScanner): Promise<LanguageClient> {
   const serverModule = context.asAbsolutePath(path.join('server', 'server.js'))
@@ -65,7 +66,8 @@ export async function activateLanguageServer (context: ExtensionContext, bitBake
     middleware: {
       provideCompletionItem: middlewareProvideCompletion,
       provideDefinition: middlewareProvideDefinition,
-      provideHover: middlewareProvideHover
+      provideHover: middlewareProvideHover,
+      provideReferences: middlewareProvideReferences
     }
   }
 

--- a/client/src/language/middlewareCompletion.ts
+++ b/client/src/language/middlewareCompletion.ts
@@ -7,7 +7,7 @@ import { CompletionList, commands, Range, workspace } from 'vscode'
 import { type CompletionMiddleware } from 'vscode-languageclient/node'
 
 import { requestsManager } from './RequestManager'
-import { getEmbeddedLanguageDocPosition, getOriginalDocRange } from './utils'
+import { getEmbeddedLanguageDocPosition, getOriginalDocRange } from './utils/embeddedLanguagesUtils'
 import { embeddedLanguageDocsManager } from './EmbeddedLanguageDocsManager'
 import { mergeArraysDistinctly } from '../lib/src/utils/arrays'
 

--- a/client/src/language/middlewareDefinition.ts
+++ b/client/src/language/middlewareDefinition.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { Location, Position, Range, commands, type LocationLink, type TextDocument, workspace } from 'vscode'
+import { Location, Position, Range, commands, type LocationLink, type TextDocument, workspace, type Uri } from 'vscode'
 import { type DefinitionMiddleware } from 'vscode-languageclient'
 
 import { requestsManager } from './RequestManager'
-import { changeDefinitionUri, checkIsDefinitionRangeEqual, checkIsDefinitionUriEqual, convertToSameDefinitionType, getDefinitionUri, getEmbeddedLanguageDocPosition, getOriginalDocRange } from './utils'
+import { getEmbeddedLanguageDocPosition, getOriginalDocRange } from './utils'
 import { logger } from '../lib/src/utils/OutputLogger'
 import { type EmbeddedLanguageDocInfos, embeddedLanguageDocsManager } from './EmbeddedLanguageDocsManager'
 
@@ -46,6 +46,67 @@ export const middlewareProvideDefinition: DefinitionMiddleware['provideDefinitio
     return await processDefinitions(tempResult, document, embeddedLanguageTextDocument, embeddedLanguageDocInfos)
   } else {
     return await processDefinitions(tempResult, document, embeddedLanguageTextDocument, embeddedLanguageDocInfos)
+  }
+}
+
+export const checkIsDefinitionUriEqual = (definition: Location | LocationLink, uri: Uri): boolean => {
+  if (definition instanceof Location) {
+    return definition.uri.fsPath === uri.fsPath
+  }
+  return definition.targetUri.fsPath === uri.fsPath
+}
+
+export const changeDefinitionUri = (definition: Location | LocationLink, uri: Uri): void => {
+  if (definition instanceof Location) {
+    definition.uri = uri
+  } else {
+    definition.targetUri = uri
+  }
+}
+
+export const getDefinitionUri = (definition: Location | LocationLink): Uri => {
+  if (definition instanceof Location) {
+    return definition.uri
+  }
+  return definition.targetUri
+}
+
+export const checkIsDefinitionRangeEqual = (definition: Location | LocationLink, range: Range): boolean => {
+  if (definition instanceof Location) {
+    return definition.range.isEqual(range)
+  }
+  return definition.targetRange.isEqual(range)
+}
+
+export const convertDefinitionToLocation = (definition: Location | LocationLink): Location => {
+  if (definition instanceof Location) {
+    return definition
+  }
+  return {
+    uri: definition.targetUri,
+    range: definition.targetRange
+  }
+}
+
+export const convertDefinitionToLocationLink = (definition: Location | LocationLink): LocationLink => {
+  if (definition instanceof Location) {
+    return {
+      targetUri: definition.uri,
+      targetRange: definition.range,
+      targetSelectionRange: definition.range
+    }
+  }
+  return definition
+}
+
+export const convertToSameDefinitionType = <DefinitionType extends Location | LocationLink>(
+  referenceDefinition: DefinitionType,
+  definitionToConvert: Location | LocationLink
+): DefinitionType => {
+  if (referenceDefinition instanceof Location) {
+    return convertDefinitionToLocation(definitionToConvert) as DefinitionType
+  } else {
+    return convertDefinitionToLocationLink(definitionToConvert) as DefinitionType
   }
 }
 

--- a/client/src/language/middlewareHover.ts
+++ b/client/src/language/middlewareHover.ts
@@ -6,7 +6,7 @@
 import { type HoverMiddleware } from 'vscode-languageclient'
 import { type Hover, commands, workspace, MarkdownString, type TextDocument, Position } from 'vscode'
 
-import { getEmbeddedLanguageDocPosition, getOriginalDocPosition } from './utils'
+import { getEmbeddedLanguageDocPosition, getOriginalDocPosition } from './utils/embeddedLanguagesUtils'
 import { type EmbeddedLanguageDocInfos, embeddedLanguageDocsManager } from './EmbeddedLanguageDocsManager'
 import { requestsManager } from './RequestManager'
 import path from 'path'

--- a/client/src/language/middlewareReferences.ts
+++ b/client/src/language/middlewareReferences.ts
@@ -1,0 +1,75 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { type ReferencesMiddleware } from 'vscode-languageclient'
+import { type EmbeddedLanguageDocInfos, embeddedLanguageDocsManager } from './EmbeddedLanguageDocsManager'
+import { requestsManager } from './RequestManager'
+import { type Location, commands, workspace, type TextDocument } from 'vscode'
+import { getEmbeddedLanguageDocPosition, getOriginalDocRange } from './utils'
+
+export const middlewareProvideReferences: ReferencesMiddleware['provideReferences'] = async (document, position, options, token, next) => {
+  const nextResult = await next(document, position, options, token)
+  if (nextResult !== undefined && nextResult !== null) {
+    return nextResult
+  }
+  const embeddedLanguageType = await requestsManager.getEmbeddedLanguageTypeOnPosition(document.uri.toString(), position)
+  if (embeddedLanguageType === undefined || embeddedLanguageType === null) {
+    return
+  }
+  const embeddedLanguageDocInfos = embeddedLanguageDocsManager.getEmbeddedLanguageDocInfos(document.uri, embeddedLanguageType)
+  if (embeddedLanguageDocInfos === undefined || embeddedLanguageDocInfos === null) {
+    return
+  }
+  const embeddedLanguageTextDocument = await workspace.openTextDocument(embeddedLanguageDocInfos.uri)
+  const adjustedPosition = getEmbeddedLanguageDocPosition(
+    document,
+    embeddedLanguageTextDocument,
+    embeddedLanguageDocInfos.characterIndexes,
+    position
+  )
+  const tempResult = await commands.executeCommand<Location[]>(
+    'vscode.executeReferenceProvider',
+    embeddedLanguageDocInfos.uri,
+    adjustedPosition
+  )
+
+  return processReferences(tempResult, document, embeddedLanguageTextDocument, embeddedLanguageDocInfos)
+}
+
+const processReferences = (
+  references: Location[],
+  originalTextDocument: TextDocument,
+  embeddedLanguageTextDocument: TextDocument,
+  embeddedLanguageDocInfos: EmbeddedLanguageDocInfos
+): Location[] => {
+  const result: Location[] = []
+  references.forEach((reference) => {
+    if (reference.uri.fsPath !== embeddedLanguageDocInfos.uri.fsPath) {
+      if (reference.uri.fsPath.includes(embeddedLanguageDocsManager.embeddedLanguageDocsFolder as string)) {
+        // This is a reference to an other embedded language document. It has to be ignored.
+        return
+      }
+      // only references located on the embedded language documents need ajustments
+      result.push(reference)
+      return
+    }
+    reference.uri = originalTextDocument.uri
+
+    const newRange = getOriginalDocRange(
+      originalTextDocument,
+      embeddedLanguageTextDocument,
+      embeddedLanguageDocInfos.characterIndexes,
+      reference.range
+    )
+
+    if (newRange === undefined) {
+      return
+    }
+    reference.range = newRange
+    result.push(reference)
+  })
+
+  return result
+}

--- a/client/src/language/middlewareReferences.ts
+++ b/client/src/language/middlewareReferences.ts
@@ -7,7 +7,7 @@ import { type ReferencesMiddleware } from 'vscode-languageclient'
 import { type EmbeddedLanguageDocInfos, embeddedLanguageDocsManager } from './EmbeddedLanguageDocsManager'
 import { requestsManager } from './RequestManager'
 import { type Location, commands, workspace, type TextDocument } from 'vscode'
-import { getEmbeddedLanguageDocPosition, getOriginalDocRange } from './utils'
+import { getEmbeddedLanguageDocPosition, getOriginalDocRange } from './utils/embeddedLanguagesUtils'
 
 export const middlewareProvideReferences: ReferencesMiddleware['provideReferences'] = async (document, position, options, token, next) => {
   const nextResult = await next(document, position, options, token)

--- a/client/src/language/utils.ts
+++ b/client/src/language/utils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { Location, type LocationLink, type Position, Range, type Uri, type TextDocument } from 'vscode'
+import { type Position, Range, type TextDocument } from 'vscode'
 
 export const getOriginalDocRange = (
   originalTextDocument: TextDocument,
@@ -58,65 +58,4 @@ export const getEmbeddedLanguageDocRange = (
 export const getIndentationOnLine = (document: TextDocument, lineNumber: number): string => {
   const line = document.lineAt(lineNumber)
   return line.text.slice(0, line.firstNonWhitespaceCharacterIndex)
-}
-
-export const checkIsDefinitionUriEqual = (definition: Location | LocationLink, uri: Uri): boolean => {
-  if (definition instanceof Location) {
-    return definition.uri.fsPath === uri.fsPath
-  }
-  return definition.targetUri.fsPath === uri.fsPath
-}
-
-export const changeDefinitionUri = (definition: Location | LocationLink, uri: Uri): void => {
-  if (definition instanceof Location) {
-    definition.uri = uri
-  } else {
-    definition.targetUri = uri
-  }
-}
-
-export const getDefinitionUri = (definition: Location | LocationLink): Uri => {
-  if (definition instanceof Location) {
-    return definition.uri
-  }
-  return definition.targetUri
-}
-
-export const checkIsDefinitionRangeEqual = (definition: Location | LocationLink, range: Range): boolean => {
-  if (definition instanceof Location) {
-    return definition.range.isEqual(range)
-  }
-  return definition.targetRange.isEqual(range)
-}
-
-export const convertDefinitionToLocation = (definition: Location | LocationLink): Location => {
-  if (definition instanceof Location) {
-    return definition
-  }
-  return {
-    uri: definition.targetUri,
-    range: definition.targetRange
-  }
-}
-
-export const convertDefinitionToLocationLink = (definition: Location | LocationLink): LocationLink => {
-  if (definition instanceof Location) {
-    return {
-      targetUri: definition.uri,
-      targetRange: definition.range,
-      targetSelectionRange: definition.range
-    }
-  }
-  return definition
-}
-
-export const convertToSameDefinitionType = <DefinitionType extends Location | LocationLink>(
-  referenceDefinition: DefinitionType,
-  definitionToConvert: Location | LocationLink
-): DefinitionType => {
-  if (referenceDefinition instanceof Location) {
-    return convertDefinitionToLocation(definitionToConvert) as DefinitionType
-  } else {
-    return convertDefinitionToLocationLink(definitionToConvert) as DefinitionType
-  }
 }

--- a/client/src/language/utils.ts
+++ b/client/src/language/utils.ts
@@ -55,14 +55,6 @@ export const getEmbeddedLanguageDocRange = (
   return new Range(start, end)
 }
 
-export const checkIsPositionEqual = (position1: Position, position2: Position): boolean => {
-  return position1.line === position2.line && position1.character === position2.character
-}
-
-export const checkIsRangeEqual = (range1: Range, range2: Range): boolean => {
-  return checkIsPositionEqual(range1.start, range2.start) && checkIsPositionEqual(range1.end, range2.end)
-}
-
 export const getIndentationOnLine = (document: TextDocument, lineNumber: number): string => {
   const line = document.lineAt(lineNumber)
   return line.text.slice(0, line.firstNonWhitespaceCharacterIndex)
@@ -92,9 +84,9 @@ export const getDefinitionUri = (definition: Location | LocationLink): Uri => {
 
 export const checkIsDefinitionRangeEqual = (definition: Location | LocationLink, range: Range): boolean => {
   if (definition instanceof Location) {
-    return checkIsRangeEqual(definition.range, range)
+    return definition.range.isEqual(range)
   }
-  return checkIsRangeEqual(definition.targetRange, range)
+  return definition.targetRange.isEqual(range)
 }
 
 export const convertDefinitionToLocation = (definition: Location | LocationLink): Location => {

--- a/client/src/language/utils/definitions.ts
+++ b/client/src/language/utils/definitions.ts
@@ -1,0 +1,67 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { Location, type LocationLink, type Range, type Uri } from 'vscode'
+
+export const checkIsDefinitionUriEqual = (definition: Location | LocationLink, uri: Uri): boolean => {
+  if (definition instanceof Location) {
+    return definition.uri.fsPath === uri.fsPath
+  }
+  return definition.targetUri.fsPath === uri.fsPath
+}
+
+export const changeDefinitionUri = (definition: Location | LocationLink, uri: Uri): void => {
+  if (definition instanceof Location) {
+    definition.uri = uri
+  } else {
+    definition.targetUri = uri
+  }
+}
+
+export const getDefinitionUri = (definition: Location | LocationLink): Uri => {
+  if (definition instanceof Location) {
+    return definition.uri
+  }
+  return definition.targetUri
+}
+
+export const checkIsDefinitionRangeEqual = (definition: Location | LocationLink, range: Range): boolean => {
+  if (definition instanceof Location) {
+    return definition.range.isEqual(range)
+  }
+  return definition.targetRange.isEqual(range)
+}
+
+export const convertDefinitionToLocation = (definition: Location | LocationLink): Location => {
+  if (definition instanceof Location) {
+    return definition
+  }
+  return {
+    uri: definition.targetUri,
+    range: definition.targetRange
+  }
+}
+
+export const convertDefinitionToLocationLink = (definition: Location | LocationLink): LocationLink => {
+  if (definition instanceof Location) {
+    return {
+      targetUri: definition.uri,
+      targetRange: definition.range,
+      targetSelectionRange: definition.range
+    }
+  }
+  return definition
+}
+
+export const convertToSameDefinitionType = <DefinitionType extends Location | LocationLink>(
+  referenceDefinition: DefinitionType,
+  definitionToConvert: Location | LocationLink
+): DefinitionType => {
+  if (referenceDefinition instanceof Location) {
+    return convertDefinitionToLocation(definitionToConvert) as DefinitionType
+  } else {
+    return convertDefinitionToLocationLink(definitionToConvert) as DefinitionType
+  }
+}

--- a/client/src/language/utils/embeddedLanguagesUtils.ts
+++ b/client/src/language/utils/embeddedLanguagesUtils.ts
@@ -54,8 +54,3 @@ export const getEmbeddedLanguageDocRange = (
   const end = getEmbeddedLanguageDocPosition(originalTextDocument, embeddedLanguageTextDocument, characterIndexes, originalRange.end)
   return new Range(start, end)
 }
-
-export const getIndentationOnLine = (document: TextDocument, lineNumber: number): string => {
-  const line = document.lineAt(lineNumber)
-  return line.text.slice(0, line.firstNonWhitespaceCharacterIndex)
-}

--- a/client/src/language/utils/textDocumentUtils.ts
+++ b/client/src/language/utils/textDocumentUtils.ts
@@ -1,0 +1,11 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { type TextDocument } from 'vscode'
+
+export const getIndentationOnLine = (document: TextDocument, lineNumber: number): string => {
+  const line = document.lineAt(lineNumber)
+  return line.text.slice(0, line.firstNonWhitespaceCharacterIndex)
+}

--- a/integration-tests/project-folder/sources/meta-fixtures/references.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures/references.bb
@@ -1,0 +1,8 @@
+python() {
+    oe
+}
+
+do_foo() {
+    foo=''
+    echo "${foo}"
+}

--- a/integration-tests/project-folder/sources/meta-fixtures/references.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures/references.bb
@@ -1,5 +1,6 @@
 python() {
-    oe
+    foo = ''
+    print(foo)
 }
 
 do_foo() {

--- a/integration-tests/src/tests/code-actions.test.ts
+++ b/integration-tests/src/tests/code-actions.test.ts
@@ -8,7 +8,6 @@ import * as vscode from 'vscode'
 import path from 'path'
 import { assertWillComeTrue } from '../utils/async'
 import { BITBAKE_TIMEOUT } from '../utils/bitbake'
-import { checkIsPositionEqual } from '../utils/vscode-tools'
 
 suite('Bitbake CodeAction Test Suite', () => {
   const filePath = path.resolve(__dirname, '../../project-folder/sources/meta-fixtures/code-actions.bb')
@@ -56,7 +55,7 @@ suite('Bitbake CodeAction Test Suite', () => {
     assert.strictEqual(textEdit.length, 1)
     assert.strictEqual(textEdit[0].newText, expectedNewText)
     const range = textEdit[0].range
-    assert.strictEqual(checkIsPositionEqual(range.start, expectedRange.start), true)
+    assert.strictEqual(range.start.isEqual(expectedRange.start), true)
   }
 
   test('CodeAction can properly show "import random"', async () => {

--- a/integration-tests/src/tests/definition.test.ts
+++ b/integration-tests/src/tests/definition.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert'
 import * as vscode from 'vscode'
 import path from 'path'
 import { assertWillComeTrue } from '../utils/async'
-import { checkIsRangeEqual, getDefinitionUri } from '../utils/vscode-tools'
+import { getDefinitionUri } from '../utils/vscode-tools'
 
 suite('Bitbake Definition Test Suite', () => {
   const filePath = path.resolve(__dirname, '../../project-folder/sources/meta-fixtures/definition.bb')
@@ -43,9 +43,9 @@ suite('Bitbake Definition Test Suite', () => {
       assert.equal(receivedUri.fsPath.endsWith(expectedPathEnding), true)
       if (expectedRange !== undefined) {
         if (definition instanceof vscode.Location) {
-          assert.equal(checkIsRangeEqual(definition?.range, expectedRange), true)
+          assert.equal(definition?.range.isEqual(expectedRange), true)
         } else {
-          assert.equal(checkIsRangeEqual(definition.targetRange, expectedRange), true)
+          assert.equal(definition.targetRange.isEqual(expectedRange), true)
         }
       }
     })

--- a/integration-tests/src/tests/references.test.ts
+++ b/integration-tests/src/tests/references.test.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode'
 import path from 'path'
 import { assertWillComeTrue } from '../utils/async'
 
-suite('Bitbake Definition Test Suite', () => {
+suite('Bitbake References Test Suite', () => {
   const filePath = path.resolve(__dirname, '../../project-folder/sources/meta-fixtures/references.bb')
   const docUri = vscode.Uri.parse(`file://${filePath}`)
 

--- a/integration-tests/src/tests/references.test.ts
+++ b/integration-tests/src/tests/references.test.ts
@@ -24,9 +24,7 @@ suite('Bitbake References Test Suite', () => {
 
   const testReferences = async (
     position: vscode.Position,
-    // A range we hope won't break on every poky update and from which we still can assume the command worked properly
-    estimatedNumberOfReferences: { min: number, max: number },
-    nbReferencesOnOriginalDocument: vscode.Range[]
+    referenceRanges: vscode.Range[]
   ): Promise<void> => {
     let referencesResult: vscode.Location[] = []
 
@@ -38,41 +36,29 @@ suite('Bitbake References Test Suite', () => {
       )
       return referencesResult.length > 0
     }, 5000)
-    assert.equal(
-      referencesResult.length >= estimatedNumberOfReferences.min && referencesResult.length <= estimatedNumberOfReferences.max,
-      true
-    )
-    let nbReferencesFoundOnOriginalDocument = 0
+    assert.equal(referencesResult.length === referenceRanges.length, true)
     referencesResult.forEach((reference, index) => {
       assert.equal(reference.uri.fsPath.includes('workspaceStorage'), false)
-      if (reference.uri.fsPath === docUri.fsPath) {
-        assert.equal(
-          nbReferencesOnOriginalDocument.some((range) => range.isEqual(reference.range)),
-          true
-        )
-        nbReferencesFoundOnOriginalDocument++
-      }
+      assert.equal(reference.uri.fsPath === docUri.fsPath, true)
+      assert.equal(referenceRanges.some((range) => range.isEqual(reference.range)), true)
     })
-    assert.equal(nbReferencesFoundOnOriginalDocument, nbReferencesOnOriginalDocument.length)
   }
 
   test('References appear properly in Python on oe', async () => {
     const position = new vscode.Position(1, 5)
-    // Got 406 on manual testing and around 600 on integration tests' environment
-    const estimatedNumberOfReferences = { min: 300, max: 1000 }
-    const nbReferencesOnOriginalDocument = [
-      new vscode.Range(1, 4, 1, 6)
+    const referenceRanges = [
+      new vscode.Range(1, 4, 1, 7),
+      new vscode.Range(2, 10, 2, 13)
     ]
-    await testReferences(position, estimatedNumberOfReferences, nbReferencesOnOriginalDocument)
+    await testReferences(position, referenceRanges)
   }).timeout(300000)
 
   test('References appear properly in Bash on variable', async () => {
-    const position = new vscode.Position(6, 13)
-    const estimatedNumberOfReferences = { min: 2, max: 2 }
-    const nbReferencesOnOriginalDocument = [
-      new vscode.Range(5, 4, 5, 7),
-      new vscode.Range(6, 12, 6, 15)
+    const position = new vscode.Position(7, 13)
+    const referenceRanges = [
+      new vscode.Range(6, 4, 6, 7),
+      new vscode.Range(7, 12, 7, 15)
     ]
-    await testReferences(position, estimatedNumberOfReferences, nbReferencesOnOriginalDocument)
+    await testReferences(position, referenceRanges)
   }).timeout(300000)
 })

--- a/integration-tests/src/tests/references.test.ts
+++ b/integration-tests/src/tests/references.test.ts
@@ -1,0 +1,78 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import path from 'path'
+import { assertWillComeTrue } from '../utils/async'
+
+suite('Bitbake Definition Test Suite', () => {
+  const filePath = path.resolve(__dirname, '../../project-folder/sources/meta-fixtures/references.bb')
+  const docUri = vscode.Uri.parse(`file://${filePath}`)
+
+  suiteSetup(async function (this: Mocha.Context) {
+    this.timeout(100000)
+    const vscodeBitbake = vscode.extensions.getExtension('yocto-project.yocto-bitbake')
+    if (vscodeBitbake === undefined) {
+      assert.fail('Bitbake extension is not available')
+    }
+    await vscodeBitbake.activate()
+    await vscode.workspace.openTextDocument(docUri)
+  })
+
+  const testReferences = async (
+    position: vscode.Position,
+    // A range we hope won't break on every poky update and from which we still can assume the command worked properly
+    estimatedNumberOfReferences: { min: number, max: number },
+    nbReferencesOnOriginalDocument: vscode.Range[]
+  ): Promise<void> => {
+    let referencesResult: vscode.Location[] = []
+
+    await assertWillComeTrue(async () => {
+      referencesResult = await vscode.commands.executeCommand<vscode.Location[]>(
+        'vscode.executeReferenceProvider',
+        docUri,
+        position
+      )
+      return referencesResult.length > 0
+    }, 5000)
+    assert.equal(
+      referencesResult.length >= estimatedNumberOfReferences.min && referencesResult.length <= estimatedNumberOfReferences.max,
+      true
+    )
+    let nbReferencesFoundOnOriginalDocument = 0
+    referencesResult.forEach((reference, index) => {
+      assert.equal(reference.uri.fsPath.includes('workspaceStorage'), false)
+      if (reference.uri.fsPath === docUri.fsPath) {
+        assert.equal(
+          nbReferencesOnOriginalDocument.some((range) => range.isEqual(reference.range)),
+          true
+        )
+        nbReferencesFoundOnOriginalDocument++
+      }
+    })
+    assert.equal(nbReferencesFoundOnOriginalDocument, nbReferencesOnOriginalDocument.length)
+  }
+
+  test('References appear properly in Python on oe', async () => {
+    const position = new vscode.Position(1, 5)
+    // Got 406 on manual testing and around 600 on integration tests' environment
+    const estimatedNumberOfReferences = { min: 300, max: 1000 }
+    const nbReferencesOnOriginalDocument = [
+      new vscode.Range(1, 4, 1, 6)
+    ]
+    await testReferences(position, estimatedNumberOfReferences, nbReferencesOnOriginalDocument)
+  }).timeout(300000)
+
+  test('References appear properly in Bash on variable', async () => {
+    const position = new vscode.Position(6, 13)
+    const estimatedNumberOfReferences = { min: 2, max: 2 }
+    const nbReferencesOnOriginalDocument = [
+      new vscode.Range(5, 4, 5, 7),
+      new vscode.Range(6, 12, 6, 15)
+    ]
+    await testReferences(position, estimatedNumberOfReferences, nbReferencesOnOriginalDocument)
+  }).timeout(300000)
+})

--- a/integration-tests/src/utils/vscode-tools.ts
+++ b/integration-tests/src/utils/vscode-tools.ts
@@ -3,15 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { Location, type LocationLink, type Position, type Range, type Uri } from 'vscode'
-
-export const checkIsPositionEqual = (position1: Position, position2: Position): boolean => {
-  return position1.line === position2.line && position1.character === position2.character
-}
-
-export const checkIsRangeEqual = (range1: Range, range2: Range): boolean => {
-  return checkIsPositionEqual(range1.start, range2.start) && checkIsPositionEqual(range1.end, range2.end)
-}
+import { Location, type LocationLink, type Uri } from 'vscode'
 
 export const getDefinitionUri = (definition: Location | LocationLink): Uri => {
   if (definition instanceof Location) {


### PR DESCRIPTION
This adds references into embedded languages regions

![Screenshot from 2024-03-07 18-44-50](https://github.com/yoctoproject/vscode-bitbake/assets/92585455/c53af940-9856-45f8-af16-ed78c88a4165)


Contrary to definitions, it does not handle `d` and `e`. I am not sure how it could be done.