### PR TITLE
Chore: Update CI, scripts and README on wasm

### DIFF
--- a/.github/workflows/update-tree-sitter-parser-info-file.yml
+++ b/.github/workflows/update-tree-sitter-parser-info-file.yml
@@ -1,7 +1,7 @@
 # Inspired by bash-language-server under MIT license
 # Reference: https://github.com/bash-lsp/bash-language-server/blob/8c42218c77a9451b308839f9a754abde901323d5/.github/workflows/upgrade-tree-sitter.yml
 
-name: Update Tree Sitter WASM File
+name: Update Tree Sitter Parser Info File
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ on:
     - cron: '0 12 * * 2'
 
 jobs:
-  update-tree-sitter-wasm:
+  update-tree-sitter-parser-info-file:
 
     runs-on: ubuntu-latest
 
@@ -45,15 +45,13 @@ jobs:
     - name: Install Dependencies
       run: npm install
 
-    - name: Update tree-sitter wasm
-      run: bash scripts/update-${{ matrix.tree-sitter-name }}-wasm.sh
+    - name: Update tree-sitter parser info file
+      run: bash scripts/update-${{ matrix.tree-sitter-name }}.sh
 
     - name: Verify file changes
       uses: tj-actions/verify-changed-files@v20
       id: verify-changed-files
       with:
-        # The script generates a new wasm file and replaces the existing one. Git will treat it as a different file even it is generated with the same commit and CLI
-        # Hence, we only compare the .info file. It should be enough to tell the difference
         files: |
             server/${{ matrix.tree-sitter-name }}.info
 
@@ -63,9 +61,8 @@ jobs:
       with:
         add-paths: |
           server/${{ matrix.tree-sitter-name }}.info
-          server/${{ matrix.tree-sitter-name }}.wasm
-        title: Auto update ${{ matrix.tree-sitter-name }} wasm file
-        commit-message: Auto update ${{ matrix.tree-sitter-name }} wasm file and parser info
-        branch: update-${{ matrix.tree-sitter-name }}-wasm-file
+        title: Auto update ${{ matrix.tree-sitter-name }} parser info file
+        commit-message: Auto update ${{ matrix.tree-sitter-name }} parser info
+        branch: update-${{ matrix.tree-sitter-name }}-parser-info-file
         base: ${{ env.BASE_BRANCH }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/README-DEVELOPER.md
+++ b/README-DEVELOPER.md
@@ -93,7 +93,7 @@ See [the individual integration tests README](integration-tests/README.md).
 ## Tree-sitter
 This extension uses [tree-sitter-bitbake](https://github.com/tree-sitter-grammars/tree-sitter-bitbake) and [tree-sitter-bash](https://github.com/tree-sitter/tree-sitter-bash) to parse the BitBake documents. They are installed with `npm run fetch:wasm`. The versions of tree-sitter-bitbake and tree-sitter-bash are documented in [server/tree-sitter-bitbake.info](server/tree-sitter-bitbake.info) and [server/tree-sitter-bash.info](server/tree-sitter-bash.info) respectively, along with the versions of the tree-sitter-cli that have to be used.
 
-To update the .info files with the latest versions of tree-sitter-bitbake and tree-sitter-bash, it is recommended to use the scripts [scripts/update-tree-sitter-bitbake-wasm.sh](scripts/update-tree-sitter-bitbake-wasm.sh) and [scripts/update-tree-sitter-bash-wasm.sh](scripts/update-tree-sitter-bash-wasm.sh). The GitHub workflow [update-tree-sitter-wasm-file.yml](.github/workflows/update-tree-sitter-wasm-file.yml) is already responsible for doing it automatically.
+To update the .info files with the latest versions of tree-sitter-bitbake and tree-sitter-bash, it is recommended to use the scripts [scripts/update-tree-sitter-bitbake.sh](scripts/update-tree-sitter-bitbake.sh) and [scripts/update-tree-sitter-bash.sh](scripts/update-tree-sitter-bash.sh). The GitHub workflow [update-tree-sitter-parser-info-file.yml](.github/workflows/update-tree-sitter-parser-info-file.yml) is already responsible for doing it automatically.
 
 After updating the .info files, it is required to call `npm run fetch:wasm` in order to rebuild the Wasm files.
 

--- a/scripts/update-tree-sitter-bash-wasm.sh
+++ b/scripts/update-tree-sitter-bash-wasm.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-. "$(dirname "$0")/update-tree-sitter-wasm.sh"
-
-repo_name=tree-sitter-bash
-repo_owner=tree-sitter
-
-update-tree-sitter-wasm $repo_name $repo_owner

--- a/scripts/update-tree-sitter-bash.sh
+++ b/scripts/update-tree-sitter-bash.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+. "$(dirname "$0")/update-tree-sitter.sh"
+
+repo_name=tree-sitter-bash
+repo_owner=tree-sitter
+
+update-tree-sitter $repo_name $repo_owner

--- a/scripts/update-tree-sitter-bitbake-wasm.sh
+++ b/scripts/update-tree-sitter-bitbake-wasm.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-. "$(dirname "$0")/update-tree-sitter-wasm.sh"
-
-repo_name=tree-sitter-bitbake
-repo_owner=tree-sitter-grammars
-
-update-tree-sitter-wasm $repo_name $repo_owner

--- a/scripts/update-tree-sitter-bitbake.sh
+++ b/scripts/update-tree-sitter-bitbake.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+. "$(dirname "$0")/update-tree-sitter.sh"
+
+repo_name=tree-sitter-bitbake
+repo_owner=tree-sitter-grammars
+
+update-tree-sitter $repo_name $repo_owner

--- a/scripts/update-tree-sitter.sh
+++ b/scripts/update-tree-sitter.sh
@@ -5,7 +5,7 @@
 
 set -euox pipefail
 
-update-tree-sitter-wasm() {
+update-tree-sitter() {
     local repo_name=$1
     local repo_owner=$2
     local info_file="$repo_name.info"


### PR DESCRIPTION
We no longer track and update the wasm files in our project, related terms on wasm should be updated.

This should solve the issue: https://github.com/yoctoproject/vscode-bitbake/actions/runs/10162417152/job/28103046768#step:7:65

Ticket: 15307