### PR TITLE
Fix: incorrect highlighting on keyword 'python'

### DIFF
--- a/client/syntaxes/bitbake.tmLanguage.json
+++ b/client/syntaxes/bitbake.tmLanguage.json
@@ -61,7 +61,7 @@
                     "include": "#python-keywords"
                 },
                 {
-                    "match": "\\b(python|def)\\b(?![[:punct:]])",
+                    "match": "\\b(python|def)\\b(\\(?)",
                     "captures": {
                         "1": {
                             "name": "storage.type.function.python.bb"

--- a/client/test/grammars/snaps/keywords.bb
+++ b/client/test/grammars/snaps/keywords.bb
@@ -24,3 +24,5 @@ python (){}
 
 inherit_defer foo2
 
+python(){}
+

--- a/client/test/grammars/test-cases/keywords.bb
+++ b/client/test/grammars/test-cases/keywords.bb
@@ -39,3 +39,6 @@
 
 >inherit_defer foo2
 #^^^^^^^^^^^^^ source.bb keyword.control.bb
+
+>python(){}
+#^^^^^^ source.bb storage.type.function.python.bb


### PR DESCRIPTION
Before:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/7710edd0-6b62-4a48-ae53-c38510d4a6f5)
After:
![image](https://github.com/yoctoproject/vscode-bitbake/assets/47988425/1114ffdf-4013-4a6e-b34c-8a25aefc6e69)
