### PR TITLE
Cache last scan results

### DIFF
--- a/client/src/driver/BitBakeProjectScanner.ts
+++ b/client/src/driver/BitBakeProjectScanner.ts
@@ -41,7 +41,7 @@ export class BitBakeProjectScanner {
   private readonly _confFileExtension: string = 'conf'
   onChange: EventEmitter = new EventEmitter()
 
-  private readonly _bitbakeScanResult: BitbakeScanResult = { _classes: [], _includes: [], _layers: [], _overrides: [], _recipes: [], _workspaces: [], _confFiles: [] }
+  private _bitbakeScanResult: BitbakeScanResult = { _classes: [], _includes: [], _layers: [], _overrides: [], _recipes: [], _workspaces: [], _confFiles: [] }
   private readonly _bitbakeDriver: BitbakeDriver
   private _languageClient: LanguageClient | undefined
 
@@ -64,6 +64,10 @@ export class BitBakeProjectScanner {
 
   get scanResult (): BitbakeScanResult {
     return this._bitbakeScanResult
+  }
+
+  set scanResult (scanResult: BitbakeScanResult) {
+    this._bitbakeScanResult = scanResult
   }
 
   get bitbakeDriver (): BitbakeDriver {

--- a/client/src/driver/BitBakeProjectScanner.ts
+++ b/client/src/driver/BitBakeProjectScanner.ts
@@ -108,7 +108,7 @@ export class BitBakeProjectScanner {
         void this._languageClient?.sendNotification('bitbake/scanReady', this._bitbakeScanResult)
         this.onChange.emit('scanReady', this._bitbakeScanResult)
       } catch (error) {
-        logger.error(`scanning of project is abborted: ${error as any}`)
+        logger.error(`scanning of project is aborted: ${error as any}`)
         this.onChange.emit('scanReady', this._bitbakeScanResult)
       }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -33,7 +33,6 @@ const bitbakeDriver: BitbakeDriver = new BitbakeDriver()
 let bitbakeTaskProvider: BitbakeTaskProvider
 let taskProvider: vscode.Disposable
 const bitbakeWorkspace: BitbakeWorkspace = new BitbakeWorkspace()
-export let bitbakeExtensionContext: vscode.ExtensionContext
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 let bitbakeRecipesView: BitbakeRecipesView | undefined
 let devtoolWorkspacesView: DevtoolWorkspacesView | undefined
@@ -124,7 +123,6 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
 
   loadLoggerSettings()
   loadEmbeddedLanguageDocsManagerSettings()
-  bitbakeExtensionContext = context
   logger.debug('Loaded bitbake workspace settings: ' + JSON.stringify(vscode.workspace.getConfiguration('bitbake')))
   bitbakeDriver.loadSettings(vscode.workspace.getConfiguration('bitbake'), vscode.workspace.workspaceFolders?.[0].uri.fsPath)
   const bitBakeProjectScanner: BitBakeProjectScanner = new BitBakeProjectScanner(bitbakeDriver)

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -238,6 +238,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
     void vscode.commands.executeCommand('bitbake.rescan-project')
   } else {
     logger.debug('Loading previous scan result')
+    bitBakeProjectScanner.scanResult = lastBitbakeScanResult
     bitBakeProjectScanner.onChange.emit('scanReady', lastBitbakeScanResult)
     void client.sendNotification('bitbake/scanReady', lastBitbakeScanResult)
   }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -227,14 +227,14 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
   // Update the scan result stored in the global state
   bitBakeProjectScanner.onChange.on('scanReady', (bitbakeScanResult: BitbakeScanResult) => {
     void context.workspaceState.update('bitbake.ScanResult', bitbakeScanResult).then(() => {
-      logger.debug('BitBake scan result saved to global state')
+      logger.debug('BitBake scan result saved to workspace state')
     })
   })
 
   const lastBitbakeScanResult: BitbakeScanResult | undefined = context.workspaceState.get('bitbake.ScanResult')
 
   if (lastBitbakeScanResult === undefined) {
-    logger.debug('No previous scan result found, rescanning the project')
+    logger.debug('No previous scan result found, scanning the project')
     void vscode.commands.executeCommand('bitbake.rescan-project')
   } else {
     logger.debug('Loading previous scan result')


### PR DESCRIPTION
Save the last scan results in the workspace state to reuse it and skip the scan in the next startup. 

Ticket: 14207