### PR TITLE
Fix: task_deps parsing on newer Yocto versions

### DIFF
--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -267,7 +267,10 @@ async function selectTask (client: LanguageClient, recipe: string): Promise<stri
   const taskDeps = await getVariableValue(client, '_task_deps', recipe)
   let chosenTask: string | undefined
   if (taskDeps !== undefined) {
-    const parsedTaskDeps = JSON.parse(taskDeps.replace(/'/g, '"'))
+    let sanitizedTaskDeps = taskDeps.replace(/'/g, '"')
+    // Remove expressions with special characters like \${create_spdx_source_deps(d)}
+    sanitizedTaskDeps = sanitizedTaskDeps.replace(/, "\\\${.*?}"/g, '')
+    const parsedTaskDeps = JSON.parse(sanitizedTaskDeps)
     /**
      * _task_deps="{'tasks': ['do_patch', ...], 'depends': {...}, ...}"
      */


### PR DESCRIPTION
Two months ago, a commit was introduced that adds tasks with special characters which broke our JSON parsing.

Since this variable is not extended, we might miss some tasks, but at least we keep providing the feature. I could not identify a replacement variable that would contained the expanded list of tasks.

We would need to run a `bitbake list-tasks` but it would be slower.