### PR TITLE
Fix: pythonDatastoreVariableSymbols sometimes misses variables

### DIFF
--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -45,7 +45,8 @@ export async function onCompletionHandler (textDocumentPositionParams: TextDocum
 
   logger.debug(`[onCompletion] current word: ${word}`)
 
-  if (analyzer.isInsideBashRegion(documentUri, wordPosition.line, wordPosition.character)) {
+  const bitBakeNode = analyzer.bitBakeNodeAtPoint(documentUri, wordPosition.line, wordPosition.character)
+  if (bitBakeNode !== null && analyzer.isInsideBashRegion(bitBakeNode)) {
     return getBashCompletionItems(documentUri, word, wordPosition)
   }
 

--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -212,7 +212,8 @@ function getBashCompletionItems (documentUri: string, word: string | null, wordP
 }
 
 function getPythonCompletionItems (documentUri: string, word: string | null, wordPosition: Position): CompletionItem[] {
-  if (analyzer.isPythonDatastoreVariable(documentUri, wordPosition.line, wordPosition.character, true)) {
+  const bitbakeNode = analyzer.bitBakeNodeAtPoint(documentUri, wordPosition.line, wordPosition.character)
+  if (bitbakeNode !== null && analyzer.isPythonDatastoreVariable(documentUri, bitbakeNode, true)) {
     const symbolCompletionItems = getSymbolCompletionItems(word)
     return mergeArraysDistinctly(
       (completionItem) => completionItem.label,

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -30,7 +30,8 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
 
   // Show documentation of a bitbake variable
   // Triggers on global declaration expressions like "VAR = 'foo'" and inside variable expansion like "FOO = ${VAR}" but skip the ones like "python VAR(){}"
-  const canShowHoverDefinitionForVariableName: boolean = (analyzer.getGlobalDeclarationSymbols(textDocument.uri).some((symbol) => symbol.name === word) && analyzer.isIdentifierOfVariableAssignment(params)) || analyzer.isBitBakeVariableExpansion(textDocument.uri, position.line, position.character) || analyzer.isPythonDatastoreVariable(textDocument.uri, position.line, position.character) || analyzer.isBashVariableName(textDocument.uri, position.line, position.character)
+  const bitbakeNode = analyzer.bitBakeNodeAtPoint(textDocument.uri, position.line, position.character)
+  const canShowHoverDefinitionForVariableName: boolean = (analyzer.getGlobalDeclarationSymbols(textDocument.uri).some((symbol) => symbol.name === word) && analyzer.isIdentifierOfVariableAssignment(params)) || analyzer.isBitBakeVariableExpansion(textDocument.uri, position.line, position.character) || (bitbakeNode !== null && analyzer.isPythonDatastoreVariable(textDocument.uri, bitbakeNode)) || analyzer.isBashVariableName(textDocument.uri, position.line, position.character)
   if (canShowHoverDefinitionForVariableName) {
     const found = [
       ...bitBakeDocScanner.bitbakeVariableInfo.filter((bitbakeVariable) => !bitBakeDocScanner.yoctoVariableInfo.some(yoctoVariable => yoctoVariable.name === bitbakeVariable.name)),

--- a/server/src/embedded-languages/general-support.ts
+++ b/server/src/embedded-languages/general-support.ts
@@ -36,7 +36,8 @@ export const getEmbeddedLanguageTypeOnPosition = (uriString: string, position: P
   }
   // isInsidePythonRegion must be tested before isInsideBashRegion because inline_python could be inside a bash region
   // In that case, the position would be first inside a python region, then inside a bash region, but it would be Python code
-  if (analyzer.isInsideBashRegion(uriString, position.line, position.character)) {
+  const bitBakeNode = analyzer.bitBakeNodeAtPoint(uriString, position.line, position.character)
+  if (bitBakeNode !== null && analyzer.isInsideBashRegion(bitBakeNode)) {
     return 'bash'
   }
   return undefined

--- a/server/src/semanticTokens.ts
+++ b/server/src/semanticTokens.ts
@@ -135,7 +135,7 @@ export function getBitBakeParsedTokens (uri: string): ParsedToken[] {
     if (
       TreeSitterUtils.isVariableReference(node) &&
       // bash variable expansions are handled by getBashParsedTokens
-      !analyzer.isInsideBashRegion(uri, node.startPosition.row, node.startPosition.column)
+      !analyzer.isInsideBashRegion(node)
     ) {
       resultTokens.push({
         ...nodeRange,

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -208,7 +208,7 @@ export default class Analyzer {
 
     TreeSitterUtils.forEach(bitBakeTree.rootNode, (node) => {
       // Bash variable expansions are handled separately in getSymbolsFromBashTree
-      const isInsideBashRegion = this.isInsideBashRegion(uri, node.startPosition.row, node.startPosition.column)
+      const isInsideBashRegion = this.isInsideBashRegion(node)
       const isNonEmptyVariableExpansion = (node.type === 'identifier' && node.parent?.type === 'variable_expansion' && !isInsideBashRegion)
       const isPythonDatastoreVariable = this.isPythonDatastoreVariable(uri, node)
       const isPythonFunctionDefinition = node.type === 'python_function_definition'
@@ -588,11 +588,9 @@ export default class Analyzer {
   }
 
   public isInsideBashRegion (
-    uri: string,
-    line: number,
-    column: number
+    node: SyntaxNode
   ): boolean {
-    let n = this.bitBakeNodeAtPoint(uri, line, column)
+    let n: SyntaxNode | null = node
     if (n !== null && this.isBuggyIdentifier(n)) {
       return false
     }
@@ -697,11 +695,11 @@ export default class Analyzer {
     line: number,
     column: number
   ): boolean {
-    if (this.isInsideBashRegion(uri, line, column)) {
+    const n = this.bitBakeNodeAtPoint(uri, line, column)
+    if (n !== null && this.isInsideBashRegion(n)) {
       // Bash variable expansions are handled with isBashVariableName
       return false
     }
-    const n = this.bitBakeNodeAtPoint(uri, line, column)
     // since @1.0.2 the tree-sitter gives empty variable expansion (e.g. `VAR = "${}""`) the type "variable_expansion". But the node type returned from bitBakeNodeAtPoint() at the position between "${" and "}" is of type "${" which is the result from descendantForPosition() (It returns the smallest node containing the given postion). In this case, the parent node has type "variable_expansion". Hence, we have n?.parent?.type === 'variable_expansion' below. The second expression after the || will be true if it encounters non-empty variable expansion syntax. e.g. `VAR = "${A}". Note that inline python with ${@} has type "inline_python"
     return n?.parent?.type === 'variable_expansion' || (n?.type === 'identifier' && n?.parent?.type === 'variable_expansion')
   }

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -210,7 +210,7 @@ export default class Analyzer {
       // Bash variable expansions are handled separately in getSymbolsFromBashTree
       const isInsideBashRegion = this.isInsideBashRegion(uri, node.startPosition.row, node.startPosition.column)
       const isNonEmptyVariableExpansion = (node.type === 'identifier' && node.parent?.type === 'variable_expansion' && !isInsideBashRegion)
-      const isPythonDatastoreVariable = this.isPythonDatastoreVariable(uri, node.startPosition.row, node.startPosition.column)
+      const isPythonDatastoreVariable = this.isPythonDatastoreVariable(uri, node)
       const isPythonFunctionDefinition = node.type === 'python_function_definition'
       // Note this does not detect python functions that are not called. Not sure how it could be done.
       // This also ignores method calls, but on purpose.
@@ -632,15 +632,13 @@ export default class Analyzer {
 
   public isPythonDatastoreVariable (
     uri: string,
-    line: number,
-    column: number,
+    n: Parser.SyntaxNode,
     // Whether or not the opening quote should be considered as part of the variable
     // We want to be able to suggest completion items as the user open the quotes
     // However, when the user hover on the variable, the quotes are not part of the variable
     includeOpeningQuote: boolean = false
   ): boolean {
-    const n = this.bitBakeNodeAtPoint(uri, line, column)
-    if (!this.isInsidePythonRegion(uri, line, column)) {
+    if (!this.isInsidePythonRegion(uri, n.startPosition.row, n.startPosition.column)) {
       return false
     }
 
@@ -828,7 +826,7 @@ export default class Analyzer {
     return tree.rootNode.descendantForPosition({ row: line, column })
   }
 
-  private bitBakeNodeAtPoint (
+  public bitBakeNodeAtPoint (
     uri: string,
     line: number,
     column: number


### PR DESCRIPTION
I noticed pythonDatastoreVariableSymbols would give inconsistent results when the document is edited.

Steps to reproduce:
1. Create the following document:
``` bitbake
python() {
    d.getVar('DESCRIPTION')
}
```
3. Restart VS Code (just making sure to have a clean state) and open the document.
4. Try to hover `DESCRIPTION`. It works.
5. Try to rename `DESCRIPTION`. It works.
6. Change the quotes:
``` bitbake
python() {
    d.getVar("DESCRIPTION")
}
```
7. Try to hover `DESCRIPTION`. It still works.
8. Try to rename `DESCRIPTION`: `The element can't be renamed` (???)
9. Save the document and restart VS Code.
10. Try to rename `DESCRIPTION`: It works.

~~Not sure why this happens (`bitBakeNodeAtPoint` gives a different result after the edition), but here's a fix.~~

Problem has been understood: bitBakeNodeAtPoint uses the tree registered in uriToAnalyzedDocument. However, getSymbolsFromBitBakeTree is called before the new tree is registered. Therefore, if bitBakeNodeAtPoint is called whithin getSymbolsFromBitBakeTree, it will give a result from the previous tree. For that reason, it must be avoided.