### PR TITLE
Feat: Handle completion on bash simple variable expansion

### DIFF
--- a/integration-tests/project-folder/sources/meta-fixtures/rename.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures/rename.bb
@@ -3,7 +3,7 @@ foo='foo'
 python() {
     foo='foo'
     print(foo)
-    d.getVar('foo') # should be included in global variables, but it does not work in integration tests for unknown reasons
+    d.getVar('foo')
 }
 
 do_stuff() {

--- a/server/src/__tests__/completions.test.ts
+++ b/server/src/__tests__/completions.test.ts
@@ -413,7 +413,7 @@ describe('On Completion', () => {
         uri: DUMMY_URI
       },
       position: {
-        line: 35,
+        line: 36,
         character: 13
       }
     })
@@ -1071,6 +1071,43 @@ describe('On Completion', () => {
     ).toBeUndefined()
   })
 
+  it('provides proper completion items on simple variable expansion in bash', async () => {
+    analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.COMPLETION
+    })
+
+    bitBakeDocScanner.parseBitbakeVariablesFile()
+    bitBakeDocScanner.parseYoctoVariablesFile()
+
+    const resultInVariableExpansion = onCompletionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 28,
+        character: 6
+      }
+    })
+
+    expect(resultInVariableExpansion).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'DESCRIPTION',
+          labelDetails: {
+            description: 'Source: Yocto'
+          },
+          documentation: {
+            value: '```man\nDESCRIPTION (bitbake-language-server)\n\n\n```\n```bitbake\n\n```\n---\n   The package description used by package managers. If not set,\n   `DESCRIPTION` takes the value of the `SUMMARY`\n   variable.\n\n\n[Reference](https://docs.yoctoproject.org/ref-manual/variables.html#term-DESCRIPTION)',
+            kind: 'markdown'
+          },
+          insertText: undefined,
+          insertTextFormat: 1
+        })
+      ])
+    )
+  })
+
   it('provides common directories completion items where it is appropriate', async () => {
     analyzer.analyze({
       uri: DUMMY_URI,
@@ -1173,7 +1210,7 @@ describe('On Completion', () => {
         uri: DUMMY_URI
       },
       position: {
-        line: 30,
+        line: 31,
         character: 12
       }
     })

--- a/server/src/__tests__/completions.test.ts
+++ b/server/src/__tests__/completions.test.ts
@@ -1035,7 +1035,7 @@ describe('On Completion', () => {
         uri: DUMMY_URI
       },
       position: {
-        line: 31,
+        line: 27,
         character: 8
       }
     })
@@ -1062,7 +1062,7 @@ describe('On Completion', () => {
         uri: DUMMY_URI
       },
       position: {
-        line: 31,
+        line: 27,
         character: 11
       }
     })
@@ -1173,7 +1173,7 @@ describe('On Completion', () => {
         uri: DUMMY_URI
       },
       position: {
-        line: 26,
+        line: 30,
         character: 12
       }
     })

--- a/server/src/__tests__/fixtures/completion.bb
+++ b/server/src/__tests__/fixtures/completion.bb
@@ -26,6 +26,7 @@ python() {
 
 do_foo() {
     "${D} D"
+    $D
 }
 
 DESCRIPTION:

--- a/server/src/__tests__/fixtures/completion.bb
+++ b/server/src/__tests__/fixtures/completion.bb
@@ -24,12 +24,12 @@ D
 python() {
 }
 
-DESCRIPTION:
-def dummy() {
-}
-
 do_foo() {
     "${D} D"
+}
+
+DESCRIPTION:
+def dummy() {
 }
 
 # Show completion at the last line https://github.com/amaanq/tree-sitter-bitbake/issues/9

--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -173,9 +173,9 @@ function getBitBakeCompletionItems (textDocumentPositionParams: TextDocumentPosi
     return getCompletionItemForDirectiveStatementKeyword(directiveStatementKeyword)
   }
 
-  const isVariableExpansion = analyzer.isVariableExpansion(documentUri, wordPosition.line, wordPosition.character)
-  const commonDirectoriesCompletionItems = isVariableExpansion ? allCommonDirectoriesCompletionItems : []
-  const reservedKeywordCompletionItems = !isVariableExpansion ? allReserverdKeywordCompletionItems : []
+  const isBitBakeVariableExpansion = analyzer.isBitBakeVariableExpansion(documentUri, wordPosition.line, wordPosition.character)
+  const commonDirectoriesCompletionItems = isBitBakeVariableExpansion ? allCommonDirectoriesCompletionItems : []
+  const reservedKeywordCompletionItems = !isBitBakeVariableExpansion ? allReserverdKeywordCompletionItems : []
 
   return mergeArraysDistinctly(
     (completionItem) => completionItem.label,

--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -189,7 +189,7 @@ function getBitBakeCompletionItems (textDocumentPositionParams: TextDocumentPosi
 }
 
 function getBashCompletionItems (documentUri: string, word: string | null, wordPosition: Position): CompletionItem[] {
-  if (analyzer.isBashVariableExpansion(documentUri, wordPosition.line, wordPosition.character)) {
+  if (analyzer.isBashVariableName(documentUri, wordPosition.line, wordPosition.character)) {
     const symbolCompletionItems = getSymbolCompletionItems(word)
     return mergeArraysDistinctly(
       (completionItem) => completionItem.label,

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -28,7 +28,7 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
 
   // Show documentation of a bitbake variable
   // Triggers on global declaration expressions like "VAR = 'foo'" and inside variable expansion like "FOO = ${VAR}" but skip the ones like "python VAR(){}"
-  const canShowHoverDefinitionForVariableName: boolean = (analyzer.getGlobalDeclarationSymbols(textDocument.uri).some((symbol) => symbol.name === word) && analyzer.isIdentifierOfVariableAssignment(params)) || analyzer.isVariableExpansion(textDocument.uri, position.line, position.character) || analyzer.isPythonDatastoreVariable(textDocument.uri, position.line, position.character) || analyzer.isBashVariableName(textDocument.uri, position.line, position.character)
+  const canShowHoverDefinitionForVariableName: boolean = (analyzer.getGlobalDeclarationSymbols(textDocument.uri).some((symbol) => symbol.name === word) && analyzer.isIdentifierOfVariableAssignment(params)) || analyzer.isBitBakeVariableExpansion(textDocument.uri, position.line, position.character) || analyzer.isPythonDatastoreVariable(textDocument.uri, position.line, position.character) || analyzer.isBashVariableName(textDocument.uri, position.line, position.character)
   if (canShowHoverDefinitionForVariableName) {
     const found = [
       ...bitBakeDocScanner.bitbakeVariableInfo.filter((bitbakeVariable) => !bitBakeDocScanner.yoctoVariableInfo.some(yoctoVariable => yoctoVariable.name === bitbakeVariable.name)),

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -28,7 +28,7 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
 
   // Show documentation of a bitbake variable
   // Triggers on global declaration expressions like "VAR = 'foo'" and inside variable expansion like "FOO = ${VAR}" but skip the ones like "python VAR(){}"
-  const canShowHoverDefinitionForVariableName: boolean = (analyzer.getGlobalDeclarationSymbols(textDocument.uri).some((symbol) => symbol.name === word) && analyzer.isIdentifierOfVariableAssignment(params)) || analyzer.isVariableExpansion(textDocument.uri, position.line, position.character) || analyzer.isPythonDatastoreVariable(textDocument.uri, position.line, position.character) || analyzer.isBashVariableExpansion(textDocument.uri, position.line, position.character)
+  const canShowHoverDefinitionForVariableName: boolean = (analyzer.getGlobalDeclarationSymbols(textDocument.uri).some((symbol) => symbol.name === word) && analyzer.isIdentifierOfVariableAssignment(params)) || analyzer.isVariableExpansion(textDocument.uri, position.line, position.character) || analyzer.isPythonDatastoreVariable(textDocument.uri, position.line, position.character) || analyzer.isBashVariableName(textDocument.uri, position.line, position.character)
   if (canShowHoverDefinitionForVariableName) {
     const found = [
       ...bitBakeDocScanner.bitbakeVariableInfo.filter((bitbakeVariable) => !bitBakeDocScanner.yoctoVariableInfo.some(yoctoVariable => yoctoVariable.name === bitbakeVariable.name)),

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -310,13 +310,18 @@ export default class Analyzer {
    * Find the full word at the given point.
    */
   public wordAtPoint (uri: string, line: number, column: number): string | null {
-    const node = this.bitBakeNodeAtPoint(uri, line, column)
+    const bashNode = this.bashNodeAtPoint(uri, line, column)
+    if (bashNode?.type === 'variable_name') {
+      return bashNode.text
+    }
 
-    if (node === null || node.childCount > 0 || node.text.trim() === '') {
+    const bitBakeNode = this.bitBakeNodeAtPoint(uri, line, column)
+
+    if (bitBakeNode === null || bitBakeNode.childCount > 0 || bitBakeNode.text.trim() === '') {
       return null
     }
 
-    return node.text.trim()
+    return bitBakeNode.text.trim()
   }
 
   public wordAtPointFromTextPosition (

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -246,7 +246,7 @@ export default class Analyzer {
    * Find the full word at the given point.
    */
   public wordAtPoint (uri: string, line: number, column: number): string | null {
-    const node = this.nodeAtPoint(uri, line, column)
+    const node = this.bitBakeNodeAtPoint(uri, line, column)
 
     if (node === null || node.childCount > 0 || node.text.trim() === '') {
       return null
@@ -279,7 +279,7 @@ export default class Analyzer {
   public getDirectiveStatementKeywordByNodeType (
     params: TextDocumentPositionParams
   ): DirectiveStatementKeyword | undefined {
-    const n = this.nodeAtPoint(
+    const n = this.bitBakeNodeAtPoint(
       params.textDocument.uri,
       params.position.line,
       params.position.character
@@ -311,7 +311,7 @@ export default class Analyzer {
   public getDirectivePathForPosition (
     params: TextDocumentPositionParams
   ): string | undefined {
-    const n = this.nodeAtPoint(
+    const n = this.bitBakeNodeAtPoint(
       params.textDocument.uri,
       params.position.line,
       params.position.character
@@ -327,7 +327,7 @@ export default class Analyzer {
   public isIdentifier (
     params: TextDocumentPositionParams
   ): boolean {
-    const n = this.nodeAtPoint(
+    const n = this.bitBakeNodeAtPoint(
       params.textDocument.uri,
       params.position.line,
       params.position.character
@@ -338,7 +338,7 @@ export default class Analyzer {
   public isFunctionIdentifier (
     params: TextDocumentPositionParams
   ): boolean {
-    const n = this.nodeAtPoint(
+    const n = this.bitBakeNodeAtPoint(
       params.textDocument.uri,
       params.position.line,
       params.position.character
@@ -356,7 +356,7 @@ export default class Analyzer {
     line: number,
     column: number
   ): boolean {
-    const n = this.nodeAtPoint(uri, line, column)
+    const n = this.bitBakeNodeAtPoint(uri, line, column)
     if (n?.type === 'string_content') {
       return true
     }
@@ -373,7 +373,7 @@ export default class Analyzer {
     column: number,
     variableNames?: string[]
   ): boolean {
-    const n = this.nodeAtPoint(uri, line, column)
+    const n = this.bitBakeNodeAtPoint(uri, line, column)
     if (n?.type !== 'string_content') {
       return false
     }
@@ -395,7 +395,7 @@ export default class Analyzer {
     line: number,
     column: number
   ): boolean {
-    const n = this.nodeAtPoint(uri, line, column)
+    const n = this.bitBakeNodeAtPoint(uri, line, column)
     // Current tree-sitter (as of @1.0.1) only treats 'append', 'prepend' and 'remove' as a node with "override" type. Other words following ":" will yield a node with "identifier" type whose parent node is of type "override"
     // However, in some cases, its parent node is not of type override but its grandparent is.
     // Some ugly checks were added (as of tree-sitter @1.1.0) due to: https://github.com/amaanq/tree-sitter-bitbake/issues/9
@@ -415,7 +415,7 @@ export default class Analyzer {
     line: number,
     column: number
   ): boolean {
-    const n = this.nodeAtPoint(uri, line, column)
+    const n = this.bitBakeNodeAtPoint(uri, line, column)
     // The bug appears on identifiers, and also on the colon of overrides
     if (n?.type !== 'identifier' && n?.type !== ':') {
       return false
@@ -441,7 +441,7 @@ export default class Analyzer {
     line: number,
     column: number
   ): boolean {
-    let n = this.nodeAtPoint(uri, line, column)
+    let n = this.bitBakeNodeAtPoint(uri, line, column)
     if (this.isBuggyIdentifier(uri, line, column)) {
       return false
     }
@@ -461,7 +461,7 @@ export default class Analyzer {
     line: number,
     column: number
   ): boolean {
-    let n = this.nodeAtPoint(uri, line, column)
+    let n = this.bitBakeNodeAtPoint(uri, line, column)
     if (this.isBuggyIdentifier(uri, line, column)) {
       return false
     }
@@ -485,7 +485,7 @@ export default class Analyzer {
     // However, when the user hover on the variable, the quotes are not part of the variable
     includeOpeningQuote: boolean = false
   ): boolean {
-    const n = this.nodeAtPoint(uri, line, column)
+    const n = this.bitBakeNodeAtPoint(uri, line, column)
     if (!this.isInsidePythonRegion(uri, line, column)) {
       return false
     }
@@ -548,8 +548,8 @@ export default class Analyzer {
     line: number,
     column: number
   ): boolean {
-    const n = this.nodeAtPoint(uri, line, column)
-    // since @1.0.2 the tree-sitter gives empty variable expansion (e.g. `VAR = "${}""`) the type "variable_expansion". But the node type returned from nodeAtPoint() at the position between "${" and "}" is of type "${" which is the result from descendantForPosition() (It returns the smallest node containing the given postion). In this case, the parent node has type "variable_expansion". Hence, we have n?.parent?.type === 'variable_expansion' below. The second expression after the || will be true if it encounters non-empty variable expansion syntax. e.g. `VAR = "${A}". Note that inline python with ${@} has type "inline_python"
+    const n = this.bitBakeNodeAtPoint(uri, line, column)
+    // since @1.0.2 the tree-sitter gives empty variable expansion (e.g. `VAR = "${}""`) the type "variable_expansion". But the node type returned from bitBakeNodeAtPoint() at the position between "${" and "}" is of type "${" which is the result from descendantForPosition() (It returns the smallest node containing the given postion). In this case, the parent node has type "variable_expansion". Hence, we have n?.parent?.type === 'variable_expansion' below. The second expression after the || will be true if it encounters non-empty variable expansion syntax. e.g. `VAR = "${A}". Note that inline python with ${@} has type "inline_python"
     return n?.parent?.type === 'variable_expansion' || (n?.type === 'identifier' && n?.parent?.type === 'variable_expansion')
   }
 
@@ -567,7 +567,7 @@ export default class Analyzer {
   public isIdentifierOfVariableAssignment (
     params: TextDocumentPositionParams
   ): boolean {
-    const n = this.nodeAtPoint(
+    const n = this.bitBakeNodeAtPoint(
       params.textDocument.uri,
       params.position.line,
       params.position.character
@@ -578,7 +578,7 @@ export default class Analyzer {
   public isVariableFlag (
     params: TextDocumentPositionParams
   ): boolean {
-    const n = this.nodeAtPoint(
+    const n = this.bitBakeNodeAtPoint(
       params.textDocument.uri,
       params.position.line,
       params.position.character
@@ -590,7 +590,7 @@ export default class Analyzer {
   public rangeForWordAtPoint (
     params: TextDocumentPositionParams
   ): Range | undefined {
-    const n = this.nodeAtPoint(
+    const n = this.bitBakeNodeAtPoint(
       params.textDocument.uri,
       params.position.line,
       params.position.character
@@ -633,7 +633,7 @@ export default class Analyzer {
     line: number,
     column: number
   ): string | undefined {
-    const n = this.nodeAtPoint(uri, line, column)
+    const n = this.bitBakeNodeAtPoint(uri, line, column)
 
     const parentNodeType = n?.parent?.type
     if (parentNodeType !== undefined) {
@@ -658,6 +658,20 @@ export default class Analyzer {
   private nodeAtPoint (
     uri: string,
     line: number,
+    column: number,
+    tree: Parser.Tree
+  ): Parser.SyntaxNode | null {
+    if (tree.rootNode === null) {
+      // Check for lacking rootNode (due to failed parse?)
+      return null
+    }
+
+    return tree.rootNode.descendantForPosition({ row: line, column })
+  }
+
+  private bitBakeNodeAtPoint (
+    uri: string,
+    line: number,
     column: number
   ): Parser.SyntaxNode | null {
     const bitBakeTree = this.uriToAnalyzedDocument[uri]?.bitBakeTree
@@ -666,12 +680,21 @@ export default class Analyzer {
       return null
     }
 
-    if (bitBakeTree.rootNode === null) {
-      // Check for lacking rootNode (due to failed parse?)
+    return this.nodeAtPoint(uri, line, column, bitBakeTree)
+  }
+
+  private bashNodeAtPoint (
+    uri: string,
+    line: number,
+    column: number
+  ): Parser.SyntaxNode | null {
+    const bashTree = this.uriToAnalyzedDocument[uri]?.bashTree
+
+    if (bashTree === undefined) {
       return null
     }
 
-    return bitBakeTree.rootNode.descendantForPosition({ row: line, column })
+    return this.nodeAtPoint(uri, line, column, bashTree)
   }
 
   // Return the uris in the diretive statements for unlimited depth
@@ -818,7 +841,7 @@ export default class Analyzer {
   public getSymbolsInStringContent (uri: string, line: number, character: number): SymbolInformation[] {
     const allSymbolsAtPosition: SymbolInformation[] = []
     const wholeWordRegex = /(?<![-.:])(--(enable|disable)-)?\b(?<name>[a-zA-Z0-9][a-zA-Z0-9-+.]*[a-zA-Z0-9])\b(?![-.:])/g
-    const n = this.nodeAtPoint(uri, line, character)
+    const n = this.bitBakeNodeAtPoint(uri, line, character)
     if (n?.type === 'string_content') {
       this.processSymbolsInStringContent(n, wholeWordRegex, (start, end, match) => {
         const symbolName = match.groups?.name

--- a/server/src/tree-sitter/declarations.ts
+++ b/server/src/tree-sitter/declarations.ts
@@ -80,16 +80,16 @@ export function nodeToSymbolInformation ({
   node,
   uri,
   getFinalValue,
-  isVariableExpansion = false
+  isBitBakeVariableExpansion = false
 }: {
   node: Parser.SyntaxNode
   uri: string
   getFinalValue?: boolean
-  isVariableExpansion?: boolean
+  isBitBakeVariableExpansion?: boolean
 }): BitbakeSymbolInformation | null {
   let namedNode = node.firstNamedChild
 
-  if (isVariableExpansion) {
+  if (isBitBakeVariableExpansion) {
     namedNode = node
   }
 


### PR DESCRIPTION
Still breaking down #215 in smaller parts.

This actually adds support for simple variable expansions on hover, references, definitions, rename and completion. However, I propose the reduce the scope of this PR to completion in order to reduce things to review. #215 has proper tests for the other functionalities.

This also adds some modifications to the rename integration test, since the changes would broke it for reasons that are not well understood.