### PR TITLE
Feat: Start toaster through context menu

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -240,7 +240,7 @@ You may toggle this behaviour through the setting `bitbake.parseOnSave`.
 The extension will receive additional information about the recipe from the `bitbake -e` command and provide more advanced features such as `Go to definition` for symbols with variable expansion (e.g., `require recipe_${PN}.bb`) and showing the final values of variables (values in the command output) on hover.
 
 ### Toaster
-Toaster users may start the toaster through the **main context menu** -> **Bitbake** -> **Start toaster in browser**. It will open the web UI in the default browser. The toaster can also be stopped by the command `Bitbake: Stop Toaster`
+Toaster users may start toaster through the **main context menu** -> **Bitbake** -> **Start toaster in browser**. It will open the web UI in the default browser. Toaster can also be stopped by the command `Bitbake: Stop Toaster`
 
 ## Troubleshooting
 See the [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) file.

--- a/client/README.md
+++ b/client/README.md
@@ -239,6 +239,8 @@ You may toggle this behaviour through the setting `bitbake.parseOnSave`.
 
 The extension will receive additional information about the recipe from the `bitbake -e` command and provide more advanced features such as `Go to definition` for symbols with variable expansion (e.g., `require recipe_${PN}.bb`) and showing the final values of variables (values in the command output) on hover.
 
+### Toaster
+Toaster users may start the toaster through the **main context menu** -> **Bitbake** -> **Start toaster in browser**. It will open the web UI in the default browser. The toaster can also be stopped by the command `Bitbake: Stop Toaster`
 
 ## Troubleshooting
 See the [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) file.

--- a/client/README.md
+++ b/client/README.md
@@ -240,7 +240,9 @@ You may toggle this behaviour through the setting `bitbake.parseOnSave`.
 The extension will receive additional information about the recipe from the `bitbake -e` command and provide more advanced features such as `Go to definition` for symbols with variable expansion (e.g., `require recipe_${PN}.bb`) and showing the final values of variables (values in the command output) on hover.
 
 ### Toaster
-Toaster users may start toaster through the **main context menu** -> **Bitbake** -> **Start toaster in browser**. It will open the web UI in the default browser. Toaster can also be stopped by the command `Bitbake: Stop Toaster`
+Toaster users may start toaster through the **main context menu** -> **Bitbake** -> **Start toaster in browser**. It will open the web UI in the default browser. Toaster can also be stopped by the command `Bitbake: Stop Toaster`.
+
+> Note: Toaster requires additional packages and ports. It may not be compatible with all commandWrapper settings. Read the Toaster manual to configure them to have all the required dependencies.
 
 ## Troubleshooting
 See the [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) file.

--- a/client/package.json
+++ b/client/package.json
@@ -584,12 +584,12 @@
           "group": "1@bitbake_dev@3"
         },
         {
-          "command": "bitbake.devtool-modify",
-          "group": "2@bitbake_devtool@0"
+          "command": "bitbake.start-toaster-in-browser",
+          "group": "1@bitbake_dev@4"
         },
         {
-          "command": "bitbake.start-toaster-in-browser",
-          "group": "3@bitbake_devtool@0"
+          "command": "bitbake.devtool-modify",
+          "group": "2@bitbake_devtool@0"
         }
       ],
       "devtool/main": [

--- a/client/package.json
+++ b/client/package.json
@@ -433,13 +433,13 @@
       {
         "command": "bitbake.start-toaster-in-browser",
         "title": "BitBake: Start toaster in browser",
-        "description": "Start the toaster and reveal it in the browser.",
+        "description": "Start Toaster and reveal it in the browser.",
         "icon": "$(preview)"
       },
       {
         "command": "bitbake.stop-toaster",
         "title": "BitBake: Stop Toaster",
-        "description": "This stops the toaster by running `source toaster stop`.",
+        "description": "This stops Toaster by running `source toaster stop`.",
         "icon": "$(stop-circle)"
       },
       {

--- a/client/package.json
+++ b/client/package.json
@@ -431,6 +431,18 @@
         "description": "This command runs bitbake in parse-only mode."
       },
       {
+        "command": "bitbake.start-toaster-in-browser",
+        "title": "BitBake: Start toaster in browser",
+        "description": "Start the toaster and reveal it in the browser.",
+        "icon": "$(preview)"
+      },
+      {
+        "command": "bitbake.stop-toaster",
+        "title": "BitBake: Stop Toaster",
+        "description": "This stops the toaster by running `source toaster stop`.",
+        "icon": "$(stop-circle)"
+      },
+      {
         "command": "bitbake.devtool-modify",
         "title": "BitBake: Devtool: Modify recipe",
         "description": "Open a new devtool workspace to modify a recipe's sources.",
@@ -574,6 +586,10 @@
         {
           "command": "bitbake.devtool-modify",
           "group": "2@bitbake_devtool@0"
+        },
+        {
+          "command": "bitbake.start-toaster-in-browser",
+          "group": "3@bitbake_devtool@0"
         }
       ],
       "devtool/main": [
@@ -624,7 +640,7 @@
       "editor/context": [
         {
           "submenu": "bitbake/main",
-          "group": "bitbake",
+          "group": "bitbake@0",
           "when": "editorLangId == bitbake"
         }
       ],

--- a/client/src/driver/BitbakeDriver.ts
+++ b/client/src/driver/BitbakeDriver.ts
@@ -110,6 +110,10 @@ export class BitbakeDriver {
     return script
   }
 
+  composeToasterCommand (command: string): string {
+    return 'source toaster ' + command
+  }
+
   async checkBitbakeSettingsSanity (): Promise<boolean> {
     if (!fs.existsSync(this.bitbakeSettings.pathToBitbakeFolder)) {
       clientNotificationManager.showBitbakeSettingsError('Bitbake folder not found on disk.')

--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -190,7 +190,13 @@ async function runTaskCommand (bitbakeWorkspace: BitbakeWorkspace, bitBakeProjec
   }
 }
 
+export let isToasterStarted = false
+
 async function startToasterInBrowser (bitbakeDriver: BitbakeDriver): Promise<void> {
+  if (isToasterStarted) {
+    void vscode.window.showInformationMessage('Toaster is already started')
+    return
+  }
   const DEFAULT_TOASTER_PORT = 8000
   const command = `nohup bash -c "${bitbakeDriver.composeToasterCommand('start')}"`
   const process = await runBitbakeTerminalCustomCommand(bitbakeDriver, command, 'Toaster')
@@ -199,6 +205,7 @@ async function startToasterInBrowser (bitbakeDriver: BitbakeDriver): Promise<voi
       void vscode.window.showErrorMessage(`Failed to start Toaster with exit code ${e.exitCode}. See terminal output.`)
       return
     }
+    isToasterStarted = true
     const url = `http://localhost:${DEFAULT_TOASTER_PORT}`
     void vscode.env.openExternal(vscode.Uri.parse(url)).then(success => {
       if (!success) {
@@ -209,8 +216,13 @@ async function startToasterInBrowser (bitbakeDriver: BitbakeDriver): Promise<voi
 }
 
 async function stopToaster (bitbakeDriver: BitbakeDriver): Promise<void> {
+  if (!isToasterStarted) {
+    void vscode.window.showInformationMessage('Toaster has not been started')
+    return
+  }
   const command = bitbakeDriver.composeToasterCommand('stop')
   await runBitbakeTerminalCustomCommand(bitbakeDriver, command, 'Toaster')
+  isToasterStarted = false
 }
 
 async function selectTask (client: LanguageClient, recipe: string): Promise<string | undefined> {

--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -192,7 +192,7 @@ async function runTaskCommand (bitbakeWorkspace: BitbakeWorkspace, bitBakeProjec
 
 async function startToasterInBrowser (bitbakeDriver: BitbakeDriver): Promise<void> {
   const DEFAULT_TOASTER_PORT = 8000
-  const command = 'nohup bash -c "source toaster start"'
+  const command = `nohup bash -c "${bitbakeDriver.composeToasterCommand('start')}"`
   const process = await runBitbakeTerminalCustomCommand(bitbakeDriver, command, 'Toaster')
   process.onExit(() => {
     const url = `http://localhost:${DEFAULT_TOASTER_PORT}`
@@ -205,7 +205,7 @@ async function startToasterInBrowser (bitbakeDriver: BitbakeDriver): Promise<voi
 }
 
 async function stopToaster (bitbakeDriver: BitbakeDriver): Promise<void> {
-  const command = 'source toaster stop'
+  const command = bitbakeDriver.composeToasterCommand('stop')
   await runBitbakeTerminalCustomCommand(bitbakeDriver, command, 'Toaster')
 }
 

--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -194,7 +194,11 @@ async function startToasterInBrowser (bitbakeDriver: BitbakeDriver): Promise<voi
   const DEFAULT_TOASTER_PORT = 8000
   const command = `nohup bash -c "${bitbakeDriver.composeToasterCommand('start')}"`
   const process = await runBitbakeTerminalCustomCommand(bitbakeDriver, command, 'Toaster')
-  process.onExit(() => {
+  process.onExit((e) => {
+    if (e.exitCode !== 0) {
+      void vscode.window.showErrorMessage(`Failed to start Toaster with exit code ${e.exitCode}. See terminal output.`)
+      return
+    }
     const url = `http://localhost:${DEFAULT_TOASTER_PORT}`
     void vscode.env.openExternal(vscode.Uri.parse(url)).then(success => {
       if (!success) {

--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -65,7 +65,7 @@ export function registerBitbakeCommands (context: vscode.ExtensionContext, bitba
   context.subscriptions.push(
     {
       dispose: async () => {
-        await stopToasterShutdown(bitBakeProjectScanner.bitbakeDriver)
+        await stopToasterOnShutdown(bitBakeProjectScanner.bitbakeDriver)
       }
     }
   )
@@ -234,7 +234,7 @@ async function stopToaster (bitbakeDriver: BitbakeDriver): Promise<void> {
   isToasterStarted = false
 }
 
-export async function stopToasterShutdown (bitbakeDriver: BitbakeDriver): Promise<void> {
+export async function stopToasterOnShutdown (bitbakeDriver: BitbakeDriver): Promise<void> {
   if (!isToasterStarted) {
     return
   }

--- a/client/src/ui/BitbakeStatusBar.ts
+++ b/client/src/ui/BitbakeStatusBar.ts
@@ -95,6 +95,8 @@ export class BitbakeStatusBar {
       let displayText = 'Building...'
       if (this.commandInProgress.includes('devtool')) displayText = 'Devtool...'
       if (this.commandInProgress.includes('which devtool')) displayText = 'Scanning...'
+      if (this.commandInProgress.includes('toaster start')) displayText = 'Starting...'
+      if (this.commandInProgress.includes('toaster stop')) displayText = 'Stopping...'
       this.statusBarItem.text = '$(loading~spin) BitBake: ' + displayText
       this.statusBarItem.tooltip = 'BitBake: ' + displayText
       this.statusBarItem.command = undefined

--- a/client/src/ui/BitbakeTerminal.ts
+++ b/client/src/ui/BitbakeTerminal.ts
@@ -27,7 +27,7 @@ export async function runBitbakeTerminalCustomCommand (bitbakeDriver: BitbakeDri
 }
 
 const bitbakeTerminals: BitbakeTerminal[] = []
-export async function runBitbakeTerminalScript (command: string, bitbakeDriver: BitbakeDriver, terminalName: string, bitbakeScript: string, isBackground: boolean): Promise<IPty> {
+async function runBitbakeTerminalScript (command: string, bitbakeDriver: BitbakeDriver, terminalName: string, bitbakeScript: string, isBackground: boolean): Promise<IPty> {
   let terminal: BitbakeTerminal | undefined
   for (const t of bitbakeTerminals) {
     if (!t.pty.isBusy()) {

--- a/client/src/ui/BitbakeTerminal.ts
+++ b/client/src/ui/BitbakeTerminal.ts
@@ -27,7 +27,7 @@ export async function runBitbakeTerminalCustomCommand (bitbakeDriver: BitbakeDri
 }
 
 const bitbakeTerminals: BitbakeTerminal[] = []
-async function runBitbakeTerminalScript (command: string, bitbakeDriver: BitbakeDriver, terminalName: string, bitbakeScript: string, isBackground: boolean): Promise<IPty> {
+export async function runBitbakeTerminalScript (command: string, bitbakeDriver: BitbakeDriver, terminalName: string, bitbakeScript: string, isBackground: boolean): Promise<IPty> {
   let terminal: BitbakeTerminal | undefined
   for (const t of bitbakeTerminals) {
     if (!t.pty.isBusy()) {


### PR DESCRIPTION
Ticket: 13369
1. Added a command to start the toaster and redirect the users to the browser with the toaster UI. This command is accessible through the main context menu 
2. Added a command to stop the toaster by spawning a process that will run the command `source toaster stop`