### PR TITLE
Chore: Optimize update-ref script

### DIFF
--- a/scripts/update-ref.sh
+++ b/scripts/update-ref.sh
@@ -2,109 +2,52 @@
 
 # Update the fetch-poky.sh script
 FILE="scripts/fetch-poky.sh"
-TMP_FILE="tmp.txt"
-tail -n +6 $FILE > $TMP_FILE
-
-echo "#!/bin/bash" > $FILE
-echo "" >> $FILE
-
-git clone --depth 1 --filter=blob:none --sparse https://github.com/yoctoproject/poky.git
-cd poky
-git fetch --tags
-TMP_TAG=$(git tag | grep "yocto-" | tail -n 1) # There is a tag: yocto_1.5_M5.rc8 which will take the tail, thus adding a hyphen
-LASTEST_RELEASE=$(git show $TMP_TAG | grep commit | sed "s/^commit //")
-echo "# Tag: $TMP_TAG" >> ../$FILE
-echo "COMMIT=$LASTEST_RELEASE" >> ../$FILE
-echo "" >> ../$FILE
-cd ..
-rm -rf poky
-
-cat $TMP_FILE >> $FILE
-rm $TMP_FILE
+LATEST_REF=$(git ls-remote --tags https://github.com/yoctoproject/poky.git | grep "yocto-" | tail -n 1)
+LATEST_COMMIT=$(echo $LATEST_REF | awk '{print $1}')
+LATEST_TAG=$(echo $LATEST_REF | awk '{print $2}' |  sed -e "s/refs\\/tags\\///" -e "s/\^.*//")
+sed -i $FILE \
+    -e "s/^\(# Tag: \).*/\1$LATEST_TAG/" \
+    -e "s/^\(COMMIT=\).*/\1$LATEST_COMMIT/"
 
 # Update the version.ts
-DEST="integration-tests/src/utils/version.ts"
+FILE="integration-tests/src/utils/version.ts"
 
-# Keep the header
-TOTAL_LINES=$(wc -l < $DEST)
-LINES_TO_KEEP=$(($TOTAL_LINES - 2))
-TMP="tmp.ts"
-head -n $LINES_TO_KEEP $DEST > $TMP
+LATEST_COMMIT=$(git ls-remote --refs --sort=-v:refname https://github.com/bash-lsp/bash-language-server | grep client | head -n 1 | awk '{print $2}' | sed s/refs\\/tags\\/vscode-client-//)
+sed -e "s/^\(export const bashVersion =\).*/\1 '$LATEST_COMMIT'/" -i $FILE
 
-git clone --depth 1 --filter=blob:none --sparse https://github.com/bash-lsp/bash-language-server
-cd bash-language-server
-git fetch --tags
-echo "export const bashVersion = '$(git tag --sort=-v:refname | head -n 1 | sed "s/^vscode-client-//")'" >> ../$TMP
-cd ..
-rm -rf bash-language-server
-
-git clone --depth 1 --filter=blob:none --sparse https://github.com/Microsoft/vscode-python
-cd vscode-python
-git fetch --tags
-echo "export const pythonVersion = '$(git tag --sort=-v:refname | head -n 1 | sed "s/^v//")'" >> ../$TMP
-cd ..
-rm -rf vscode-python
-
-cp $TMP $DEST
-rm $TMP
+LATEST_COMMIT=$(git ls-remote --refs --sort=-v:refname https://github.com/Microsoft/vscode-python | head -n 1 |  awk '{print $2}' | sed s/refs\\/tags\\/v//)
+sed -e "s/^\(export const pythonVersion =\).*/\1 '$LATEST_COMMIT'/" -i $FILE
 
 # Update the fetch-docs.sh script
 FILE="scripts/fetch-docs.sh"
-TMP_FILE="tmp.txt"
-tail -n +8 $FILE > $TMP_FILE
 
-echo "#!/bin/bash" > $FILE
-echo "" >> $FILE
+LATEST_REF=$(git ls-remote --refs --sort=-v:refname https://github.com/openembedded/bitbake.git | head -n 1)
+LATEST_COMMIT=$(echo $LATEST_REF | awk '{print $1}')
+LATEST_TAG=$(echo $LATEST_REF | awk '{print $2}' | sed s/refs\\/tags\\///)
+sed -i $FILE \
+    -e "s/^\(# Tag: \).*/\1$LATEST_TAG/" \
+    -e "s/^\(BITBAKE_DOCS_COMMIT=\).*/\1$LATEST_COMMIT/" 
 
-git clone --depth 1 --filter=blob:none --sparse https://github.com/openembedded/bitbake.git
-cd bitbake
-git fetch --tags
-TMP_TAG=$(git tag --sort=-v:refname | head -n 1)
-LASTEST_RELEASE=$(git show $TMP_TAG | grep commit | sed "s/^commit //")
-echo "# Tag: $TMP_TAG" >> ../$FILE
-echo "BITBAKE_DOCS_COMMIT=$LASTEST_RELEASE" >> ../$FILE
-cd ..
-rm -rf bitbake
+LATEST_REF=$(git ls-remote --refs --sort=-v:refname https://git.yoctoproject.org/yocto-docs | head -n 1)
+LATEST_COMMIT=$(echo $LATEST_REF | awk '{print $1}')
+LATEST_TAG=$(echo $LATEST_REF | awk '{print $2}' | sed s/refs\\/tags\\///)
+sed -i $FILE \
+    -e "s/^\(# Tag: \).*/\1$LATEST_TAG/" \
+    -e "s/^\(YOCTO_DOCS_COMMIT=\).*/\1$LATEST_COMMIT/"
 
-git clone --depth 1 --filter=blob:none --sparse https://git.yoctoproject.org/yocto-docs
-cd yocto-docs
-git fetch --tags
-TMP_TAG=$(git tag --sort=-v:refname | head -n 1)
-LASTEST_RELEASE=$(git show $TMP_TAG | grep commit | sed "s/^commit //")
-echo "# Tag: $TMP_TAG" >> ../$FILE
-echo "YOCTO_DOCS_COMMIT=$LASTEST_RELEASE" >> ../$FILE
-echo "" >> ../$FILE
-cd ..
-rm -rf yocto-docs
+# Update vscodeVersion in runTest.ts
+FILE="integration-tests/src/runTest.ts"
 
-git clone --depth 1 --filter=blob:none --sparse https://github.com/microsoft/vscode.git
-cd vscode
-git fetch --tags
-TMP_TAG=$(git tag --sort=-v:refname | grep -E '^[0-9.]+$' | head -n 1)
-sed -e "s/vscodeVersion = '.*'/vscodeVersion = '$TMP_TAG'/" -i ../integration-tests/src/runTest.ts
-cd ..
-rm -rf vscode
-
-cat $TMP_FILE >> $FILE
-rm $TMP_FILE
+LATEST_TAG=$(git ls-remote --tags --sort=-v:refname https://github.com/microsoft/vscode.git | grep "refs/tags/[0-9.]" | head -n 1 | awk '{print $2}' | sed s/refs\\/tags\\///)
+sed -e "s/vscodeVersion = '.*'/vscodeVersion = '$LATEST_TAG'/" -i $FILE
 
 # Update the fetch-spdx-licenses.sh script
 FILE="scripts/fetch-spdx-licenses.sh"
-TMP_FILE="tmp.txt"
-tail -n +5 $FILE > $TMP_FILE
 
-echo "#!/bin/bash" > $FILE
-echo "" >> $FILE
+LATEST_REF=$(git ls-remote --refs --sort=-v:refname https://github.com/spdx/license-list-data.git | head -n 1)
+LATEST_COMMIT=$(echo $LATEST_REF | awk '{print $1}')
+LATEST_TAG=$(echo $LATEST_REF | awk '{print $2}' | sed s/refs\\/tags\\///)
+sed -i $FILE \
+    -e "s/^\(# Tag: \).*/\1$LATEST_TAG/" \
+    -e "s/^\(SPDX_LICENSES_COMMIT=\).*/\1$LATEST_COMMIT/"
 
-git clone --depth 1 --filter=blob:none --sparse https://github.com/spdx/license-list-data.git
-cd license-list-data
-git fetch --tags
-TMP_TAG=$(git tag --sort=-v:refname | head -n 1)
-LATEST_RELEASE=$(git show $TMP_TAG | grep commit -m 1 | sed "s/^commit //")
-echo "# Tag: $TMP_TAG" >> ../$FILE
-echo "SPDX_LICENSES_COMMIT=$LATEST_RELEASE" >> ../$FILE
-cd ..
-rm -rf license-list-data
-
-cat $TMP_FILE >> $FILE
-rm $TMP_FILE


### PR DESCRIPTION
Use `git ls-remote` command to fetch refs or tags without cloning the projects first. This script now only takes a few seconds to complete.