### PR TITLE
Feature: Add commands to generate and examine the dependency graph

### DIFF
--- a/client/src/ui/BitbakeStatusBar.ts
+++ b/client/src/ui/BitbakeStatusBar.ts
@@ -97,6 +97,7 @@ export class BitbakeStatusBar {
       if (this.commandInProgress.includes('which devtool')) displayText = 'Scanning...'
       if (this.commandInProgress.includes('toaster start')) displayText = 'Starting...'
       if (this.commandInProgress.includes('toaster stop')) displayText = 'Stopping...'
+      if (this.commandInProgress.includes('taskexp')) displayText = 'Running taskexp...'
       this.statusBarItem.text = '$(loading~spin) BitBake: ' + displayText
       this.statusBarItem.tooltip = 'BitBake: ' + displayText
       this.statusBarItem.command = undefined

--- a/package.json
+++ b/package.json
@@ -445,6 +445,11 @@
 			"description": "This clears all the data stored in the workspace state which would persist between sessions. This can potentially solve the crash caused by downgrading the extension to a version that is not able to handle the new workspace state data format."
 		  },
 		  {
+			"command": "bitbake.examine-dependency-taskexp",
+			"title": "BitBake: Examine recipe's dependencies with taskexp",
+			"description": "Examine the recipe's dependencies with taskexp."
+		  },
+		  {
 			"command": "bitbake.devtool-modify",
 			"title": "BitBake: Devtool: Modify recipe",
 			"description": "Open a new devtool workspace to modify a recipe's sources.",
@@ -588,6 +593,10 @@
 			{
 			  "command": "bitbake.start-toaster-in-browser",
 			  "group": "1@bitbake_dev@4"
+			},
+			{
+			  "command": "bitbake.examine-dependency-taskexp",
+			  "group": "1@bitbake_dev@5"
 			},
 			{
 			  "command": "bitbake.devtool-modify",
@@ -774,6 +783,11 @@
 			{
 			  "command": "bitbake.open-recipe-workdir",
 			  "group": "1@bitbake_dev@3",
+			  "when": "viewItem == bitbakeRecipeCtx"
+			},
+			{
+			  "command": "bitbake.examine-dependency-taskexp",
+			  "group": "1@bitbake_dev@4",
 			  "when": "viewItem == bitbakeRecipeCtx"
 			},
 			{


### PR DESCRIPTION
This adds two commands. One to generate the dependency graph, and the other to examine the dependency graph with taskexp.

In fact, both are independent commands that will generate the dependency graph. I have in mind the first one could be handful if the user has installed the [Yocto Project Dependency Visualizer](https://marketplace.visualstudio.com/items?itemName=MLinha.yocto-project-dependency-visualizer) extension, which won't generate the .dot file by itself, or eventually an other similar extension.

Note it is not possible to run an other BitBake command while taskexp is launched.