### PR TITLE
Fix: Fetch WASM and SPDX licenses in NPM package in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,6 +140,8 @@ jobs:
             client/package-lock.json
       - run: npm install
       - run: npm run fetch:docs
+      - run: npm run fetch:wasm
+      - run: npm run fetch:spdx-licenses
       - run: cd server && npm pack
       - name: Archive server package
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
With the fetch script refactoring, we had a regression in the node package of the CI wich missed these resources.

Fixes #308 