### PR TITLE
Fix: Variable expansion references inside Shell region

### DIFF
--- a/integration-tests/project-folder/sources/meta-fixtures/references.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures/references.bb
@@ -3,6 +3,8 @@ python() {
     print(foo)
 }
 
+foo = ''
+
 do_foo() {
     foo=''
     echo "${foo}"

--- a/integration-tests/src/tests/references.test.ts
+++ b/integration-tests/src/tests/references.test.ts
@@ -54,10 +54,11 @@ suite('Bitbake References Test Suite', () => {
   }).timeout(300000)
 
   test('References appear properly in Bash on variable', async () => {
-    const position = new vscode.Position(7, 13)
+    const position = new vscode.Position(9, 13)
     const referenceRanges = [
-      new vscode.Range(6, 4, 6, 7),
-      new vscode.Range(7, 12, 7, 15)
+      new vscode.Range(5, 0, 5, 3),
+      new vscode.Range(8, 4, 8, 7),
+      new vscode.Range(9, 12, 9, 15)
     ]
     await testReferences(position, referenceRanges)
   }).timeout(300000)

--- a/integration-tests/src/tests/references.test.ts
+++ b/integration-tests/src/tests/references.test.ts
@@ -44,7 +44,7 @@ suite('Bitbake References Test Suite', () => {
     })
   }
 
-  test('References appear properly in Python on oe', async () => {
+  test('References appear properly in Python on variable', async () => {
     const position = new vscode.Position(1, 5)
     const referenceRanges = [
       new vscode.Range(1, 4, 1, 7),


### PR DESCRIPTION
We have the integration tests faililng since the merge of the new tree-sitter-bitbake version:
https://github.com/yoctoproject/vscode-bitbake/actions/runs/8284971253/job/22671672578?pr=173#step:8:22130
https://github.com/yoctoproject/vscode-bitbake/actions/runs/8279689831/job/22654612415#step:8:22599

The issue is because the variables expansions inside bash regions are now included into the references by the onReference handler (see [this line](https://github.com/yoctoproject/vscode-bitbake/blob/staging/server/src/connectionHandlers/onReference.ts#L33C21-L33C48)).

Instead of trying to fix the issue directly on that line, I decided to merge the results together. It has for benefit that the references outside of the bash region are now also included in the references list. I added a test case for it.