### PR TITLE
Use synchronize option to sync settings

### DIFF
--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -6,7 +6,6 @@
 import * as path from 'path'
 
 import {
-  workspace,
   type ExtensionContext,
   window,
   languages,
@@ -49,22 +48,14 @@ export async function activateLanguageServer (context: ExtensionContext, bitBake
     debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
   }
 
-  const sendSettings = async (): Promise<void> => {
-    const settings = workspace.getConfiguration()
-    try {
-      await client.sendNotification('workspace/didChangeConfiguration', { settings })
-    } catch (error) {
-      logger.error('Failed to send settings to language server: ' + String(error))
-    }
-  }
-
-  workspace.onDidChangeConfiguration(sendSettings)
-
   // Options to control the language client
   const clientOptions: LanguageClientOptions = {
     // Register the server for bitbake documents
-    // TODO: check new documentSelector
     documentSelector: [{ scheme: 'file', language: 'bitbake' }],
+    // TODO: Use the new pull-model for configuration settings
+    synchronize: {
+      configurationSection: 'bitbake'
+    },
     middleware: {
       provideCompletionItem: middlewareProvideCompletion,
       provideDefinition: middlewareProvideDefinition,
@@ -146,7 +137,6 @@ export async function activateLanguageServer (context: ExtensionContext, bitBake
 
   // Start the client and launch the server
   await client.start()
-  await sendSettings()
 
   return client
 }


### PR DESCRIPTION
The synchronize option is marked as deprecated but what we did to sync the settings was not a good practice either. The recommended pull-model for configurations is demonstrated [here](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#explaining-the-language-server). However, this model doesn't really fit our case as the logging level needs an immediate update but others can be fetched when needed.

One of the advantages of using the pull-model is it can specify the scope (user/workspace/workspaceFolder) of the configurations before fetching.
