### PR TITLE
Activate the extension if the workspace contains a bblayers.conf

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -44,9 +44,7 @@
         "extensions": [
           ".bb",
           ".bbappend",
-          ".inc",
-          ".bbclass",
-          ".conf"
+          ".bbclass"
         ],
         "configuration": "./language-configuration.json",
         "icon": {

--- a/client/package.json
+++ b/client/package.json
@@ -29,7 +29,8 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "workspaceContains:**/bblayers.conf"
+    "workspaceContains:**/bblayers.conf",
+    "workspaceContains:**/*.bb"
   ],
   "main": "./out/extension",
   "browser": "./out/extension-web",

--- a/client/package.json
+++ b/client/package.json
@@ -28,7 +28,9 @@
   "categories": [
     "Programming Languages"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "workspaceContains:**/bblayers.conf"
+  ],
   "main": "./out/extension",
   "browser": "./out/extension-web",
   "contributes": {


### PR DESCRIPTION
Ticket: 14106

Before, the extension will be activated whenever a file with languageId bitbake is opened and focused. Now it activates when vscode finds a bblayers.conf in the workspace.