### PR TITLE
Fix: Use inclusive comparison for bitbake version checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,9 @@ jobs:
       node-version: 20
 
     steps:
+    - name: Enable unprivileged user namespaces
+      run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
     - name: Checkout Repository
       uses: actions/checkout@v4
 

--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -456,7 +456,7 @@ async function devtoolIdeSDKCommand (bitbakeWorkspace: BitbakeWorkspace, bitBake
 async function checkIdeSdkAvailable (scanResult: BitbakeScanResult, bitbakeDriver: BitbakeDriver): Promise<boolean> {
   if(!bitbakeESDKMode) {
     // devtool ide-sdk appeared in Yocto version Scarthgap
-    return bitbakeVersionAbove(scanResult, '2.8.0')
+    return bitbakeVersionAboveEqual(scanResult, '2.8.0')
   } else {
     const command = "devtool --help | grep 'ide-sdk'"
     const process = runBitbakeTerminalCustomCommand(bitbakeDriver, command, 'Bitbake: Devtool ide-sdk: check')
@@ -468,7 +468,7 @@ async function checkIdeSdkAvailable (scanResult: BitbakeScanResult, bitbakeDrive
 async function checkDevtoolDebugBuildAvailable (scanResult: BitbakeScanResult, bitbakeDriver: BitbakeDriver): Promise<boolean> {
   if(!bitbakeESDKMode) {
     // devtool debug-build appeared in Yocto version Walnascard
-    return bitbakeVersionAbove(scanResult, '2.12.0')
+    return bitbakeVersionAboveEqual(scanResult, '2.12.0')
   } else {
     const command = "devtool modify --help | grep '\\-\\-debug-build'"
     const process = runBitbakeTerminalCustomCommand(bitbakeDriver, command, 'Bitbake: Devtool debug-build: check')
@@ -679,6 +679,6 @@ async function collapseActiveList (): Promise<void> {
   await vscode.commands.executeCommand('list.collapseAll')
 }
 
-function bitbakeVersionAbove (scanResult: BitbakeScanResult, version: string): boolean {
-  return semver.gt(scanResult._bitbakeVersion, version);
+function bitbakeVersionAboveEqual (scanResult: BitbakeScanResult, version: string): boolean {
+  return semver.gte(scanResult._bitbakeVersion, version);
 }


### PR DESCRIPTION
The previous checks for bitbake version were using exclusive comparison which caused some features to be disabled despite when the exact version was used.