### PR TITLE
Feat: Show toaster web interface in the webview

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -426,6 +426,18 @@
         "description": "This command runs bitbake in parse-only mode."
       },
       {
+        "command": "bitbake.start-toaster-webview",
+        "title": "BitBake: Start Toaster Webview",
+        "description": "Start the Toaster web interface in a new window or reveal the existing one.",
+        "icon": "$(play-circle)"
+      },
+      {
+        "command": "bitbake.stop-toaster-webview",
+        "title": "BitBake: Stop Toaster Webview",
+        "description": "Close the Toaster web interface and stop the toaster.",
+        "icon": "$(stop-circle)"
+      },
+      {
         "command": "bitbake.devtool-modify",
         "title": "BitBake: Devtool: Modify recipe",
         "description": "Open a new devtool workspace to modify a recipe's sources.",
@@ -619,7 +631,12 @@
       "editor/context": [
         {
           "submenu": "bitbake/main",
-          "group": "bitbake",
+          "group": "bitbake@0",
+          "when": "editorLangId == bitbake"
+        },
+        {
+          "command": "bitbake.start-toaster-webview",
+          "group": "bitbake@1",
           "when": "editorLangId == bitbake"
         }
       ],

--- a/client/package.json
+++ b/client/package.json
@@ -432,6 +432,12 @@
         "icon": "$(play-circle)"
       },
       {
+        "command": "bitbake.start-toaster-in-browser",
+        "title": "BitBake: Start toaster in browser",
+        "description": "Start the toaster and reveal it in the browser.",
+        "icon": "$(preview)"
+      },
+      {
         "command": "bitbake.stop-toaster-webview",
         "title": "BitBake: Stop Toaster Webview",
         "description": "Close the Toaster web interface and stop the toaster.",
@@ -637,6 +643,11 @@
         {
           "command": "bitbake.start-toaster-webview",
           "group": "bitbake@1",
+          "when": "editorLangId == bitbake"
+        },
+        {
+          "command": "bitbake.start-toaster-in-browser",
+          "group": "bitbake@2",
           "when": "editorLangId == bitbake"
         }
       ],

--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -29,6 +29,7 @@ import { mergeArraysDistinctly } from '../lib/src/utils/arrays'
 import { finishProcessExecution } from '../utils/ProcessUtils'
 import { type LanguageClient } from 'vscode-languageclient/node'
 import { getVariableValue } from '../language/languageClient'
+import { ToasterPanel } from './ToasterWebview'
 
 let parsingPending = false
 let bitbakeSanity = false
@@ -47,6 +48,8 @@ export function registerBitbakeCommands (context: vscode.ExtensionContext, bitba
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.open-recipe-workdir', async (uri) => { await openRecipeWorkdirCommand(bitbakeWorkspace, bitBakeProjectScanner, client, uri) }))
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.recipe-devshell', async (uri) => { await openBitbakeDevshell(bitbakeTerminalProfileProvider, bitbakeWorkspace, bitBakeProjectScanner, uri) }))
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.collapse-list', async () => { await collapseActiveList() }))
+  context.subscriptions.push(vscode.commands.registerCommand('bitbake.start-toaster-webview', async () => { ToasterPanel.createOrShow() }))
+  context.subscriptions.push(vscode.commands.registerCommand('bitbake.stop-toaster-webview', async () => { ToasterPanel.stop() }))
 
   // Handles enqueued parsing requests (onSave)
   context.subscriptions.push(

--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -50,6 +50,7 @@ export function registerBitbakeCommands (context: vscode.ExtensionContext, bitba
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.collapse-list', async () => { await collapseActiveList() }))
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.start-toaster-webview', async () => { ToasterPanel.createOrShow() }))
   context.subscriptions.push(vscode.commands.registerCommand('bitbake.stop-toaster-webview', async () => { ToasterPanel.stop() }))
+  context.subscriptions.push(vscode.commands.registerCommand('bitbake.start-toaster-in-browser', async () => { await ToasterPanel.startToasterInBrowser() }))
 
   // Handles enqueued parsing requests (onSave)
   context.subscriptions.push(

--- a/client/src/ui/BitbakeTerminal.ts
+++ b/client/src/ui/BitbakeTerminal.ts
@@ -26,7 +26,7 @@ export async function runBitbakeTerminalCustomCommand (bitbakeDriver: BitbakeDri
   return await runBitbakeTerminalScript(command, bitbakeDriver, terminalName, script, isBackground)
 }
 
-const bitbakeTerminals: BitbakeTerminal[] = []
+export const bitbakeTerminals: BitbakeTerminal[] = []
 async function runBitbakeTerminalScript (command: string, bitbakeDriver: BitbakeDriver, terminalName: string, bitbakeScript: string, isBackground: boolean): Promise<IPty> {
   let terminal: BitbakeTerminal | undefined
   for (const t of bitbakeTerminals) {
@@ -175,7 +175,7 @@ export class BitbakePseudoTerminal implements vscode.Pseudoterminal {
   }
 }
 
-class BitbakeTerminal {
+export class BitbakeTerminal {
   readonly terminal: vscode.Terminal
   readonly pty: BitbakePseudoTerminal
 

--- a/client/src/ui/ToasterWebview.ts
+++ b/client/src/ui/ToasterWebview.ts
@@ -1,0 +1,192 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode'
+import type { IPty } from 'node-pty'
+import { BitbakeTerminal, bitbakeTerminals } from './BitbakeTerminal'
+import { BitbakeDriver } from '../driver/BitbakeDriver'
+import { pty } from '../utils/ProcessUtils'
+import { logger } from '../lib/src/utils/OutputLogger'
+import { loadBitbakeSettings } from '../lib/src/BitbakeSettings'
+
+const DEFAULT_TOASTER_PORT = 8000
+
+export class ToasterPanel {
+  /**
+  * Track the currently panel. Only allow a single panel to exist at a time.
+  */
+  public static currentPanel: ToasterPanel | undefined
+  public static toasterProcess: IPty | undefined
+  public static readonly viewType = 'bitbake.toasterView'
+
+  private readonly _panel: vscode.WebviewPanel
+  private readonly _disposables: vscode.Disposable[] = []
+
+  public static createOrShow (): void {
+    const column = vscode.window.activeTextEditor !== undefined
+      ? vscode.window.activeTextEditor.viewColumn
+      : undefined
+
+    // If we already have a panel, show it.
+    if (ToasterPanel.currentPanel !== undefined) {
+      ToasterPanel.currentPanel._panel.reveal(column)
+      return
+    }
+
+    // Otherwise, create a new panel.
+    const panel = vscode.window.createWebviewPanel(
+      ToasterPanel.viewType,
+      'Yocto Toaster',
+      column ?? vscode.ViewColumn.One,
+      getWebviewOptions()
+    )
+
+    ToasterPanel.currentPanel = new ToasterPanel(panel)
+  }
+
+  // Close the webview and stop the toaster
+  public static stop (): void {
+    ToasterPanel.currentPanel?.dispose()
+  }
+
+  // A custom replicate of runBitbakeCommand() from BitbakeTerminal.ts
+  private static async runToasterCommand (command: string, isBackground: boolean = false, terminalName: string = 'Toaster'): Promise<IPty> {
+    let terminal: BitbakeTerminal | undefined
+    for (const t of bitbakeTerminals) {
+      if (!t.pty.isBusy()) {
+        terminal = t
+        terminal.pty.changeNameEmitter.fire(terminalName)
+        break
+      }
+    }
+
+    if (terminal === undefined) {
+      const bitbakeDriver = new BitbakeDriver()
+      terminal = new BitbakeTerminal(terminalName, bitbakeDriver)
+
+      await new Promise(resolve => terminal?.pty.onDidOpen.event(resolve))
+    }
+
+    if (!isBackground) {
+      terminal.terminal.show()
+    }
+    const process = ToasterPanel.spawnToasterProcess(command)
+    await terminal.pty.runProcess(process, command, terminalName)
+    return await process
+  }
+
+  // A custom replicate of spawnBitbakeProcess() from BitbakeDriver.ts
+  private static async spawnToasterProcess (command: string): Promise<IPty> {
+    // TODO: check if the env file exists
+    const script = 'source oe-init-build-env' + ' && ' + command
+    const shell = process.env.SHELL ?? '/bin/sh'
+
+    if (vscode.workspace.workspaceFolders === undefined) {
+      logger.error('[spawnToasterProcess] No workspace folder found')
+      return pty.spawn(shell, ['-c', 'echo "No workspace folder found"'], {})
+    }
+
+    const cwd = loadBitbakeSettings(vscode.workspace.getConfiguration('bitbake'), vscode.workspace.workspaceFolders[0].uri.fsPath).workingDirectory
+
+    // wait for the previous process to finish
+    await new Promise<void>((resolve) => {
+      const interval = setInterval(() => {
+        if (ToasterPanel.toasterProcess === undefined) {
+          clearInterval(interval)
+          resolve()
+        }
+      }, 100)
+    })
+
+    logger.debug(`Executing Bitbake command with ${shell} in ${cwd}: ${script}`)
+    const child = pty.spawn(
+      shell,
+      ['-c', script],
+      {
+        cwd
+      }
+    )
+
+    ToasterPanel.toasterProcess = child
+
+    child.onData(() => {
+      logger.debug('Toaster process onData event')
+    })
+    child.onExit(() => {
+      ToasterPanel.toasterProcess = undefined
+      logger.debug('Toaster process exited')
+    })
+    return child
+  }
+
+  private constructor (panel: vscode.WebviewPanel) {
+    this._panel = panel
+
+    void ToasterPanel.runToasterCommand('source toaster start', true).then(() => {
+      // Set the webview's initial html content
+      this._setInitialView()
+    })
+
+    // Listen for when the panel is disposed
+    // This happens when the user closes the panel or when the panel is closed programmatically
+    this._panel.onDidDispose(() => { this.dispose() }, null, this._disposables)
+
+    // Handle messages from the webview
+    this._panel.webview.onDidReceiveMessage(
+      message => {
+        // handle message
+      },
+      null,
+      this._disposables
+    )
+  }
+
+  public dispose (): void {
+    ToasterPanel.currentPanel = undefined
+
+    void ToasterPanel.runToasterCommand('source toaster stop', true)
+
+    // Clean up our resources
+    this._panel.dispose()
+
+    while (this._disposables.length > 0) {
+      const x = this._disposables.pop()
+      if (x !== undefined) {
+        x.dispose()
+      }
+    }
+  }
+
+  private _setInitialView (): void {
+    this._panel.title = 'Yocto Toaster'
+    this._panel.webview.html = this._getHtmlForWebview()
+  }
+
+  private _getHtmlForWebview (): string {
+    return `<!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Toaster</title>
+        </head>
+        <body>
+            <iframe src="http://localhost:${DEFAULT_TOASTER_PORT}" width="100%" height="800"></iframe>
+        </body>
+        </html>`
+  }
+}
+
+function getWebviewOptions (): vscode.WebviewOptions {
+  return {
+    portMapping: [
+      {
+        webviewPort: DEFAULT_TOASTER_PORT,
+        extensionHostPort: DEFAULT_TOASTER_PORT
+      }
+    ]
+
+  }
+}

--- a/client/src/ui/ToasterWebview.ts
+++ b/client/src/ui/ToasterWebview.ts
@@ -46,6 +46,16 @@ export class ToasterPanel {
     ToasterPanel.currentPanel = new ToasterPanel(panel)
   }
 
+  public static async startToasterInBrowser (): Promise<void> {
+    await ToasterPanel.runToasterCommand('source toaster start', true)
+    const url = `http://localhost:${DEFAULT_TOASTER_PORT}`
+    await vscode.env.openExternal(vscode.Uri.parse(url)).then(success => {
+      if (!success) {
+        void vscode.window.showErrorMessage(`Failed to open URL ${url}`)
+      }
+    })
+  }
+
   // Close the webview and stop the toaster
   public static stop (): void {
     ToasterPanel.currentPanel?.dispose()


### PR DESCRIPTION
Ticket: 13369


1. Add a command to start the toaster and open the webview to show the web interface.
2. Add a command to start the toaster in the browser.
3. Add a command to stop the toaster and close the webview.
4. Closing the webview manually will also stop the toaster.
5. Only one toaster webview is allowed.