### PR TITLE
Refactor: Use 'configurationDefaults' instead of 'disableInteferingSettings'

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -16,6 +16,11 @@ We haven't found a way to prevent these tabs from opening, but we try to close t
 
 If this problem gets too annoying, consider activating the `bitbake.disableEmbeddedLanguagesFiles` setting.
 
+# files.trimTrailingWhitespace does not work on Python and Shell files
+When the extension is activated, `files.trimTrailingWhiteSpace` is deactivated for Python and Shell documents because this option interferes with the handling of Python and Shell code in BitBake documents.
+
+In the background, some Python and Shell documents are made in order to handle Python and Shell languages in BitBake files. These documents contain a lot of trailing whitespaces. If `files.trimTrailingWhiteSpace` is activated, it will trim the whitespaces into these files, making it hard to map the positions between the generated files and the original BitBake file.
+
 ### BrokenPipeError on BitBake commands
 
 If you are using a `bitbake.commandWrapper` that relies on docker containers, you may encounter the following errors:

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -92,18 +92,6 @@ function updatePythonPath (): void {
   }
 }
 
-async function disableInteferingSettings (): Promise<void> {
-  const config = vscode.workspace.getConfiguration()
-  for (const languageKey of ['[python]', '[shellscript]']) {
-    const languageConfig = config.get<Record<string, unknown>>(languageKey) ?? {}
-    // 'files.trimTrailingWhitespace' modifies the embedded languages documents and breaks the mapping of the positions
-    languageConfig['files.trimTrailingWhitespace'] = false
-    if (canModifyConfig()) {
-      await config.update(languageKey, languageConfig, vscode.ConfigurationTarget.Workspace)
-    }
-  }
-}
-
 async function installExtensions (extensionId: string): Promise<void> {
   await vscode.window.showInformationMessage(`The extension ${extensionId} is required for yocto-project.yocto-bitbake to work properly. Do you want to install it?`, 'Install', 'Show extension page', 'Cancel')
     .then((item) => {
@@ -148,7 +136,6 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
   bitbakeDriver.loadSettings(vscode.workspace.getConfiguration('bitbake'), vscode.workspace.workspaceFolders?.[0].uri.fsPath)
   const bitBakeProjectScanner: BitBakeProjectScanner = new BitBakeProjectScanner(bitbakeDriver)
   updatePythonPath()
-  await disableInteferingSettings()
   bitbakeWorkspace.loadBitbakeWorkspace(context.workspaceState)
   bitbakeTaskProvider = new BitbakeTaskProvider(bitbakeDriver)
   client = await activateLanguageServer(context, bitBakeProjectScanner)

--- a/package.json
+++ b/package.json
@@ -209,6 +209,14 @@
 			}
 		  }
 		},
+		"configurationDefaults": {
+			"[shellscript]": {
+				"files.trimTrailingWhitespace": false
+			},
+			"[python]": {
+				"files.trimTrailingWhitespace": false
+			}
+		},
 		"taskDefinitions": [
 		  {
 			"type": "bitbake",
@@ -785,55 +793,55 @@
 			  "command": "bitbake.devtool-build",
 			  "group": "0@devtool_build@0",
 			  "when": "viewItem == devtoolWorskpaceCtx"
-	
+
 			},
 			{
 			  "command": "bitbake.devtool-clean",
 			  "group": "0@devtool_build@1",
 			  "when": "viewItem == devtoolWorskpaceCtx"
-	
+
 			},
 			{
 			  "command": "bitbake.devtool-deploy",
 			  "group": "0@devtool_build@2",
 			  "when": "viewItem == devtoolWorskpaceCtx"
-	
+
 			},
 			{
 			  "command": "bitbake.devtool-open-workspace",
 			  "group": "1@devtool_dev@0",
 			  "when": "viewItem == devtoolWorskpaceCtx"
-	
+
 			},
 			{
 			  "command": "bitbake.devtool-ide-sdk",
 			  "group": "1@devtool_dev@1",
 			  "when": "viewItem == devtoolWorskpaceCtx"
-	
+
 			},
 			{
 			  "command": "bitbake.devtool-sdk-fallback",
 			  "group": "1@devtool_dev@2",
 			  "when": "viewItem == devtoolWorskpaceCtx"
-	
+
 			},
 			{
 			  "command": "bitbake.terminal-profile",
 			  "group": "1@devtool_dev@3",
 			  "when": "viewItem == devtoolWorskpaceCtx"
-	
+
 			},
 			{
 			  "command": "bitbake.devtool-update",
 			  "group": "1@devtool_finalize@0",
 			  "when": "viewItem == devtoolWorskpaceCtx"
-	
+
 			},
 			{
 			  "command": "bitbake.devtool-reset",
 			  "group": "1@devtool_finalize@1",
 			  "when": "viewItem == devtoolWorskpaceCtx"
-	
+
 			}
 		  ]
 		},


### PR DESCRIPTION
The "interfering settings" are moved to "configurationDefaults" so they can be deactivated without having to modify the user's settings.json file.