### PR TITLE
Self hosted runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - '*'
+      - 'staging'
+      - 'main'
     tags:
       - "v*"
   pull_request:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,14 @@ on:
   pull_request:
     branches:
       - '*'
+  schedule: # This run is just to keep the self-hosted runner active. They get deleted after 14 days of inactivity.
+    - cron: '0 8 * * 1'  # Run weekly on Mondays at 9AM CET (8AM UTC)
 
 jobs:
   build-test-vscode:
 
-    runs-on: ubuntu-latest
+    # We need a faster runner with a Yocto cache in order for the tests to complete in time
+    runs-on: self-hosted
 
     defaults:
       run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,11 @@ jobs:
 
     - name: Test Project
       run: npm run test
+      env:
+        # NFS Yocto cache directories on the self-hosted runner
+        DL_DIR: /var/cache/yocto/yocto-dldir
+        SSTATE_DIR: /var/cache/yocto/yocto-sstate
+        BB_ENV_PASSTHROUGH_ADDITIONS: "DL_DIR SSTATE_DIR"
 
     - name: Build the VSIX
       run: npm run package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,9 +29,6 @@ jobs:
       node-version: 20
 
     steps:
-    - name: Enable unprivileged user namespaces
-      run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
-
     - name: Checkout Repository
       uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,6 +108,10 @@ jobs:
         name: vscode-bitbake
         path: ./yocto-bitbake*.vsix
 
+    - name: Cleanup
+      if: success()
+      run: npm run clean
+
   # Inspired by https://github.com/microsoft/vscode-platform-specific-sample/blob/a0192a21122dfa5c90934b006f027cdf4e4d892d/.github/workflows/ci.yml#L64C11-L64C11 MIT License
   publish-vsce:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,9 +50,6 @@ jobs:
         git config --global user.name "${GITHUB_ACTOR}"
         git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
-    - name: Install apt dependencies
-      run: sudo apt install chrpath diffstat
-
     - name: Cache fetch
       id: cache-fetch
       uses: actions/cache@v4

--- a/client/src/__tests__/unit-tests/driver/bitbake-driver.test.ts
+++ b/client/src/__tests__/unit-tests/driver/bitbake-driver.test.ts
@@ -6,6 +6,7 @@
 import * as fs from 'fs'
 import { BitbakeDriver } from '../../../driver/BitbakeDriver'
 import { type BitbakeTaskDefinition } from '../../../ui/BitbakeTaskProvider'
+import { BITBAKE_TIMEOUT } from '../../../utils/ProcessUtils'
 
 describe('BitbakeDriver Tests', () => {
   it('should protect from shell injections', (done) => {
@@ -22,7 +23,7 @@ describe('BitbakeDriver Tests', () => {
         done()
       })
     })
-  })
+  }, BITBAKE_TIMEOUT)
 
   it('should source the environment script', (done) => {
     const fakeEnvScriptPath = '/tmp/bitbake-vscode-test/envsetup.sh'

--- a/client/src/__tests__/unit-tests/driver/scanner.test.ts
+++ b/client/src/__tests__/unit-tests/driver/scanner.test.ts
@@ -7,7 +7,7 @@ import path from 'path'
 import fs from 'fs'
 import { BitBakeProjectScanner } from '../../../driver/BitBakeProjectScanner'
 import { BitbakeDriver } from '../../../driver/BitbakeDriver'
-import { BITBAKE_TIMEOUT } from '../../../utils/ProcessUtils'
+import { BITBAKE_BUILD_TIMEOUT, BITBAKE_TIMEOUT } from '../../../utils/ProcessUtils'
 import { mockVscodeEvents } from '../../utils/vscodeMock'
 import { importRecipe, removeRecipe, integrationBitbakeFolder } from '../../utils/bitbake'
 import { logger } from '../../../lib/src/utils/OutputLogger'
@@ -54,7 +54,14 @@ describe('BitBakeProjectScanner', () => {
     }, (error) => {
       throw error
     })
-  }, BITBAKE_TIMEOUT)
+  // Running devtool modify needs to build uninative, quilt-native, and a few recipes
+  // Since the age of AI, fetching anything now takes ages, so we increase the timeout
+  // Note that such a timeout is only possible on Github self-hosted runners or local machines
+  // Public Github runners have a max timeout of 1 hour per job
+  // The workspace is kept for the remaining tests, so we don't need to do it again
+  // Also, our self-hosted runner have a Yocto sstate cache, so it's only
+  // rebuilt when changing the openembedded version
+  }, BITBAKE_BUILD_TIMEOUT)
 
   afterAll((done) => {
     bitBakeProjectScanner.bitbakeDriver.spawnBitbakeProcess('devtool reset busybox').then((child) => {

--- a/client/src/utils/ProcessUtils.ts
+++ b/client/src/utils/ProcessUtils.ts
@@ -36,7 +36,8 @@ function importFromVSCode (id: string): NodeRequire {
 // The conversion allows the linter to understand the type of the imported module
 export const pty = importFromVSCode('node-pty') as unknown as typeof nodepty
 
-export const BITBAKE_TIMEOUT = 600000 // 10 minutes
+export const BITBAKE_TIMEOUT = 300000 // 3 minutes
+export const BITBAKE_BUILD_TIMEOUT = 600000 // 10 minutes
 export const BITBAKE_EXIT_TIMEOUT = 30000
 
 export type KillProcessFunction = (child: nodepty.IPty) => Promise<void>


### PR DESCRIPTION
Linked to #492 

I configured a new self-hosted runner that shouldn't timeout. It has a beefier CPU, disk and no time restriction.
Also has a Yocto SSTATE cache, so it makes less demands and takes less time.