### PR TITLE
Fix: Pass buildConfigurations environment to terminal profile

### DIFF
--- a/client/src/driver/BitBakeProjectScanner.ts
+++ b/client/src/driver/BitBakeProjectScanner.ts
@@ -238,7 +238,7 @@ export class BitBakeProjectScanner {
     }
     if (this.containerMountPoint === undefined && !hostToContainer) {
       // Should only be called through scanAvailableLayers()
-      const hostWorkdir = this.bitbakeDriver?.bitbakeSettings.workingDirectory
+      const hostWorkdir = this.bitbakeDriver?.getBuildConfig('workingDirectory')
       if (hostWorkdir === undefined) {
         throw new Error('hostWorkdir is undefined')
       }

--- a/client/src/driver/BitbakeDriver.ts
+++ b/client/src/driver/BitbakeDriver.ts
@@ -79,11 +79,15 @@ export class BitbakeDriver {
 
   prepareCommand (command: string): {
     shell: string
+    shellEnv: Record<string, string>
     script: string
+    workingDirectory: string | undefined
   } {
     const shell = process.env.SHELL ?? '/bin/sh'
+    const shellEnv = this.getBuildConfig('shellEnv')
     const script = this.composeBitbakeScript(command)
-    return { shell, script }
+    const workingDirectory = this.getBuildConfig('workingDirectory') ?? '.'
+    return { shell, shellEnv, script, workingDirectory }
   }
 
   composeBitbakeScript (command: string): string {

--- a/client/src/driver/BitbakeDriver.ts
+++ b/client/src/driver/BitbakeDriver.ts
@@ -40,7 +40,7 @@ export class BitbakeDriver {
     })
   }
 
-  private getBuildConfig (property: keyof BitbakeBuildConfigSettings): any {
+  getBuildConfig (property: keyof BitbakeBuildConfigSettings): any {
     return getBuildSetting(this.bitbakeSettings, this.activeBuildConfiguration, property)
   }
 
@@ -129,7 +129,7 @@ export class BitbakeDriver {
       return false
     }
 
-    if ((this.bitbakeSettings.workingDirectory != null) && !fs.existsSync(this.bitbakeSettings.workingDirectory)) {
+    if ((this.getBuildConfig('workingDirectory') != null) && !fs.existsSync(this.getBuildConfig('workingDirectory'))) {
       // If it is not defined, then we will use the workspace folder which is always valid
       clientNotificationManager.showBitbakeSettingsError('Working directory does not exist.')
       return false

--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -451,7 +451,7 @@ async function checkIdeSdkAvailable (bitbakeDriver: BitbakeDriver): Promise<bool
 }
 
 function checkIdeSdkConfiguration (bitbakeDriver: BitbakeDriver): boolean {
-  const sdkImage = bitbakeDriver.bitbakeSettings.sdkImage
+  const sdkImage = bitbakeDriver.getBuildConfig('sdkImage')
   return sdkImage !== undefined && sdkImage !== ''
 }
 
@@ -620,7 +620,7 @@ async function devtoolDeployCommand (bitbakeWorkspace: BitbakeWorkspace, bitBake
   const bitbakeDriver = bitBakeProjectScanner.bitbakeDriver
   if (chosenRecipe !== undefined) {
     logger.debug(`Command: devtool-deploy: ${chosenRecipe}`)
-    const sshTarget = bitbakeDriver.bitbakeSettings.sshTarget
+    const sshTarget = bitbakeDriver.getBuildConfig('sshTarget')
     if (sshTarget === undefined || sshTarget === '') {
       clientNotificationManager.showSDKConfigurationError()
       return

--- a/client/src/ui/BitbakeTerminalProfile.ts
+++ b/client/src/ui/BitbakeTerminalProfile.ts
@@ -21,15 +21,15 @@ export class BitbakeTerminalProfileProvider implements vscode.TerminalProfilePro
     // However it's also expected an interactive terminal can stay open on the side.
     // We can't use BitbakeTerminal either because VSCode won't allow it to be interactive.
     const command = this.bitbakeDriver.composeInteractiveCommand()
-    const { shell, script } = this.bitbakeDriver.prepareCommand(command)
-    logger.info(`Spawning Bitbake terminal with ${shell} -c ${script}`)
+    const { shell, shellEnv, script, workingDirectory } = this.bitbakeDriver.prepareCommand(command)
+    logger.info(`Spawning Bitbake terminal in ${workingDirectory} with ${shell} -c "${script}"`)
     return {
       options: {
         name: script,
         shellPath: shell,
         shellArgs: ['-c', script],
-        env: { ...process.env, ...this.bitbakeDriver.bitbakeSettings.shellEnv },
-        cwd: this.bitbakeDriver.bitbakeSettings.workingDirectory,
+        env: shellEnv,
+        cwd: workingDirectory,
         iconPath: vscode.Uri.file(path.resolve(__dirname, '../../images/yocto-view-icon.svg'))
       } satisfies vscode.TerminalOptions
     }


### PR DESCRIPTION
In the specific case of the BitbakeTerminalProfile, the environment used was the one defined in the global settings. It did not take into account the ones defined in the build configurations if defined.