### PR TITLE
Refactor BitbakeDriver to be editor agnostic

### DIFF
--- a/client/src/__tests__/unit-tests/driver/eSDKMode.test.ts
+++ b/client/src/__tests__/unit-tests/driver/eSDKMode.test.ts
@@ -5,7 +5,6 @@
 
 import { BitBakeProjectScanner } from '../../../driver/BitBakeProjectScanner'
 import { BitbakeDriver } from '../../../driver/BitbakeDriver'
-import * as BitbakeTerminal from '../../../ui/BitbakeTerminal'
 import * as ProcessUtils from '../../../utils/ProcessUtils'
 import { bitbakeESDKMode, setBitbakeESDKMode } from '../../../driver/BitbakeESDK'
 import { clientNotificationManager } from '../../../ui/ClientNotificationManager'
@@ -47,7 +46,7 @@ describe('Devtool eSDK Mode Test Suite', () => {
       pathToBuildFolder: 'nonexistent'
     }
     bitbakeDriver.loadSettings(bitbakeSettings, __dirname)
-    const bitbakeTerminalSpy = jest.spyOn(BitbakeTerminal, 'runBitbakeTerminalCustomCommand').mockImplementation(async () => (undefined as unknown as Promise<IPty>))
+    const bitbakeTerminalSpy = jest.spyOn(bitbakeDriver, 'runTerminalCommand').mockImplementation(async () => (undefined as unknown as Promise<IPty>))
     const bitbakeExecutionSpy = jest.spyOn(ProcessUtils, 'finishProcessExecution')
     clientNotificationManager.showBitbakeSettingsError = jest.fn()
 

--- a/client/src/driver/BitbakeDriver.ts
+++ b/client/src/driver/BitbakeDriver.ts
@@ -9,7 +9,6 @@ import fs from 'fs'
 import { logger } from '../lib/src/utils/OutputLogger'
 import { type BitbakeSettings, loadBitbakeSettings, sanitizeForShell, type BitbakeBuildConfigSettings, getBuildSetting } from '../lib/src/BitbakeSettings'
 import { type BitbakeTaskDefinition } from '../ui/BitbakeTaskProvider'
-import { runBitbakeTerminalCustomCommand } from '../ui/BitbakeTerminal'
 import { bitbakeESDKMode, setBitbakeESDKMode } from './BitbakeESDK'
 import { BITBAKE_EXIT_TIMEOUT, finishProcessExecution, pty } from '../utils/ProcessUtils'
 
@@ -23,6 +22,14 @@ export class BitbakeDriver {
   bitbakeProcessCommand: string | undefined
   onBitbakeProcessChange: EventEmitter = new EventEmitter()
   logBitbakeSettingsError: (message: string) => void = logger.error.bind(logger)
+  runTerminalCommand: (
+    bitbakeDriver: BitbakeDriver,
+    command: string,
+    terminalName: string,
+    isBackground?: boolean
+  ) => Promise<IPty> = async () => {
+    return {} as IPty;
+  };
 
   loadSettings (settings: Record<string, unknown>, workspaceFolder: string = '.'): void {
     this.bitbakeSettings = loadBitbakeSettings(settings, workspaceFolder)
@@ -139,7 +146,7 @@ export class BitbakeDriver {
 
     // We could test for devtool and bitbake to know if we are in an eSDK or not
     const command = 'which devtool bitbake || true'
-    const process = runBitbakeTerminalCustomCommand(this, command, 'Bitbake: Sanity test', true)
+    const process = this.runTerminalCommand(this, command, 'Bitbake: Sanity test', true)
     const ret = await finishProcessExecution(process, async () => { await this.killBitbake() })
     const outLines = ret.stdout.toString().split(/\r?\n/g)
 

--- a/client/src/driver/BitbakeDriver.ts
+++ b/client/src/driver/BitbakeDriver.ts
@@ -8,7 +8,6 @@ import fs from 'fs'
 
 import { logger } from '../lib/src/utils/OutputLogger'
 import { type BitbakeSettings, loadBitbakeSettings, sanitizeForShell, type BitbakeBuildConfigSettings, getBuildSetting } from '../lib/src/BitbakeSettings'
-import { clientNotificationManager } from '../ui/ClientNotificationManager'
 import { type BitbakeTaskDefinition } from '../ui/BitbakeTaskProvider'
 import { runBitbakeTerminalCustomCommand } from '../ui/BitbakeTerminal'
 import { bitbakeESDKMode, setBitbakeESDKMode } from './BitbakeESDK'
@@ -23,6 +22,7 @@ export class BitbakeDriver {
   bitbakeProcess: IPty | undefined
   bitbakeProcessCommand: string | undefined
   onBitbakeProcessChange: EventEmitter = new EventEmitter()
+  logBitbakeSettingsError: (message: string) => void = logger.error.bind(logger)
 
   loadSettings (settings: Record<string, unknown>, workspaceFolder: string = '.'): void {
     this.bitbakeSettings = loadBitbakeSettings(settings, workspaceFolder)
@@ -126,14 +126,14 @@ export class BitbakeDriver {
 
   async checkBitbakeSettingsSanity (): Promise<boolean> {
     if (!fs.existsSync(this.bitbakeSettings.pathToBitbakeFolder)) {
-      clientNotificationManager.showBitbakeSettingsError('Bitbake folder not found on disk.')
+      this.logBitbakeSettingsError('Bitbake folder not found on disk.')
       return false
     }
 
     const workingDirectory = this.getBuildConfig('workingDirectory')
     if (typeof workingDirectory === 'string' && !fs.existsSync(workingDirectory)) {
       // If it is not defined, then we will use the workspace folder which is always valid
-      clientNotificationManager.showBitbakeSettingsError('Working directory does not exist.')
+      this.logBitbakeSettingsError('Working directory does not exist.')
       return false
     }
 
@@ -144,7 +144,7 @@ export class BitbakeDriver {
     const outLines = ret.stdout.toString().split(/\r?\n/g)
 
     if (outLines.filter((line) => /devtool$/.test(line)).length === 0) {
-      clientNotificationManager.showBitbakeSettingsError('devtool not found in $PATH\nSee Bitbake Terminal for command output.')
+      this.logBitbakeSettingsError('devtool not found in $PATH\nSee Bitbake Terminal for command output.')
       return false
     }
 

--- a/client/src/driver/BitbakeDriverVSCode.ts
+++ b/client/src/driver/BitbakeDriverVSCode.ts
@@ -5,7 +5,15 @@
 
 import { BitbakeDriver } from "./BitbakeDriver";
 import { clientNotificationManager } from '../ui/ClientNotificationManager'
+import { runBitbakeTerminalCustomCommand } from '../ui/BitbakeTerminal'
+import { type IPty } from 'node-pty'
 
 export class BitbakeDriverVSCode extends BitbakeDriver {
   logBitbakeSettingsError: (message: string) => void = clientNotificationManager.showBitbakeSettingsError.bind(clientNotificationManager)
+  runTerminalCommand: (
+    bitbakeDriver: BitbakeDriver,
+    command: string,
+    terminalName: string,
+    isBackground?: boolean
+  ) => Promise<IPty> = runBitbakeTerminalCustomCommand
 }

--- a/client/src/driver/BitbakeDriverVSCode.ts
+++ b/client/src/driver/BitbakeDriverVSCode.ts
@@ -4,6 +4,8 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { BitbakeDriver } from "./BitbakeDriver";
+import { clientNotificationManager } from '../ui/ClientNotificationManager'
 
 export class BitbakeDriverVSCode extends BitbakeDriver {
+  logBitbakeSettingsError: (message: string) => void = clientNotificationManager.showBitbakeSettingsError.bind(clientNotificationManager)
 }

--- a/client/src/driver/BitbakeDriverVSCode.ts
+++ b/client/src/driver/BitbakeDriverVSCode.ts
@@ -1,0 +1,9 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2025 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { BitbakeDriver } from "./BitbakeDriver";
+
+export class BitbakeDriverVSCode extends BitbakeDriver {
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -9,7 +9,7 @@ import { type LanguageClient } from 'vscode-languageclient/node'
 import { clientNotificationManager } from './ui/ClientNotificationManager'
 import { logger } from './lib/src/utils/OutputLogger'
 import { activateLanguageServer, deactivateLanguageServer } from './language/languageClient'
-import { BitbakeDriver } from './driver/BitbakeDriver'
+import { BitbakeDriverVSCode } from './driver/BitbakeDriverVSCode'
 import { BitbakeTaskProvider } from './ui/BitbakeTaskProvider'
 import { registerBitbakeCommands, registerDevtoolCommands } from './ui/BitbakeCommands'
 import { BitbakeWorkspace } from './ui/BitbakeWorkspace'
@@ -30,7 +30,7 @@ import { embeddedLanguageDocsManager } from './language/EmbeddedLanguageDocsMana
 import { NotificationMethod } from './lib/src/types/notifications'
 
 let client: LanguageClient
-const bitbakeDriver: BitbakeDriver = new BitbakeDriver()
+const bitbakeDriver: BitbakeDriverVSCode = new BitbakeDriverVSCode()
 let bitbakeTaskProvider: BitbakeTaskProvider
 let taskProvider: vscode.Disposable
 const bitbakeWorkspace: BitbakeWorkspace = new BitbakeWorkspace()


### PR DESCRIPTION
Factoring out VSCode specific functionality from BitbakeDriver to BitbakeDriverVSCode.

I would love some input on how I factored out runBitbakeTerminalCustomCommand, I don't currently love exactly how I did it.
I made the default behaviour of runTerminalCommand to be a noop since it needs to be implemented by a subclass to make sense. This solution also forces the client to implement their own queuing/locking logic for running terminal commands which I am also not too pleased about.

I also though about making it an abstract function that only gets implemented in a subclass but then that would require making BitbakeDriver an abstract class which seemed like too big of a change to me.

Some next steps after this would be moving it to one of the lib folders.

Thanks!