### PR TITLE
Fix: Update server bin in package

### DIFF
--- a/server/.npmignore
+++ b/server/.npmignore
@@ -3,8 +3,7 @@
 !/package.json
 !/out/
 *.map
-/out/__tests__/
-/out/lib/src/__tests__/
+/out/src/__tests__/
+/out/src/lib/src/__tests__/
 
-!/*.wasm
-!/resources
+*.tsbuildinfo

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,7 +18,7 @@
         "web-tree-sitter": "^0.20.8"
       },
       "bin": {
-        "language-server-bitbake": "out/server.js"
+        "language-server-bitbake": "out/src/server.js"
       },
       "devDependencies": {
         "@types/glob": "^8.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "Savoir-faire Linux"
   ],
   "license": "MIT",
-  "bin": "out/server.js",
+  "bin": "out/src/server.js",
   "engines": {
     "node": "*"
   },
@@ -26,7 +26,7 @@
     "web-tree-sitter": "^0.20.8"
   },
   "scripts": {
-    "prepack": "../scripts/fetch-docs.sh && tsc --outDir out",
+    "prepack": "../scripts/fetch-docs.sh && tsc --outDir out && cp -r ./resources ./tree-sitter-bitbake.wasm out/",
     "installServer": "installServerIntoExtension ../client ./package.json ./tsconfig.json && npm run installServerResources",
     "installServerResources": "cp -r ./resources ./tree-sitter-bitbake.wasm ../client/server/"
   },


### PR DESCRIPTION
Fixes language server packaging change in 40cef6296e09bb0d0ff6eb41aef41dde3c56bea0

The compilation path has been updated but not the bin path in the package.json. This broke the VIM integration.