### PR TITLE
Chore: Add comment with original uri on embedded language documents

### DIFF
--- a/client/src/language/middlewareDefinition.ts
+++ b/client/src/language/middlewareDefinition.ts
@@ -136,8 +136,8 @@ const redirectDefinition = async <DefinitionType extends Location | LocationLink
   return redirectedResult.map((redirectedDefinition) => convertToSameDefinitionType(initialDefinition, redirectedDefinition))
 }
 
-export const dRange = new Range(2, 0, 2, 1) // Where `d` is located in the embedded language document
-export const dataSmartPosition = new Position(2, 19) // Where `DataSmart` (data_smart.DataSmart()) is reachable in the embedded language document
+export const dRange = new Range(3, 0, 3, 1) // Where `d` is located in the embedded language document
+export const dataSmartPosition = new Position(3, 19) // Where `DataSmart` (data_smart.DataSmart()) is reachable in the embedded language document
 
 // Handle `d` in `d.getVar('')`
 const getDefinitionOfD = async <DefinitionType extends Location | LocationLink>(
@@ -146,8 +146,8 @@ const getDefinitionOfD = async <DefinitionType extends Location | LocationLink>(
   return await redirectDefinition(definition, dRange, dataSmartPosition)
 }
 
-export const eRange = new Range(3, 0, 3, 1) // Where `e` is located in the embedded language document
-export const eventPosition = new Position(3, 14) // Where `Event` (event.Event()) is reachable in the embedded language document
+export const eRange = new Range(4, 0, 4, 1) // Where `e` is located in the embedded language document
+export const eventPosition = new Position(4, 14) // Where `Event` (event.Event()) is reachable in the embedded language document
 
 // Handle `e` in `e.data.getVar('')`
 const getDefinitionOfE = async <DefinitionType extends Location | LocationLink>(

--- a/server/src/embedded-languages/bash-support.ts
+++ b/server/src/embedded-languages/bash-support.ts
@@ -20,12 +20,6 @@ const shellcheckDisables = [
   '# shellcheck disable=SC2317'
 ]
 
-export const bashHeader = [
-  shebang,
-  ...shellcheckDisables,
-  ''
-].join('\n')
-
 export const generateBashEmbeddedLanguageDoc = (
   textDocument: TextDocument,
   bitBakeTree: Parser.Tree,
@@ -53,8 +47,17 @@ export const generateBashEmbeddedLanguageDoc = (
   return embeddedLanguageDoc
 }
 
+export const getBashHeader = (originalUri: string): string => {
+  return [
+    shebang,
+    `# Original BitBake document: ${originalUri}`,
+    ...shellcheckDisables,
+    ''
+  ].join('\n')
+}
+
 const insertBashHeader = (embeddedLanguageDoc: EmbeddedLanguageDoc): void => {
-  insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, 0, 0, bashHeader)
+  insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, 0, 0, getBashHeader(embeddedLanguageDoc.originalUri))
 }
 
 const insertBashTools = (embeddedLanguageDoc: EmbeddedLanguageDoc, pokyFolder: string): void => {

--- a/server/src/embedded-languages/python-support.ts
+++ b/server/src/embedded-languages/python-support.ts
@@ -18,9 +18,8 @@ export const imports = [
   'd = bb.data_smart.DataSmart()',
   'e = bb.event.Event()',
   'e.data = d',
-  'import os',
-  ''
-].join('\n')
+  'import os'
+]
 
 export const generatePythonEmbeddedLanguageDoc = (
   textDocument: TextDocument,
@@ -42,8 +41,21 @@ export const generatePythonEmbeddedLanguageDoc = (
         return true
     }
   })
-  insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, 0, 0, imports)
+  insertHeader(embeddedLanguageDoc)
   return embeddedLanguageDoc
+}
+
+export const getPythonHeader = (originalUri: string): string => {
+  const headers = [
+    `# Original BitBake document: ${originalUri}`,
+    ...imports,
+    ''
+  ].join('\n')
+  return headers
+}
+
+const insertHeader = (embeddedLanguageDoc: EmbeddedLanguageDoc): void => {
+  insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, 0, 0, getPythonHeader(embeddedLanguageDoc.originalUri))
 }
 
 const handlePythonFunctionDefinition = (node: SyntaxNode, embeddedLanguageDoc: EmbeddedLanguageDoc): void => {


### PR DESCRIPTION
Only commit still relevant on #237 .

This simply adds the uri of the original document as a comment on the embedded language document in order to ease debugging.