### PR TITLE
Chore: Update tree-sitter-bitbake

### DIFF
--- a/server/tree-sitter-bitbake.info
+++ b/server/tree-sitter-bitbake.info
@@ -1,2 +1,2 @@
-"https://api.github.com/repos/idillon-sfl/tree-sitter-bitbake/git/commits/821169a172bfe3c7125927ca151e299a1f43759b"
+"https://api.github.com/repos/idillon-sfl/tree-sitter-bitbake/git/commits/bc577daab90b551ad1dc42c3373db2cb7c43857d"
 tree-sitter-cli "^0.22.6"


### PR DESCRIPTION
The new version fixes shell variable expansions outside of strings:
```
foo() {
  echo ${bar}
}
```

Note [the commit](https://github.com/tree-sitter-grammars/tree-sitter-bitbake/pull/23/commits/3461edde4442efb1e4043effa9b6f626108620f6) that fixes the issue on the tree-sitter-bitbake's branch claims to fix the opposite (variable expansions *inside* of strings outside of strings). That's because I deleted a commit that "inverted" the issue. The new solution makes sure it works in both cases, and several tests have been added to prevent eventual regressions.
