### PR TITLE
Use actions that run on node20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -56,7 +56,7 @@ jobs:
       run: npm run package
 
     - name: Archive VSIX
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: vscode-bitbake
         path: client/yocto-bitbake*.vsix
@@ -68,7 +68,7 @@ jobs:
     needs: build
     if: success() && startsWith( github.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
       - run: npx vsce publish --packagePath $(find . -iname yocto-bitbake*.vsix)
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
@@ -80,7 +80,7 @@ jobs:
     needs: build
     if: success() && startsWith( github.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
       - run: npx ovsx publish $(find . -iname yocto-bitbake*.vsix) -p ${VSX_PAT}
         env:
           VSX_PAT: ${{ secrets.VSX_PAT }}
@@ -88,15 +88,15 @@ jobs:
   build-language-server-standalone:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm run clean
       - run: cd server && npm install
       - run: cd server && npm pack
       - name: Archive server package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: language-server-bitbake
           path: server/language-server-bitbake-*.tgz
@@ -109,11 +109,11 @@ jobs:
     if: success() && startsWith( github.ref, 'refs/tags/')
     steps:
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
       - name: Publish to npm
         run: npm publish $(find . -iname language-server-bitbake-*.tgz)
         env:


### PR DESCRIPTION
This PR updates the following actions to the versions that support node20. [Reason](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
`actions/checkout@v4`: [changelog](https://github.com/actions/checkout/releases/tag/v4.0.0)
`actions/setup-node@v4`: [changelog](https://github.com/actions/setup-node/releases/tag/v4.0.0)
These two didn't mention node20 in the change log specifically:
`actions/upload-artifact@v4`: [PR](https://github.com/actions/upload-artifact/issues/444)
`actions/download-artifact@v4`: [action.yml](https://github.com/actions/download-artifact/blob/c850b930e6ba138125429b7e5c93fc707a7f8427/action.yml#L39)

Ticket: 14334