### PR TITLE
Chore: Update tree-sitter-bitbake

### DIFF
--- a/server/src/semanticTokens.ts
+++ b/server/src/semanticTokens.ts
@@ -132,11 +132,7 @@ export function getBitBakeParsedTokens (uri: string): ParsedToken[] {
       length: Math.max(node.endPosition.column - node.startPosition.column, 0)
     }
 
-    if (
-      TreeSitterUtils.isVariableReference(node) &&
-      // bash variable expansions are handled by getBashParsedTokens
-      !analyzer.isInsideBashRegion(node)
-    ) {
+    if (TreeSitterUtils.isVariableReference(node)) {
       resultTokens.push({
         ...nodeRange,
         tokenType: TOKEN_LEGEND.types.variable,

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -208,8 +208,7 @@ export default class Analyzer {
 
     TreeSitterUtils.forEach(bitBakeTree.rootNode, (node) => {
       // Bash variable expansions are handled separately in getSymbolsFromBashTree
-      const isInsideBashRegion = this.isInsideBashRegion(node)
-      const isNonEmptyVariableExpansion = (node.type === 'identifier' && node.parent?.type === 'variable_expansion' && !isInsideBashRegion)
+      const isNonEmptyVariableExpansion = (node.type === 'identifier' && node.parent?.type === 'variable_expansion')
       const isPythonDatastoreVariable = this.isPythonDatastoreVariable(node)
       const isPythonFunctionDefinition = node.type === 'python_function_definition'
       // Note this does not detect python functions that are not called. Not sure how it could be done.
@@ -693,10 +692,6 @@ export default class Analyzer {
     column: number
   ): boolean {
     const n = this.bitBakeNodeAtPoint(uri, line, column)
-    if (n !== null && this.isInsideBashRegion(n)) {
-      // Bash variable expansions are handled with isBashVariableName
-      return false
-    }
     // since @1.0.2 the tree-sitter gives empty variable expansion (e.g. `VAR = "${}""`) the type "variable_expansion". But the node type returned from bitBakeNodeAtPoint() at the position between "${" and "}" is of type "${" which is the result from descendantForPosition() (It returns the smallest node containing the given postion). In this case, the parent node has type "variable_expansion". Hence, we have n?.parent?.type === 'variable_expansion' below. The second expression after the || will be true if it encounters non-empty variable expansion syntax. e.g. `VAR = "${A}". Note that inline python with ${@} has type "inline_python"
     return n?.parent?.type === 'variable_expansion' || (n?.type === 'identifier' && n?.parent?.type === 'variable_expansion')
   }

--- a/server/tree-sitter-bitbake.info
+++ b/server/tree-sitter-bitbake.info
@@ -1,2 +1,2 @@
-"https://api.github.com/repos/idillon-sfl/tree-sitter-bitbake/git/commits/c69337c5c8f374613fb13f2dc8738e7827353084"
+"https://api.github.com/repos/idillon-sfl/tree-sitter-bitbake/git/commits/821169a172bfe3c7125927ca151e299a1f43759b"
 tree-sitter-cli "^0.22.6"


### PR DESCRIPTION
This fixes nested variable expansions in shell regions
```
cmake_runcmake_build() {
	bbnote ${DESTDIR:+DESTDIR=${DESTDIR} }${CMAKE_VERBOSE} cmake --build '${B}' "$@" -- ${EXTRA_OECMAKE_BUILD}
	eval ${DESTDIR:+DESTDIR=${DESTDIR} }${CMAKE_VERBOSE} cmake --build '${B}' "$@" -- ${EXTRA_OECMAKE_BUILD}
}
```

Here's a test I added: https://github.com/idillon-sfl/tree-sitter-bitbake/blob/821169a172bfe3c7125927ca151e299a1f43759b/test/corpus/shell.txt#L45

Note the new version of tree-sitter-bitbake does not handle shell variable expansions anymore. It was a lot of trouble, and we now use tree-sitter-bash instead for those.