### PR TITLE
Chore: analyzer.isInsidePythonRegion takes a node for parameter

### DIFF
--- a/integration-tests/src/tests/references.test.ts
+++ b/integration-tests/src/tests/references.test.ts
@@ -58,8 +58,8 @@ suite('Bitbake References Test Suite', () => {
       new vscode.Range(0, 0, 0, 3),
       new vscode.Range(1, 7, 1, 10),
       // For unknown reason, Python datastore variables fail in integration tests
-      // new vscode.Range(4, 14, 4, 17),
-      // new vscode.Range(8, 18, 8, 21),
+      new vscode.Range(4, 14, 4, 17),
+      new vscode.Range(8, 18, 8, 21),
       new vscode.Range(9, 4, 9, 7),
       new vscode.Range(9, 10, 9, 13),
       new vscode.Range(9, 16, 9, 19)

--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -50,7 +50,7 @@ export async function onCompletionHandler (textDocumentPositionParams: TextDocum
     return getBashCompletionItems(documentUri, word, wordPosition)
   }
 
-  if (analyzer.isInsidePythonRegion(documentUri, wordPosition.line, wordPosition.character)) {
+  if (bitBakeNode !== null && analyzer.isInsidePythonRegion(bitBakeNode)) {
     return getPythonCompletionItems(documentUri, word, wordPosition)
   }
 
@@ -214,7 +214,7 @@ function getBashCompletionItems (documentUri: string, word: string | null, wordP
 
 function getPythonCompletionItems (documentUri: string, word: string | null, wordPosition: Position): CompletionItem[] {
   const bitbakeNode = analyzer.bitBakeNodeAtPoint(documentUri, wordPosition.line, wordPosition.character)
-  if (bitbakeNode !== null && analyzer.isPythonDatastoreVariable(documentUri, bitbakeNode, true)) {
+  if (bitbakeNode !== null && analyzer.isPythonDatastoreVariable(bitbakeNode, true)) {
     const symbolCompletionItems = getSymbolCompletionItems(word)
     return mergeArraysDistinctly(
       (completionItem) => completionItem.label,

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -31,7 +31,7 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
   // Show documentation of a bitbake variable
   // Triggers on global declaration expressions like "VAR = 'foo'" and inside variable expansion like "FOO = ${VAR}" but skip the ones like "python VAR(){}"
   const bitbakeNode = analyzer.bitBakeNodeAtPoint(textDocument.uri, position.line, position.character)
-  const canShowHoverDefinitionForVariableName: boolean = (analyzer.getGlobalDeclarationSymbols(textDocument.uri).some((symbol) => symbol.name === word) && analyzer.isIdentifierOfVariableAssignment(params)) || analyzer.isBitBakeVariableExpansion(textDocument.uri, position.line, position.character) || (bitbakeNode !== null && analyzer.isPythonDatastoreVariable(textDocument.uri, bitbakeNode)) || analyzer.isBashVariableName(textDocument.uri, position.line, position.character)
+  const canShowHoverDefinitionForVariableName: boolean = (analyzer.getGlobalDeclarationSymbols(textDocument.uri).some((symbol) => symbol.name === word) && analyzer.isIdentifierOfVariableAssignment(params)) || analyzer.isBitBakeVariableExpansion(textDocument.uri, position.line, position.character) || (bitbakeNode !== null && analyzer.isPythonDatastoreVariable(bitbakeNode)) || analyzer.isBashVariableName(textDocument.uri, position.line, position.character)
   if (canShowHoverDefinitionForVariableName) {
     const found = [
       ...bitBakeDocScanner.bitbakeVariableInfo.filter((bitbakeVariable) => !bitBakeDocScanner.yoctoVariableInfo.some(yoctoVariable => yoctoVariable.name === bitbakeVariable.name)),

--- a/server/src/embedded-languages/general-support.ts
+++ b/server/src/embedded-languages/general-support.ts
@@ -31,13 +31,17 @@ export const generateEmbeddedLanguageDocs = (textDocument: TextDocument, pokyFol
 }
 
 export const getEmbeddedLanguageTypeOnPosition = (uriString: string, position: Position): EmbeddedLanguageType | undefined => {
-  if (analyzer.isInsidePythonRegion(uriString, position.line, position.character)) {
+  const bitBakeNode = analyzer.bitBakeNodeAtPoint(uriString, position.line, position.character)
+  if (bitBakeNode === null) {
+    return undefined
+  }
+
+  if (analyzer.isInsidePythonRegion(bitBakeNode)) {
     return 'python'
   }
   // isInsidePythonRegion must be tested before isInsideBashRegion because inline_python could be inside a bash region
   // In that case, the position would be first inside a python region, then inside a bash region, but it would be Python code
-  const bitBakeNode = analyzer.bitBakeNodeAtPoint(uriString, position.line, position.character)
-  if (bitBakeNode !== null && analyzer.isInsideBashRegion(bitBakeNode)) {
+  if (analyzer.isInsideBashRegion(bitBakeNode)) {
     return 'bash'
   }
   return undefined


### PR DESCRIPTION
Some `nodeAtPoint` was forgotten in PR #283 . `isPythonDatastoreVariable` also calls `isInsidePythonRegion`