### PR TITLE
Add BitBake getting started walkthrough

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,6 +222,69 @@
         "files.trimTrailingWhitespace": false
       }
     },
+    "walkthroughs": [
+      {
+        "id": "bitbake.getStarted",
+        "title": "Get Started with BitBake",
+        "description": "Configure the BitBake extension and learn the main VS Code features for Yocto Project workspaces.",
+        "steps": [
+          {
+            "id": "bitbake.getStarted.host",
+            "title": "Check your host setup",
+            "description": "Check that your workspace runs on a supported Linux host.",
+            "media": {
+              "markdown": "walkthroughs/host-setup.md"
+            }
+          },
+          {
+            "id": "bitbake.getStarted.dependencies",
+            "title": "Install the required dependencies",
+            "description": "Install the required host packages and locale before starting BitBake from the extension.",
+            "media": {
+              "markdown": "walkthroughs/dependencies.md"
+            }
+          },
+          {
+            "id": "bitbake.getStarted.settings",
+            "title": "Configure BitBake settings",
+            "description": "Open VS Code Settings and search for `BitBake`. Configure the basic workspace settings needed to start BitBake, such as `bitbake.pathToBuildFolder`, `bitbake.pathToEnvScript`, and `bitbake.pathToBitbakeFolder`.",
+            "media": {
+              "image": "images/config-picker.png",
+              "altText": "BitBake configuration picker"
+            },
+            "completionEvents": [
+              "onCommand:bitbake.pick-configuration",
+              "onSettingChanged:bitbake.pathToBuildFolder",
+              "onSettingChanged:bitbake.pathToEnvScript",
+              "onSettingChanged:bitbake.pathToBitbakeFolder"
+            ]
+          },
+          {
+            "id": "bitbake.getStarted.language",
+            "title": "Try language features",
+            "description": "Open a BitBake recipe and try language server features such as hover information, completion, and go to definition.",
+            "media": {
+              "markdown": "walkthroughs/language-features.md"
+            }
+          },
+          {
+            "id": "bitbake.getStarted.gui",
+            "title": "Use BitBake views and commands",
+            "description": "Use the Recipes Explorer and command links to try common BitBake extension actions.",
+            "media": {
+              "markdown": "walkthroughs/bitbake-gui.md"
+            },
+            "completionEvents": [
+              "onView:bitbakeRecipes",
+              "onCommand:bitbake.watch-recipe",
+              "onCommand:bitbake.rescan-project",
+              "onCommand:bitbake.terminal-profile",
+              "onCommand:bitbake.build-recipe"
+            ]
+          }
+        ]
+      }
+    ],
     "taskDefinitions": [
       {
         "type": "bitbake",

--- a/walkthroughs/bitbake-gui.md
+++ b/walkthroughs/bitbake-gui.md
@@ -1,0 +1,12 @@
+# Use BitBake views and commands
+
+Use the actions below to try the main BitBake UI features:
+
+- [Watch recipe (track recipe in the workspace)](command:bitbake.watch-recipe)
+- [Rescan project](command:bitbake.rescan-project)
+- [Open BitBake terminal](command:bitbake.terminal-profile)
+- [Build recipe](command:bitbake.build-recipe)
+
+The Recipes Explorer shows recipes you choose to track, not every recipe in the workspace.
+
+![BitBake recipes view](../images/recipe-view.png)

--- a/walkthroughs/dependencies.md
+++ b/walkthroughs/dependencies.md
@@ -1,0 +1,7 @@
+# Install the required dependencies
+
+Install the host packages required by the [Yocto Project quick build guide](https://docs.yoctoproject.org/brief-yoctoprojectqs/index.html) before using BitBake from this extension.
+
+Make sure an `en_US.UTF-8` locale is available.
+
+On Ubuntu 24.04 and newer, BitBake may also require an AppArmor exception for user namespaces. See the Yocto Project documentation for the current distribution-specific requirements.

--- a/walkthroughs/host-setup.md
+++ b/walkthroughs/host-setup.md
@@ -1,0 +1,7 @@
+# Check your host setup
+
+This extension is designed for BitBake workspaces on Linux hosts.
+
+For the best experience, use one of the Linux distributions supported by the [Yocto Project quick build guide](https://docs.yoctoproject.org/brief-yoctoprojectqs/index.html).
+
+Windows users should run BitBake from a Linux environment, such as WSL.

--- a/walkthroughs/language-features.md
+++ b/walkthroughs/language-features.md
@@ -1,0 +1,16 @@
+# Try language features
+
+Open a BitBake recipe file such as a `.bb`, `.bbappend`, or `.bbclass` file.
+
+This extension can help with:
+
+- syntax highlighting for BitBake files
+- hover information for known BitBake variables
+- context-aware completions
+- go to definition for recipes, classes, includes, and symbols
+
+![BitBake hover information](../images/hover-information.gif)
+
+Completions are context-aware and use information from the parsed BitBake workspace. After the extension is configured and the project has been scanned, suggestions become more useful for common BitBake statements such as `inherit`, `require`, and `include`.
+
+![BitBake context-aware completions](../images/directive-statements.gif)


### PR DESCRIPTION
## Summary

- add a VS Code Getting Started walkthrough for the BitBake extension
- cover basic host/dependency prerequisites, workspace settings, language features, and BitBake GUI features
- add small Markdown walkthrough media files for host setup and dependencies

## Notes

This is intended as a first basic walkthrough for configuring and using the extension, not as a general Yocto Project walkthrough.

It intentionally keeps the initial scope limited to the manual/basic setup path and does not cover `commandWrapper`, `buildConfigurations`, or `bitbake-setup`.

Fixes #360.