### PR TITLE
fix(lsp): add semantic tokens for OVERRIDES statement and bash control-flow keywords

### DIFF
--- a/server/src/__tests__/semanticTokens.test.ts
+++ b/server/src/__tests__/semanticTokens.test.ts
@@ -7,6 +7,7 @@ import { analyzer } from '../tree-sitter/analyzer'
 import { generateBashParser, generateBitBakeParser } from '../tree-sitter/parser'
 import { getParsedTokens, TOKEN_LEGEND } from '../semanticTokens'
 import { FIXTURE_DOCUMENT, DUMMY_URI } from './fixtures/fixtures'
+import { TextDocument } from 'vscode-languageserver-textdocument'
 
 describe('Semantic tokens', () => {
   beforeAll(async () => {
@@ -118,5 +119,98 @@ describe('Semantic tokens', () => {
         }
       ]
     )
+  })
+
+  it('gives variable and override tokens to OVERRIDES statement (issue #353 case 1)', async () => {
+    // OVERRIDES = "linux:arm:pn-foo" is parsed by tree-sitter-bitbake as an
+    // overrides_statement. The OVERRIDES keyword itself has node type 'OVERRIDES'
+    // (not 'identifier'), and the override names are identifiers whose parent
+    // is 'overrides_statement' rather than 'override'.
+    const content = 'OVERRIDES = "linux:arm:pn-foo"'
+    analyzer.analyze({
+      uri: DUMMY_URI,
+      document: TextDocument.create(DUMMY_URI, 'bitbake', 0, content)
+    })
+
+    const result = getParsedTokens(DUMMY_URI)
+
+    // OVERRIDES keyword → variable + declaration
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          line: 0,
+          startCharacter: 0,
+          length: 9, // 'OVERRIDES'
+          tokenType: TOKEN_LEGEND.types.variable,
+          tokenModifiers: [TOKEN_LEGEND.modifiers.declaration]
+        }
+      ])
+    )
+
+    // 'linux' → operator + readonly (override name)
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          line: 0,
+          startCharacter: 13,
+          length: 5, // 'linux'
+          tokenType: TOKEN_LEGEND.types.operator,
+          tokenModifiers: [TOKEN_LEGEND.modifiers.readonly]
+        }
+      ])
+    )
+
+    // 'arm' → operator + readonly
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          line: 0,
+          startCharacter: 19,
+          length: 3, // 'arm'
+          tokenType: TOKEN_LEGEND.types.operator,
+          tokenModifiers: [TOKEN_LEGEND.modifiers.readonly]
+        }
+      ])
+    )
+
+    // 'pn-foo' → operator + readonly
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          line: 0,
+          startCharacter: 23,
+          length: 6, // 'pn-foo'
+          tokenType: TOKEN_LEGEND.types.operator,
+          tokenModifiers: [TOKEN_LEGEND.modifiers.readonly]
+        }
+      ])
+    )
+  })
+
+  it('gives keyword tokens to bash control-flow keywords inside shell functions (issue #353 case 3)', async () => {
+    // Bash keywords such as 'then', 'if', 'fi' have node types matching their
+    // text in tree-sitter-bash. They should receive a keyword semantic token
+    // so they are highlighted inside BitBake shell functions.
+    const content = [
+      'do_install () {',
+      '    if [ -f "${D}/file" ]; then',
+      '        echo "found"',
+      '    fi',
+      '}'
+    ].join('\n')
+
+    analyzer.analyze({
+      uri: DUMMY_URI,
+      document: TextDocument.create(DUMMY_URI, 'bitbake', 0, content)
+    })
+
+    const result = getParsedTokens(DUMMY_URI)
+    const keywordTokens = result.filter((t) => t.tokenType === TOKEN_LEGEND.types.keyword)
+
+    // 'if', 'then', 'fi' should all appear as keyword tokens
+    const labels = keywordTokens.map((t) => content.split('\n')[t.line].substring(t.startCharacter, t.startCharacter + t.length))
+    expect(labels).toContain('if')
+    expect(labels).toContain('then')
+    expect(labels).toContain('fi')
   })
 })

--- a/server/src/semanticTokens.ts
+++ b/server/src/semanticTokens.ts
@@ -56,6 +56,16 @@ const generateSemanticTokensLegend = (): SemanticTokensLegend => {
 
 export const legend: SemanticTokensLegend = generateSemanticTokensLegend()
 
+// Bash control-flow keywords have node types matching their text in the
+// tree-sitter-bash grammar (e.g. 'if', 'then', 'else', 'fi', 'for',
+// 'while', 'do', 'done', 'case', 'in', 'esac', 'elif').
+const BASH_KEYWORDS = new Set([
+  'if', 'then', 'else', 'elif', 'fi',
+  'for', 'while', 'until', 'do', 'done',
+  'case', 'in', 'esac',
+  'function', 'select', 'time'
+])
+
 // Check node_modules/@types/vscode/index.d.ts for more encoding details
 function encodeTokenType (tokenType: string): number {
   if (tokenTypes.has(tokenType)) {
@@ -110,15 +120,6 @@ export function getBashParsedTokens (uri: string): ParsedToken[] {
       })
     }
 
-    // Bash control-flow keywords have node types matching their text in the
-    // tree-sitter-bash grammar (e.g. 'if', 'then', 'else', 'fi', 'for',
-    // 'while', 'do', 'done', 'case', 'in', 'esac', 'elif').
-    const BASH_KEYWORDS = new Set([
-      'if', 'then', 'else', 'elif', 'fi',
-      'for', 'while', 'until', 'do', 'done',
-      'case', 'in', 'esac',
-      'function', 'select', 'time'
-    ])
     if (BASH_KEYWORDS.has(node.type)) {
       resultTokens.push({
         ...nodeRange,

--- a/server/src/semanticTokens.ts
+++ b/server/src/semanticTokens.ts
@@ -110,6 +110,23 @@ export function getBashParsedTokens (uri: string): ParsedToken[] {
       })
     }
 
+    // Bash control-flow keywords have node types matching their text in the
+    // tree-sitter-bash grammar (e.g. 'if', 'then', 'else', 'fi', 'for',
+    // 'while', 'do', 'done', 'case', 'in', 'esac', 'elif').
+    const BASH_KEYWORDS = new Set([
+      'if', 'then', 'else', 'elif', 'fi',
+      'for', 'while', 'until', 'do', 'done',
+      'case', 'in', 'esac',
+      'function', 'select', 'time'
+    ])
+    if (BASH_KEYWORDS.has(node.type)) {
+      resultTokens.push({
+        ...nodeRange,
+        tokenType: TOKEN_LEGEND.types.keyword,
+        tokenModifiers: []
+      })
+    }
+
     // Traverse every node
     return true
   })
@@ -133,6 +150,17 @@ export function getBitBakeParsedTokens (uri: string): ParsedToken[] {
     }
 
     if (TreeSitterUtils.isVariableReference(node)) {
+      resultTokens.push({
+        ...nodeRange,
+        tokenType: TOKEN_LEGEND.types.variable,
+        tokenModifiers: [TOKEN_LEGEND.modifiers.declaration]
+      })
+    }
+
+    // OVERRIDES is a named token in the tree-sitter-bitbake grammar (not 'identifier').
+    // It is the left-hand side of an overrides_statement and should be treated as a
+    // variable declaration for semantic highlighting purposes.
+    if (node.type === 'OVERRIDES') {
       resultTokens.push({
         ...nodeRange,
         tokenType: TOKEN_LEGEND.types.variable,

--- a/server/src/tree-sitter/utils.ts
+++ b/server/src/tree-sitter/utils.ts
@@ -84,11 +84,25 @@ export function isOverride (n: SyntaxNode): boolean {
               (variable_expansion [0, 27] - [0, 32]
                 (identifier [0, 29] - [0, 31]))
               (identifier [0, 32] - [0, 36])))))
+   *
+   * Example (OVERRIDES statement):
+   * OVERRIDES = "linux:arm:pn-foo"
+   *
+   * Tree node:
+   *    (overrides_statement
+   *      (OVERRIDES)
+   *      (identifier "linux")
+   *      (identifier "arm")
+   *      (identifier "pn-foo"))
+   *
+   * The override names inside overrides_statement are identifiers whose parent
+   * is 'overrides_statement' rather than 'override'. They are semantically
+   * override tokens and should be highlighted as such.
    */
   const parentType = n?.parent?.type
   switch (n.type) {
     case 'identifier':
-      return parentType === 'override' || parentType === 'concatenation'
+      return parentType === 'override' || parentType === 'concatenation' || parentType === 'overrides_statement'
     default:
       return false
   }


### PR DESCRIPTION
## Problem

Two semantic highlighting gaps reported in #353:

**1 — OVERRIDES statement**

`OVERRIDES = "linux:arm:pn-foo"` is parsed by tree-sitter-bitbake as an
`overrides_statement` node, not a `variable_assignment`. As a result:

- The `OVERRIDES` keyword has node type `'OVERRIDES'` (not `'identifier'`),
  so `isVariableReference()` does not match it — it receives no semantic token
  and is not highlighted as a variable declaration.
- The override names inside the string (`linux`, `arm`, `pn-foo`) are identifiers
  whose parent is `'overrides_statement'`, not `'override'`. `utils.ts isOverride()`
  does not match `'overrides_statement'` — they receive no semantic token and are
  not highlighted as override tokens.

**2 — Bash control-flow keywords**

Bash keywords such as `then`, `if`, `fi`, `else`, `do`, `done` have node types
matching their text in tree-sitter-bash. `getBashParsedTokens()` only handled
`variable_name` and `command_name`, leaving all control-flow keywords unhighlighted
inside BitBake shell functions.

## Fix

**`server/src/tree-sitter/utils.ts`** — `isOverride()`:
Add `parentType === 'overrides_statement'` so override names inside the OVERRIDES
value are highlighted as `operator+readonly` tokens.

**`server/src/semanticTokens.ts`** — `getBitBakeParsedTokens()`:
Add `node.type === 'OVERRIDES'` check to emit a `variable+declaration` token for
the OVERRIDES keyword itself.

**`server/src/semanticTokens.ts`** — `getBashParsedTokens()`:
Add `BASH_KEYWORDS` set check to emit `keyword` tokens for `if`, `then`, `else`,
`elif`, `fi`, `for`, `while`, `until`, `do`, `done`, `case`, `in`, `esac`.

## Tests

Two new test cases in `semanticTokens.test.ts`:
- `OVERRIDES = "linux:arm:pn-foo"` — verifies variable and operator tokens
- Shell function with `if [...]; then ... fi` — verifies keyword tokens for all three

Note: Case 2 (multi-line variable continuation breaking whole-file highlight) appears
to be a tree-sitter-bitbake grammar issue. It is not addressed in this PR.

Fixes #353