### PR TITLE
Chore: Add dependabot.yml for auto checks for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" 
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    target-branch: "staging"
+
+  - package-ecosystem: "npm"
+    directory: "/client" 
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    target-branch: "staging"
+
+  - package-ecosystem: "npm"
+    directory: "/server"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    target-branch: "staging"


### PR DESCRIPTION
With this file, Github will periodically check for version updates for the npm packages. **The `Code security and analysis` -> `Dependabot on Actions runners` setting must be enabled for this behaviour to take effect.**