### PR TITLE
Fix: Adapt devtool status parsing for new Yocto releases

### DIFF
--- a/client/src/driver/BitBakeProjectScanner.ts
+++ b/client/src/driver/BitBakeProjectScanner.ts
@@ -393,7 +393,7 @@ You should adjust your docker volumes to use the same URIs as those present on y
   private async scanDevtoolWorkspaces (): Promise<void> {
     this._bitbakeScanResult._workspaces = new Array < DevtoolWorkspaceInfo >()
     const output = await this.executeBitBakeCommand('devtool status')
-    const regex = /^([^\s]+):\s([^\s]+)$/gm
+    const regex = /^([^\s]+):\s([^\s]+)(?:\s\([^\s]+\))?$/gm
     let match
     while ((match = regex.exec(output)) !== null) {
       this._bitbakeScanResult._workspaces.push({ name: match[1], path: match[2] })


### PR DESCRIPTION
The current master branch also outputs the .bb location in the devtool status output. It broke our parsing which could not detect the workspaces.

The regex was updated to optionally match the .bb location. But we don't capture it since we always run a complete scan in the end. This could be way for future optimizations.