### PR TITLE
Feat: Import require/inherit in Bash and Python context

### DIFF
--- a/client/src/language/RequestManager.ts
+++ b/client/src/language/RequestManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { type Position } from 'vscode'
+import { type TextDocument, type Definition, type Position } from 'vscode'
 import { type LanguageClient } from 'vscode-languageclient/node'
 
 import { RequestMethod, type RequestParams, type RequestResult } from '../lib/src/types/requests'
@@ -27,6 +27,21 @@ export class RequestManager {
       return
     }
     return await getAllVariableValues(this.client, recipe, false)
+  }
+
+  getDefinition = async (textDocument: TextDocument, position: Position): Promise<Definition[]> => {
+    if (this.client === undefined) {
+      return []
+    }
+    return await this.client.sendRequest(
+      'textDocument/definition',
+      {
+        textDocument: {
+          uri: textDocument.uri.toString()
+        },
+        position
+      }
+    )
   }
 }
 

--- a/client/src/language/RequestManager.ts
+++ b/client/src/language/RequestManager.ts
@@ -7,7 +7,6 @@ import { type TextDocument, type Definition, type Position } from 'vscode'
 import { type LanguageClient } from 'vscode-languageclient/node'
 
 import { RequestMethod, type RequestParams, type RequestResult } from '../lib/src/types/requests'
-import { getAllVariableValues } from './languageClient'
 
 export class RequestManager {
   client: LanguageClient | undefined
@@ -18,15 +17,6 @@ export class RequestManager {
   ): RequestResult['EmbeddedLanguageTypeOnPosition'] => {
     const params: RequestParams['EmbeddedLanguageTypeOnPosition'] = { uriString, position }
     return await this.client?.sendRequest(RequestMethod.EmbeddedLanguageTypeOnPosition, params)
-  }
-
-  getAllVariableValues = async (
-    recipe: string
-  ): Promise<ReturnType<typeof getAllVariableValues>> => {
-    if (this.client === undefined) {
-      return
-    }
-    return await getAllVariableValues(this.client, recipe, false)
   }
 
   getDefinition = async (textDocument: TextDocument, position: Position): Promise<Definition[]> => {

--- a/client/src/language/diagnosticsSupport.ts
+++ b/client/src/language/diagnosticsSupport.ts
@@ -136,7 +136,10 @@ const checkIsIgnoredShellcheckSc2154 = async (
   originalTextDocument: vscode.TextDocument,
   adjustedRange: vscode.Range
 ): Promise<boolean> => {
-  if (diagnostic.source?.includes('shellcheck') !== true && diagnostic.code !== 'SC2154') {
+  if (diagnostic.source?.includes('shellcheck') !== true) {
+    return false
+  }
+  if (typeof diagnostic.code !== 'object' || diagnostic.code?.value !== 'SC2154') {
     return false
   }
 

--- a/client/src/language/diagnosticsSupport.ts
+++ b/client/src/language/diagnosticsSupport.ts
@@ -68,21 +68,21 @@ export const updateDiagnostics = async (uri: vscode.Uri): Promise<void> => {
     if (diagnostic.range === undefined) {
       cleanDiagnostics.push(diagnostic)
     }
-    const newRange = getOriginalDocRange(
+    const adjustedRange = getOriginalDocRange(
       originalTextDocument,
       embeddedLanguageDoc,
       embeddedLanguageDocInfos.characterIndexes,
       diagnostic.range
     )
-    if (newRange === undefined) {
+    if (adjustedRange === undefined) {
       return
     }
-    const newDiagnostic = {
+    const adjustedDiagnostic = {
       ...diagnostic,
-      range: newRange,
+      range: adjustedRange,
       source: `${diagnostic.source}, ${diagnosticCollection.name}`
     }
-    cleanDiagnostics.push(newDiagnostic)
+    cleanDiagnostics.push(adjustedDiagnostic)
   }))
   diagnosticCollection.set(originalTextDocument.uri, cleanDiagnostics)
 }

--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -197,11 +197,3 @@ export async function getVariableValue (
 ): Promise<string | undefined> {
   return await getScanResult(client, RequestMethod.getVar, { variable, recipe }, canTriggerScan)
 }
-
-export async function getAllVariableValues (
-  client: LanguageClient,
-  recipe: string,
-  canTriggerScan: boolean = false
-): Promise<Array<{ name: string, value: string }> | undefined> {
-  return await getScanResult(client, RequestMethod.getAllVar, { recipe }, canTriggerScan)
-}

--- a/client/src/language/middlewareDefinition.ts
+++ b/client/src/language/middlewareDefinition.ts
@@ -93,11 +93,11 @@ const ajustDefinitionRange = (
   characterIndexes: number[]
 ): boolean => {
   if (definition instanceof Location) {
-    const newRange = getOriginalDocRange(originalTextDocument, embeddedLanguageTextDocument, characterIndexes, definition.range)
-    if (newRange === undefined) {
+    const adjustedRange = getOriginalDocRange(originalTextDocument, embeddedLanguageTextDocument, characterIndexes, definition.range)
+    if (adjustedRange === undefined) {
       return false
     }
-    definition.range = newRange
+    definition.range = adjustedRange
   } else {
     const newTargetRange = getOriginalDocRange(originalTextDocument, embeddedLanguageTextDocument, characterIndexes, definition.targetRange)
     if (newTargetRange === undefined) {

--- a/client/src/language/middlewareReferences.ts
+++ b/client/src/language/middlewareReferences.ts
@@ -64,17 +64,17 @@ const processReferences = (
     }
     reference.uri = originalTextDocument.uri
 
-    const newRange = getOriginalDocRange(
+    const adjustedRange = getOriginalDocRange(
       originalTextDocument,
       embeddedLanguageTextDocument,
       embeddedLanguageDocInfos.characterIndexes,
       reference.range
     )
 
-    if (newRange === undefined) {
+    if (adjustedRange === undefined) {
       return
     }
-    reference.range = newRange
+    reference.range = adjustedRange
     result.push(reference)
   })
 

--- a/client/src/lib/src/types/requests.ts
+++ b/client/src/lib/src/types/requests.ts
@@ -11,7 +11,6 @@ export enum RequestType {
   getLinksInDocument = 'getLinksInDocument',
   ProcessRecipeScanResults = 'ProcessRecipeScanResults',
   GetVar = 'getVar',
-  GetAllVar = 'getAllVar',
   GetRecipeLocalFiles = 'getRecipeLocalFiles'
 }
 
@@ -20,7 +19,6 @@ export const RequestMethod: Record<RequestType, string> = {
   [RequestType.getLinksInDocument]: 'bitbake/getLinksInDocument',
   [RequestType.ProcessRecipeScanResults]: 'bitbake/ProcessRecipeScanResults',
   [RequestType.GetVar]: 'bitbake/getVar',
-  [RequestType.GetAllVar]: 'bitbake/getAllVar',
   [RequestType.GetRecipeLocalFiles]: 'bitbake/getRecipeLocalFiles'
 }
 
@@ -29,7 +27,6 @@ export interface RequestParams {
   [RequestType.getLinksInDocument]: { documentUri: string }
   [RequestType.ProcessRecipeScanResults]: { scanResults: string, uri: any, chosenRecipe: string }
   [RequestType.GetVar]: { variable: string, recipe: string }
-  [RequestType.GetAllVar]: { recipe: string }
   [RequestType.GetRecipeLocalFiles]: { uri: string }
 }
 

--- a/integration-tests/src/tests/rename.test.ts
+++ b/integration-tests/src/tests/rename.test.ts
@@ -76,6 +76,8 @@ suite('Bitbake Rename Test Suite', () => {
     })
   }
 
+  // This test is not reliable on embedded language regions.
+  // It might succeed (can't be renamed) just because it has been called before the embedded language document finished to be generated.
   const testInvalidRename = async (
     position: vscode.Position
   ): Promise<void> => {
@@ -87,8 +89,6 @@ suite('Bitbake Rename Test Suite', () => {
       )
     } catch (error) {
       if (error instanceof Error) {
-        // This test is not completely reliable.
-        // It might succeed just because it has been called before the embedded language document finished to be generated.
         assert.strictEqual(error.message === "The element can't be renamed.", true)
         return
       }

--- a/integration-tests/src/tests/rename.test.ts
+++ b/integration-tests/src/tests/rename.test.ts
@@ -63,16 +63,17 @@ suite('Bitbake Rename Test Suite', () => {
     let result: { range: vscode.Range, placeholder: string } | undefined
 
     await assertWillComeTrue(async () => {
-      result = await vscode.commands.executeCommand<{ range: vscode.Range, placeholder: string } | undefined>(
-        'vscode.prepareRename',
-        docUri,
-        position
-      )
-      return result !== undefined
+      try {
+        result = await vscode.commands.executeCommand<{ range: vscode.Range, placeholder: string } | undefined>(
+          'vscode.prepareRename',
+          docUri,
+          position
+        )
+      } catch (error) {
+        // pass
+      }
+      return result !== undefined && result.range.isEqual(expected.range) && result.placeholder === expected.placeholder
     })
-
-    assert.strictEqual(result?.range.isEqual(expected.range), true)
-    assert.strictEqual(result?.placeholder === expected.placeholder, true)
   }
 
   const testInvalidRename = async (
@@ -86,6 +87,8 @@ suite('Bitbake Rename Test Suite', () => {
       )
     } catch (error) {
       if (error instanceof Error) {
+        // This test is not completely reliable.
+        // It might succeed just because it has been called before the embedded language document finished to be generated.
         assert.strictEqual(error.message === "The element can't be renamed.", true)
         return
       }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -183,11 +183,6 @@ disposables.push(
     return scanResult?.symbols.find(symbolInfo => symbolInfo.name === params.variable)?.finalValue
   }),
 
-  connection.onRequest(RequestMethod.getAllVar, async (params: RequestParams['getAllVar']) => {
-    const scanResult = analyzer.getLastScanResult(params.recipe)
-    return scanResult?.symbols.map(symbolInfo => ({ name: symbolInfo.name, value: symbolInfo.finalValue }))
-  }),
-
   connection.onNotification(NotificationMethod.RemoveScanResult, (param: NotificationParams['RemoveScanResult']) => {
     logger.debug(`[onNotification] <${NotificationMethod.RemoveScanResult}> recipe: ${param.recipeName}`)
     analyzer.removeLastScanResultForRecipe(param.recipeName)

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -326,7 +326,7 @@ export default class Analyzer {
    */
   public wordAtPoint (uri: string, line: number, column: number): string | null {
     const bashNode = this.bashNodeAtPoint(uri, line, column)
-    if (bashNode?.type === 'variable_name') {
+    if (bashNode?.type === 'variable_name' || bashNode?.type === 'word') {
       return bashNode.text
     }
 


### PR DESCRIPTION
This adds "definition" functionality to variables that are required, inherited or included into Bash or Python regions. It also filter out Pylance's `reportUndefinedVariable` when the variable is actually defined. It even removes the requirement to make a new scan for filtering out shellchecks `SC2154` diagnostics when the variable actually exist.

Lets take examples from the file `meta/recipes-core/busybox/busybox.inc` in Poky. After, a scan, `find_cfgs` (python region) won't appear anymore as undefined, and clicking on it will bring to its definition in `meta/classes-recipe/cml1.bbclass`. `cml1_do_configure` (shell region) will also bring to its definition when clicked.