### PR TITLE
Fix: Random CI fail on bitbake-parse

### DIFF
--- a/integration-tests/src/tests/bitbake-parse.test.ts
+++ b/integration-tests/src/tests/bitbake-parse.test.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode'
 
 import path from 'path'
 import { BITBAKE_TIMEOUT, addLayer, excludeRecipes, resetExcludedRecipes, awaitBitbakeParsingResult, resetLayer } from '../utils/bitbake'
-import { assertWorkspaceWillBeOpen, delay } from '../utils/async'
+import { assertWillComeTrue, assertWorkspaceWillBeOpen, delay } from '../utils/async'
 
 suite('Bitbake Parsing Test Suite', () => {
   let workspaceURI: vscode.Uri
@@ -68,9 +68,12 @@ suite('Bitbake Parsing Test Suite', () => {
     // Wait for the diagnostics to be updated. Another method would be to use
     // the onDidChangeDiagnostics event, but it is not useful with the other test
     // that checks for no diagnostics.
-    await delay(500)
+    let diagnostics: ReturnType<typeof vscode.languages.getDiagnostics> = []
+    await assertWillComeTrue(async () => {
+      diagnostics = vscode.languages.getDiagnostics()
+      return diagnostics.length > 0
+    })
 
-    const diagnostics = vscode.languages.getDiagnostics()
     // Only 1 file has problem(s)
     assert.strictEqual(diagnostics.length, 1)
     // Only 1 problem on the file


### PR DESCRIPTION
This is an attempt to fix the following random failure:
https://github.com/yoctoproject/vscode-bitbake/actions/runs/7562449592/job/20592942697?pr=70#step:8:7034
https://github.com/yoctoproject/vscode-bitbake/actions/runs/7533652255/job/20506884056#step:8:6969
https://github.com/yoctoproject/vscode-bitbake/actions/runs/8237472786/job/22526287225#step:8:23906

The reasoning is simply that waiting 500 miliseconds might be too short once in a while