### PR TITLE
Fix: 'python' highlighting when not a keyword

### DIFF
--- a/client/syntaxes/bitbake.tmLanguage.json
+++ b/client/syntaxes/bitbake.tmLanguage.json
@@ -61,7 +61,7 @@
                     "include": "#python-keywords"
                 },
                 {
-                    "match": "\\b(python|def)\\b(\\(?)",
+                    "match": "(?<=^|^fakeroot +)\\b(python|def)\\b",
                     "captures": {
                         "1": {
                             "name": "storage.type.function.python.bb"

--- a/client/test/grammars/snaps/keywords.bb
+++ b/client/test/grammars/snaps/keywords.bb
@@ -26,3 +26,10 @@ inherit_defer foo2
 
 python(){}
 
+test() {
+    test python
+}
+
+def test() {
+    python = "test"
+}

--- a/client/test/grammars/test-cases/functions.bb
+++ b/client/test/grammars/test-cases/functions.bb
@@ -25,8 +25,8 @@
 >    else:
 >        return "dependency"
  
->python () {
-#^^^^^^ source.bb storage.type.function.python.bb - entity.name.function.python.bb
+python () {
+#<------ source.bb storage.type.function.python.bb - entity.name.function.python.bb
 >    if d.getVar('SOMEVAR') == 'value':
 #         ^^^^^^ source.bb entity.name.function.python.bb
 >      d.setVar('ANOTHERVAR', 'value2')

--- a/client/test/grammars/test-cases/keywords.bb
+++ b/client/test/grammars/test-cases/keywords.bb
@@ -30,15 +30,15 @@
 >INHERIT += "autotools pkgconfig"
 #^^^^^^^ source.bb keyword.control.bb
 
->fakeroot python foo3() {}
-#^^^^^^^^ source.bb keyword.control.bb
-#         ^^^^^^ source.bb storage.type.function.python.bb
+fakeroot python foo3() {}
+#<-------- source.bb keyword.control.bb
+#        ^^^^^^ source.bb storage.type.function.python.bb
 
->python (){}
-#^^^^^^ source.bb storage.type.function.python.bb
+python (){}
+#<------ source.bb storage.type.function.python.bb
 
 >inherit_defer foo2
 #^^^^^^^^^^^^^ source.bb keyword.control.bb
 
->python(){}
-#^^^^^^ source.bb storage.type.function.python.bb
+python(){}
+#<------ source.bb storage.type.function.python.bb

--- a/client/test/grammars/test-cases/keywords.bb
+++ b/client/test/grammars/test-cases/keywords.bb
@@ -42,3 +42,13 @@ python (){}
 
 python(){}
 #<------ source.bb storage.type.function.python.bb
+
+>test() {
+>    test python
+#         ^^^^^^ source.bb variable.other.names.bb
+>}
+
+>def test() {
+>    python = "test"
+#    ^^^^^^ source.bb variable.other.names.bb
+>}


### PR DESCRIPTION
Before:
<img width="537" alt="Screenshot 2024-11-15 at 10 19 12 AM" src="https://github.com/user-attachments/assets/ae1c9c26-6487-4951-99bc-ac9f547e705a">

After:
<img width="537" alt="Screenshot 2024-11-15 at 10 19 44 AM" src="https://github.com/user-attachments/assets/01a955e2-8d68-4973-a17c-335662a34ecc">
