### PR TITLE
Feat: Use settings to associate .conf and .inc files with the BitBake…

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -45,9 +45,7 @@
         "extensions": [
           ".bb",
           ".bbappend",
-          ".bbclass",
-          ".inc",
-          ".conf"
+          ".bbclass"
         ],
         "configuration": "./language-configuration.json",
         "icon": {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -51,6 +51,14 @@ function loadEmbeddedLanguageDocsManagerSettings (): void {
   }
 }
 
+function configureBitBakeFileAssociation (): void {
+  const filesSettings = vscode.workspace.getConfiguration('files')
+  const associations = filesSettings.get<Record<string, string>>('associations') ?? {}
+  associations['*.conf'] = 'bitbake'
+  associations['*.inc'] = 'bitbake'
+  void filesSettings.update('associations', associations, vscode.ConfigurationTarget.Workspace)
+}
+
 function updatePythonPath (): void {
   // Deliberately load the workspace configuration here instead of using
   // bitbakeDriver.bitbakeSettings, because the latter contains resolved
@@ -161,6 +169,8 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
   const provider = new BitbakeDocumentLinkProvider(client)
   const selector = { scheme: 'file', language: 'bitbake' }
   context.subscriptions.push(vscode.languages.registerDocumentLinkProvider(selector, provider))
+
+  configureBitBakeFileAssociation()
 
   // Handle settings change for bitbake driver
   context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async (event) => {


### PR DESCRIPTION
… language

The extension gets activated when a .conf or .inc file is opened, but they may also appear in non bitbake projects which is annoying for the user. A bitbake error gets displayed and the parsing is wrong.

The alternative presented in this commit is to configure that association after the activation. The cost is that we have to (once more) modify settings.json. The tradeoff seems positive for me.