### PR TITLE
Fix: Don't use variable-length lookbehind assertions in grammar

### DIFF
--- a/client/syntaxes/bitbake.tmLanguage.json
+++ b/client/syntaxes/bitbake.tmLanguage.json
@@ -50,6 +50,17 @@
         "keywords": {
             "patterns": [
                 {
+                    "match": "^(fakeroot +)?(python|def)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.control.bb"
+                        },
+                        "2": {
+                            "name": "storage.type.function.python.bb"
+                        }
+                    }
+                },
+                {
                     "match": "(?<![[:punct:]])\\b(include|require|inherit|inherit_defer|addtask|deltask|after|before|export|echo|if|fi|unset|print|fakeroot|EXPORT_FUNCTIONS|INHERIT)\\b(?![[:punct:]])",
                     "captures": {
                         "1": {
@@ -59,14 +70,6 @@
                 },
                 {
                     "include": "#python-keywords"
-                },
-                {
-                    "match": "(?<=^|^fakeroot +)\\b(python|def)\\b",
-                    "captures": {
-                        "1": {
-                            "name": "storage.type.function.python.bb"
-                        }
-                    }
                 }
             ]
         },


### PR DESCRIPTION
Hello,

The `bitbake.tmLanguage.json` grammar from this repository is used by GitHub [linguist] library to provide syntax highlighting for the BitBake language on GitHub. It uses the PCRE regex engine, which unlike ECMAScript regexes, does not support variable-length lookbehind assertions.

Commit b24a574 has introduced a variable-length lookbehind assertion in the grammar, thus causes highlighting issues in linguist. The problem is tracked in [issue 3924] in linguist repository.

This commit replaces this lookbehind by duplicating the "fakeroot" capture (for python functions) and moving it before the other fakeroot capture (used for shell functions).  All `npm run test:grammar` tests passed.

[linguist]: https://github.com/github-linguist/linguist
[issue 3924]: https://github.com/github-linguist/linguist/issues/3924