### PR TITLE
Fix: Remove definition inherit integration test

### DIFF
--- a/integration-tests/src/tests/definition.test.ts
+++ b/integration-tests/src/tests/definition.test.ts
@@ -51,12 +51,6 @@ suite('Bitbake Definition Test Suite', () => {
     })
   }
 
-  test('Definition appears properly on inherit', async () => {
-    const position = new vscode.Position(0, 10)
-    const expectedPathEnding = 'meta/classes-recipe/image.bbclass'
-    await testDefinition(position, expectedPathEnding)
-  }).timeout(300000)
-
   test('Definition appears properly in Python on d', async () => {
     const position = new vscode.Position(3, 3)
     const expectedPathEnding = 'lib/bb/data_smart.py'


### PR DESCRIPTION
We already have a unit test for this in
server/src/__tests__/definition.test.ts

This test randomly got stuck in CI.