### PR TITLE
Fix: Restore .inc and .conf file extensions

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -45,7 +45,9 @@
         "extensions": [
           ".bb",
           ".bbappend",
-          ".bbclass"
+          ".bbclass",
+          ".inc",
+          ".conf"
         ],
         "configuration": "./language-configuration.json",
         "icon": {


### PR DESCRIPTION
We need the highlighting and language features there. Unfortuanetly this implicitely adds them as activation events but VSCode has no way of preventing that.