### PR TITLE
Specify target branch for the auto PR

### DIFF
--- a/.github/workflows/update-ref.yml
+++ b/.github/workflows/update-ref.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       DBUS_SESSION_BUS_ADDRESS: unix:path=/run/user/1001/bus
       SHELL: /usr/bin/bash
+      BASE_BRANCH: staging
       FILE_PATHS: |
         integration-tests/src/utils/version.ts
         scripts/fetch-docs.sh
@@ -29,6 +30,8 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v3
+      with:
+        ref: ${{ env.BASE_BRANCH }}
 
     - name: Setup Node.js
       uses: actions/setup-node@v3
@@ -51,4 +54,6 @@ jobs:
         add-paths: ${{ env.FILE_PATHS }}
         title: Auto update references for commits, tags, etc
         commit-message: Auto update references for commits, tags, etc
+        branch: update-ref
+        base: ${{ env.BASE_BRANCH }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-tree-sitter-wasm-file.yml
+++ b/.github/workflows/update-tree-sitter-wasm-file.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       DBUS_SESSION_BUS_ADDRESS: unix:path=/run/user/1001/bus
       SHELL: /usr/bin/bash
+      BASE_BRANCH: staging
 
     strategy:
       matrix:
@@ -28,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v3
+      with:
+        ref: ${{ env.BASE_BRANCH }}
 
     - name: Setup Node.js
       uses: actions/setup-node@v3
@@ -61,4 +64,6 @@ jobs:
           server/tree-sitter-bitbake.wasm
         title: Auto update tree-sitter-bitbake wasm file
         commit-message: Auto update tree-sitter-bitbake wasm file and parser info
+        branch: update-tree-sitter-wasm-file
+        base: ${{ env.BASE_BRANCH }}
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To prevent PR like https://github.com/yoctoproject/vscode-bitbake/pull/210 from being created where the target branch should be `staging` instead of the `main` which is the default branch.