### PR TITLE
chore: Increase timeout to 10 minutes

### DIFF
--- a/client/src/utils/ProcessUtils.ts
+++ b/client/src/utils/ProcessUtils.ts
@@ -36,7 +36,7 @@ function importFromVSCode (id: string): NodeRequire {
 // The conversion allows the linter to understand the type of the imported module
 export const pty = importFromVSCode('node-pty') as unknown as typeof nodepty
 
-export const BITBAKE_TIMEOUT = 300000
+export const BITBAKE_TIMEOUT = 600000 // 10 minutes
 export const BITBAKE_EXIT_TIMEOUT = 30000
 
 export type KillProcessFunction = (child: nodepty.IPty) => Promise<void>


### PR DESCRIPTION
The scanner unit tests often require more than 5 minutes to complete.

Based on the following CI results, 10 minutes of timeout should be enough for the scanner unit tests:
https://github.com/yoctoproject/vscode-bitbake/actions/runs/17841666750/job/50732404783
https://github.com/yoctoproject/vscode-bitbake/actions/runs/17841666750/job/50734311096
https://github.com/yoctoproject/vscode-bitbake/actions/runs/17841666750/job/50734781920


This PR should be the first step to help isolate the issues that block the integration tests.