### PR TITLE
UI: Add a sanity check for the working directory

### DIFF
--- a/client/src/__tests__/unit-tests/driver/eSDKMode.test.ts
+++ b/client/src/__tests__/unit-tests/driver/eSDKMode.test.ts
@@ -40,12 +40,12 @@ describe('Devtool eSDK Mode Test Suite', () => {
     const bitbakeDriver = new BitbakeDriver()
     const bitbakeSettings: BitbakeSettings = {
       pathToBitbakeFolder: __dirname,
-      workingDirectory: '/path/to/workspace',
+      workingDirectory: __dirname,
       commandWrapper: '',
       pathToEnvScript: 'fakeEnvScript',
       pathToBuildFolder: 'nonexistent'
     }
-    bitbakeDriver.loadSettings(bitbakeSettings, '/path/to/workspace')
+    bitbakeDriver.loadSettings(bitbakeSettings, __dirname)
     const bitbakeTerminalSpy = jest.spyOn(BitbakeTerminal, 'runBitbakeTerminalCustomCommand').mockImplementation(async () => undefined as any)
     const bitbakeExecutionSpy = jest.spyOn(ProcessUtils, 'finishProcessExecution')
     clientNotificationManager.showBitbakeSettingsError = jest.fn()

--- a/client/src/driver/BitbakeDriver.ts
+++ b/client/src/driver/BitbakeDriver.ts
@@ -125,6 +125,12 @@ export class BitbakeDriver {
       return false
     }
 
+    if ((this.bitbakeSettings.workingDirectory != null) && !fs.existsSync(this.bitbakeSettings.workingDirectory)) {
+      // If it is not defined, then we will use the workspace folder which is always valid
+      clientNotificationManager.showBitbakeSettingsError('Working directory does not exist.')
+      return false
+    }
+
     // We could test for devtool and bitbake to know if we are in an eSDK or not
     const command = 'which devtool bitbake || true'
     const process = runBitbakeTerminalCustomCommand(this, command, 'Bitbake: Sanity test', true)


### PR DESCRIPTION
If the user configures a faulty working directory, the error message was not very clear. This very simple check will show a more clear message early on.

Closes #306
