### PR TITLE
Feat: Add 'bitbake.disableEmbeddedLanguagesFiles' setting

### DIFF
--- a/client/TROUBLESHOOTING.md
+++ b/client/TROUBLESHOOTING.md
@@ -7,14 +7,14 @@ Errors and warnings appear twice in the "PROBLEMS" tab. They first appear for th
 
 Unfortunately, the VS Code API does not offer a way to programmatically filter the "PROBLEMS" tab. However, manual filtering is still possible. Typing `!workspaceStorage` or `!workspaceStorage/**/yocto-project.yocto-bitbake/embedded-documents` (if more precision is needed) should filter out all these unwanted problems.
 
-If this problem gets to annoying, consider activating the `bitbake.disableTemporaryFiles` setting.
+If this problem gets too annoying, consider activating the `bitbake.disableEmbeddedLanguagesFiles` setting.
 
 ### Tabs from Unknown Files Open and Close Quickly
 While typing, tabs with hash names (ex. 9dab97ca1ef2b71ea07d42d4609e9e54.sh) might occasionally open in the tabs bar and then close shortly thereafter.  This occurs as a result of our method for handling diagnostics (errors and warnings). See [Trade-offs on Diagnostics](TROUBLESHOOTING.md#trade-offs-on-diagnostics).
 
 We haven't found a way to prevent these tabs from opening, but we try to close them as quickly as possible.
 
-If this problem gets to annoying, consider activating the `bitbake.disableTemporaryFiles` setting.
+If this problem gets too annoying, consider activating the `bitbake.disableEmbeddedLanguagesFiles` setting.
 
 ### BrokenPipeError on BitBake commands
 

--- a/client/TROUBLESHOOTING.md
+++ b/client/TROUBLESHOOTING.md
@@ -7,10 +7,14 @@ Errors and warnings appear twice in the "PROBLEMS" tab. They first appear for th
 
 Unfortunately, the VS Code API does not offer a way to programmatically filter the "PROBLEMS" tab. However, manual filtering is still possible. Typing `!workspaceStorage` or `!workspaceStorage/**/yocto-project.yocto-bitbake/embedded-documents` (if more precision is needed) should filter out all these unwanted problems.
 
+If this problem gets to annoying, consider activating the `bitbake.disableTemporaryFiles` setting.
+
 ### Tabs from Unknown Files Open and Close Quickly
 While typing, tabs with hash names (ex. 9dab97ca1ef2b71ea07d42d4609e9e54.sh) might occasionally open in the tabs bar and then close shortly thereafter.  This occurs as a result of our method for handling diagnostics (errors and warnings). See [Trade-offs on Diagnostics](TROUBLESHOOTING.md#trade-offs-on-diagnostics).
 
 We haven't found a way to prevent these tabs from opening, but we try to close them as quickly as possible.
+
+If this problem gets to annoying, consider activating the `bitbake.disableTemporaryFiles` setting.
 
 ### BrokenPipeError on BitBake commands
 

--- a/client/package.json
+++ b/client/package.json
@@ -161,6 +161,11 @@
           "markdownDescription": "SDK image to use for cross-compilation and debugging.\n\nExample: `core-image-minimal`",
           "examples": "core-image-minimal"
         },
+        "bitbake.disableTemporaryFiles": {
+          "type": "boolean",
+          "markdownDescription": "Disables temporary files generated for BitBake's embedded languages. This action will turn off most features within Shell and Python regions of BitBake code. This is intended for users who don't want temporary files to be saved on their drive, or do not want to see the diagnostics of these temporary files polluting their 'PROBLEMS' tab. Please note a reload of VS Code might be required after activating or deactivating this setting for the full change to take effect.",
+          "default": false
+        },
         "bitbake.buildConfigurations": {
           "type": "array",
           "description": "Array of alternative configurations for starting bitbake. It can be useful to handle multiple build folders for multiple targets (MACHINE configurations). If an option is not defined, the value from the main configuration will be used.",

--- a/client/package.json
+++ b/client/package.json
@@ -161,7 +161,7 @@
           "markdownDescription": "SDK image to use for cross-compilation and debugging.\n\nExample: `core-image-minimal`",
           "examples": "core-image-minimal"
         },
-        "bitbake.disableTemporaryFiles": {
+        "bitbake.disableEmbeddedLanguagesFiles": {
           "type": "boolean",
           "markdownDescription": "Disables temporary files generated for BitBake's embedded languages. This action will turn off most features within Shell and Python regions of BitBake code. This is intended for users who don't want temporary files to be saved on their drive, or do not want to see the diagnostics of these temporary files polluting their 'PROBLEMS' tab. Please note a reload of VS Code might be required after activating or deactivating this setting for the full change to take effect.",
           "default": false

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -45,7 +45,7 @@ function loadLoggerSettings (): void {
 }
 
 function loadEmbeddedLanguageDocsManagerSettings (): void {
-  const isDisabled = vscode.workspace.getConfiguration('bitbake').get('disableTemporaryFiles')
+  const isDisabled = vscode.workspace.getConfiguration('bitbake').get('disableEmbeddedLanguagesFiles')
   logger.info(`Disable embedded language features ${isDisabled as any}`)
   if (typeof isDisabled === 'boolean') {
     embeddedLanguageDocsManager.isDisabled = isDisabled
@@ -188,7 +188,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
     if (event.affectsConfiguration('bitbake.loggingLevel')) {
       loadLoggerSettings()
     }
-    if (event.affectsConfiguration('bitbake.disableTemporaryFiles')) {
+    if (event.affectsConfiguration('bitbake.disableEmbeddedLanguagesFiles')) {
       loadEmbeddedLanguageDocsManagerSettings()
     }
   }))

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -26,6 +26,7 @@ import { extractRecipeName } from './lib/src/utils/files'
 import { BitbakeConfigPicker } from './ui/BitbakeConfigPicker'
 import { scanContainsData } from './lib/src/types/BitbakeScanResult'
 import { reviewDiagnostics } from './language/diagnosticsSupport'
+import { embeddedLanguageDocsManager } from './language/EmbeddedLanguageDocsManager'
 
 let client: LanguageClient
 const bitbakeDriver: BitbakeDriver = new BitbakeDriver()
@@ -41,6 +42,14 @@ let terminalProvider: BitbakeTerminalProfileProvider | undefined
 function loadLoggerSettings (): void {
   logger.level = vscode.workspace.getConfiguration('bitbake').get('loggingLevel') ?? 'info'
   logger.info('Bitbake logging level: ' + logger.level)
+}
+
+function loadEmbeddedLanguageDocsManagerSettings (): void {
+  const isDisabled = vscode.workspace.getConfiguration('bitbake').get('disableTemporaryFiles')
+  logger.info(`Disable embedded language features ${isDisabled as any}`)
+  if (typeof isDisabled === 'boolean') {
+    embeddedLanguageDocsManager.isDisabled = isDisabled
+  }
 }
 
 function updatePythonPath (): void {
@@ -114,6 +123,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
   logger.outputChannel = vscode.window.createOutputChannel('BitBake')
 
   loadLoggerSettings()
+  loadEmbeddedLanguageDocsManagerSettings()
   bitbakeExtensionContext = context
   logger.debug('Loaded bitbake workspace settings: ' + JSON.stringify(vscode.workspace.getConfiguration('bitbake')))
   bitbakeDriver.loadSettings(vscode.workspace.getConfiguration('bitbake'), vscode.workspace.workspaceFolders?.[0].uri.fsPath)
@@ -177,6 +187,9 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
     }
     if (event.affectsConfiguration('bitbake.loggingLevel')) {
       loadLoggerSettings()
+    }
+    if (event.affectsConfiguration('bitbake.disableTemporaryFiles')) {
+      loadEmbeddedLanguageDocsManagerSettings()
     }
   }))
   context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders((event) => {


### PR DESCRIPTION
This adds a setting to disable the generation of "embedded language files". 

Unfortunately, I realized it won't be possible to disable only the diagnostics. If it was, we would not have these unwanted diagnostics polluting the "PROBLEMS" tab.