### PR TITLE
Fix: Update server .npmignore to include tree-sitter-bash.wasm

### DIFF
--- a/server/.npmignore
+++ b/server/.npmignore
@@ -4,6 +4,7 @@
 !/out/
 !/resources/
 !tree-sitter-bitbake.wasm
+!tree-sitter-bash.wasm
 *.map
 **/__tests__/
 **/*.tgz


### PR DESCRIPTION
In order for the standalone server to work on neoVim, it needs this dependency.