### PR TITLE
Move BitBake settings error into recipes view

### DIFF
--- a/client/src/__tests__/unit-tests/driver/bitbake-driver.test.ts
+++ b/client/src/__tests__/unit-tests/driver/bitbake-driver.test.ts
@@ -4,9 +4,13 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as fs from 'fs'
+import { SpawnSyncReturns } from 'child_process'
+import { IPty } from 'node-pty'
 import { BitbakeDriver } from '../../../driver/BitbakeDriver'
 import { type BitbakeTaskDefinition } from '../../../ui/BitbakeTaskProvider'
 import { BITBAKE_TIMEOUT } from '../../../utils/ProcessUtils'
+import * as BitbakeTerminal from '../../../ui/BitbakeTerminal'
+import * as ProcessUtils from '../../../utils/ProcessUtils'
 
 describe('BitbakeDriver Tests', () => {
   it('should protect from shell injections', (done) => {
@@ -102,6 +106,71 @@ describe('BitbakeDriver Tests', () => {
     driver.activeBuildConfiguration = 'Alternative'
     const script = driver.composeBitbakeScript('bitbake busybox')
     expect(script).toEqual(expect.stringContaining('. /tmp/envsetup.sh /tmp/alternative-build'))
+  })
+
+  describe('settings sanity', () => {
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('tracks sane BitBake settings', async () => {
+      const bitbakeDriver = new BitbakeDriver()
+      const bitbakeSettings: Record<string, unknown> = {
+        pathToBitbakeFolder: __dirname,
+        workingDirectory: __dirname,
+        commandWrapper: '',
+        pathToEnvScript: 'fakeEnvScript',
+        pathToBuildFolder: 'nonexistent'
+      }
+
+      bitbakeDriver.loadSettings(bitbakeSettings, __dirname)
+      jest.spyOn(BitbakeTerminal, 'runBitbakeTerminalCustomCommand').mockImplementation(async () => (undefined as unknown as Promise<IPty>))
+      jest.spyOn(ProcessUtils, 'finishProcessExecution').mockReturnValueOnce(Promise.resolve({
+        status: 0,
+        stdout: '/tmp/devtool\r\n/tmp/bitbake'
+      } as unknown as Promise<SpawnSyncReturns<Buffer>>))
+
+      const onSanityChange = jest.fn()
+      bitbakeDriver.onBitbakeSettingsSanityChange.on('change', onSanityChange)
+
+      const sane = await bitbakeDriver.checkBitbakeSettingsSanity()
+
+      expect(sane).toStrictEqual(true)
+      expect(bitbakeDriver.isBitbakeSettingsSane()).toStrictEqual(true)
+      expect(bitbakeDriver.getBitbakeSettingsError()).toBeUndefined()
+      expect(onSanityChange).toHaveBeenCalledWith({ sane: true, error: undefined })
+    })
+
+    it('tracks BitBake settings errors', async () => {
+      const bitbakeDriver = new BitbakeDriver()
+      const bitbakeSettings: Record<string, unknown> = {
+        pathToBitbakeFolder: __dirname,
+        workingDirectory: __dirname,
+        commandWrapper: '',
+        pathToEnvScript: 'fakeEnvScript',
+        pathToBuildFolder: 'nonexistent'
+      }
+
+      bitbakeDriver.loadSettings(bitbakeSettings, __dirname)
+      jest.spyOn(BitbakeTerminal, 'runBitbakeTerminalCustomCommand').mockImplementation(async () => (undefined as unknown as Promise<IPty>))
+      jest.spyOn(ProcessUtils, 'finishProcessExecution').mockReturnValueOnce(Promise.resolve({
+        status: 1,
+        stdout: 'error'
+      } as unknown as Promise<SpawnSyncReturns<Buffer>>))
+
+      const onSanityChange = jest.fn()
+      bitbakeDriver.onBitbakeSettingsSanityChange.on('change', onSanityChange)
+
+      const sane = await bitbakeDriver.checkBitbakeSettingsSanity()
+
+      expect(sane).toStrictEqual(false)
+      expect(bitbakeDriver.isBitbakeSettingsSane()).toStrictEqual(false)
+      expect(bitbakeDriver.getBitbakeSettingsError()).toStrictEqual('devtool not found in $PATH\nSee Bitbake Terminal for command output.')
+      expect(onSanityChange).toHaveBeenCalledWith({
+        sane: false,
+        error: 'devtool not found in $PATH\nSee Bitbake Terminal for command output.'
+      })
+    })
   })
 
   describe('composeBitbakeCommand', () => {

--- a/client/src/__tests__/unit-tests/driver/eSDKMode.test.ts
+++ b/client/src/__tests__/unit-tests/driver/eSDKMode.test.ts
@@ -8,7 +8,6 @@ import { BitbakeDriver } from '../../../driver/BitbakeDriver'
 import * as BitbakeTerminal from '../../../ui/BitbakeTerminal'
 import * as ProcessUtils from '../../../utils/ProcessUtils'
 import { bitbakeESDKMode, setBitbakeESDKMode } from '../../../driver/BitbakeESDK'
-import { clientNotificationManager } from '../../../ui/ClientNotificationManager'
 import { SpawnSyncReturns } from 'child_process'
 import { IPty } from 'node-pty'
 
@@ -49,7 +48,6 @@ describe('Devtool eSDK Mode Test Suite', () => {
     bitbakeDriver.loadSettings(bitbakeSettings, __dirname)
     const bitbakeTerminalSpy = jest.spyOn(BitbakeTerminal, 'runBitbakeTerminalCustomCommand').mockImplementation(async () => (undefined as unknown as Promise<IPty>))
     const bitbakeExecutionSpy = jest.spyOn(ProcessUtils, 'finishProcessExecution')
-    clientNotificationManager.showBitbakeSettingsError = jest.fn()
 
     bitbakeExecutionSpy.mockReturnValueOnce(Promise.resolve({
       status: 1,

--- a/client/src/__tests__/unit-tests/ui/bitbake-commands.test.ts
+++ b/client/src/__tests__/unit-tests/ui/bitbake-commands.test.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode'
 import type childProcess from 'child_process'
 import { BitbakeWorkspace } from '../../../ui/BitbakeWorkspace'
 import { BitBakeProjectScanner } from '../../../driver/BitBakeProjectScanner'
+import { mockVscodeExtensionContext } from '../../utils/vscodeMock'
 import { BitbakeDriver } from '../../../driver/BitbakeDriver'
 import { addDevtoolDebugBuild, registerDevtoolCommands } from '../../../ui/BitbakeCommands'
 import { clientNotificationManager } from '../../../ui/ClientNotificationManager'
@@ -21,11 +22,7 @@ jest.mock('vscode')
 
 function mockExtensionContext (bitBakeProjectScanner: BitBakeProjectScanner): (...args: unknown[]) => unknown {
   const bitbakeWorkspace = new BitbakeWorkspace()
-  const contextMock: vscode.ExtensionContext = {
-    subscriptions: {
-      push: jest.fn()
-    }
-  } as unknown as vscode.ExtensionContext
+  const contextMock = mockVscodeExtensionContext()
   const clientMock = jest.fn() as unknown as LanguageClient
 
   let ideSDKCommand = () => {}

--- a/client/src/__tests__/unit-tests/ui/bitbake-recipes-view.test.ts
+++ b/client/src/__tests__/unit-tests/ui/bitbake-recipes-view.test.ts
@@ -9,7 +9,7 @@ import { BitbakeWorkspace } from '../../../ui/BitbakeWorkspace'
 import { BitBakeProjectScanner } from '../../../driver/BitBakeProjectScanner'
 import { type BitbakeScanResult } from '../../../lib/src/types/BitbakeScanResult'
 import { BitbakeDriver } from '../../../driver/BitbakeDriver'
-import { mockVscodeEvents } from '../../utils/vscodeMock'
+import { mockVscodeEvents, mockVscodeExtensionContext } from '../../utils/vscodeMock'
 
 jest.mock('vscode')
 
@@ -25,11 +25,7 @@ describe('BitbakeDriver Recipes View', () => {
     const bitBakeProjectScanner = new BitBakeProjectScanner(bitbakeDriver)
     void bitbakeWorkspace.addActiveRecipe('base-files') // The promise is the memento which is under mock
 
-    const contextMock = {
-      subscriptions: {
-        push: jest.fn()
-      }
-    } as unknown as vscode.ExtensionContext
+    const contextMock = mockVscodeExtensionContext()
 
     const scanResult: BitbakeScanResult = {
       _recipes: [
@@ -88,11 +84,7 @@ describe('BitbakeDriver Recipes View', () => {
     jest.spyOn(bitbakeDriver, 'isBitbakeSettingsSane').mockReturnValue(false)
     const bitBakeProjectScanner = new BitBakeProjectScanner(bitbakeDriver)
 
-    const contextMock = {
-      subscriptions: {
-        push: jest.fn()
-      }
-    } as unknown as vscode.ExtensionContext
+    const contextMock = mockVscodeExtensionContext()
 
     vscode.window.registerTreeDataProvider = jest.fn().mockImplementation(
       async (viewId: string, treeDataProvider: vscode.TreeDataProvider<BitbakeRecipeTreeItem>): Promise<void> => {

--- a/client/src/__tests__/unit-tests/ui/bitbake-recipes-view.test.ts
+++ b/client/src/__tests__/unit-tests/ui/bitbake-recipes-view.test.ts
@@ -20,7 +20,9 @@ describe('BitbakeDriver Recipes View', () => {
 
   it('should list recipes', (done) => {
     const bitbakeWorkspace = new BitbakeWorkspace()
-    const bitBakeProjectScanner = new BitBakeProjectScanner(new BitbakeDriver())
+    const bitbakeDriver = new BitbakeDriver()
+    jest.spyOn(bitbakeDriver, 'isBitbakeSettingsSane').mockReturnValue(true)
+    const bitBakeProjectScanner = new BitBakeProjectScanner(bitbakeDriver)
     void bitbakeWorkspace.addActiveRecipe('base-files') // The promise is the memento which is under mock
 
     const contextMock = {
@@ -77,6 +79,32 @@ describe('BitbakeDriver Recipes View', () => {
 
     const bitbakeRecipesView = new BitbakeRecipesView(bitbakeWorkspace, bitBakeProjectScanner)
     bitBakeProjectScanner.onChange.emit(BitBakeProjectScanner.EventType.SCAN_COMPLETE, scanResult)
+    bitbakeRecipesView.registerView(contextMock)
+  })
+
+  it('should show welcome content when BitBake settings are not sane', (done) => {
+    const bitbakeWorkspace = new BitbakeWorkspace()
+    const bitbakeDriver = new BitbakeDriver()
+    jest.spyOn(bitbakeDriver, 'isBitbakeSettingsSane').mockReturnValue(false)
+    const bitBakeProjectScanner = new BitBakeProjectScanner(bitbakeDriver)
+
+    const contextMock = {
+      subscriptions: {
+        push: jest.fn()
+      }
+    } as unknown as vscode.ExtensionContext
+
+    vscode.window.registerTreeDataProvider = jest.fn().mockImplementation(
+      async (viewId: string, treeDataProvider: vscode.TreeDataProvider<BitbakeRecipeTreeItem>): Promise<void> => {
+        const rootTreeItem = await treeDataProvider.getChildren(undefined)
+        expect(rootTreeItem).toBeDefined()
+        expect(rootTreeItem).toStrictEqual([])
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith('setContext', 'bitbake.settingsError', true)
+        done()
+      })
+    mockVscodeEvents()
+
+    const bitbakeRecipesView = new BitbakeRecipesView(bitbakeWorkspace, bitBakeProjectScanner)
     bitbakeRecipesView.registerView(contextMock)
   })
 })

--- a/client/src/__tests__/unit-tests/ui/devtool-workspaces-view.test.ts
+++ b/client/src/__tests__/unit-tests/ui/devtool-workspaces-view.test.ts
@@ -8,7 +8,7 @@ import { type DevtoolWorkspaceTreeItem, DevtoolWorkspacesView } from '../../../u
 import { BitBakeProjectScanner } from '../../../driver/BitBakeProjectScanner'
 import { type BitbakeScanResult } from '../../../lib/src/types/BitbakeScanResult'
 import { BitbakeDriver } from '../../../driver/BitbakeDriver'
-import { mockVscodeEvents } from '../../utils/vscodeMock'
+import { mockVscodeEvents, mockVscodeExtensionContext } from '../../utils/vscodeMock'
 
 jest.mock('vscode')
 
@@ -18,11 +18,7 @@ describe('Devtool Worskapces View', () => {
   })
 
   it('should list devtool workspaces', (done) => {
-    const contextMock = {
-      subscriptions: {
-        push: jest.fn()
-      }
-    } as unknown as vscode.ExtensionContext
+    const contextMock = mockVscodeExtensionContext()
 
     const scanResult: BitbakeScanResult = {
       _recipes: [{

--- a/client/src/__tests__/utils/vscodeMock.ts
+++ b/client/src/__tests__/utils/vscodeMock.ts
@@ -15,3 +15,11 @@ export function mockVscodeEvents (): void {
     }
   })
 }
+
+export function mockVscodeExtensionContext (): vscode.ExtensionContext {
+  return {
+    subscriptions: {
+      push: jest.fn()
+    }
+  } as unknown as vscode.ExtensionContext
+}

--- a/client/src/driver/BitbakeDriver.ts
+++ b/client/src/driver/BitbakeDriver.ts
@@ -8,7 +8,6 @@ import fs from 'fs'
 
 import { logger } from '../lib/src/utils/OutputLogger'
 import { type BitbakeSettings, loadBitbakeSettings, sanitizeForShell, type BitbakeBuildConfigSettings, getBuildSetting } from '../lib/src/BitbakeSettings'
-import { clientNotificationManager } from '../ui/ClientNotificationManager'
 import { type BitbakeTaskDefinition } from '../ui/BitbakeTaskProvider'
 import { runBitbakeTerminalCustomCommand } from '../ui/BitbakeTerminal'
 import { bitbakeESDKMode, setBitbakeESDKMode } from './BitbakeESDK'
@@ -22,10 +21,14 @@ export class BitbakeDriver {
   activeBuildConfiguration: string = 'No BitBake configuration'
   bitbakeProcess: IPty | undefined
   bitbakeProcessCommand: string | undefined
+  private bitbakeSettingsSane = false
+  private bitbakeSettingsError: string | undefined
   onBitbakeProcessChange: EventEmitter = new EventEmitter()
+  onBitbakeSettingsSanityChange: EventEmitter = new EventEmitter()
 
   loadSettings (settings: Record<string, unknown>, workspaceFolder: string = '.'): void {
     this.bitbakeSettings = loadBitbakeSettings(settings, workspaceFolder)
+    this.setBitbakeSettingsSanity(false)
     logger.debug('BitbakeDriver settings updated: ' + JSON.stringify(this.bitbakeSettings))
   }
 
@@ -42,6 +45,20 @@ export class BitbakeDriver {
 
   getBuildConfig (property: keyof BitbakeBuildConfigSettings): string | NodeJS.Dict<string> | boolean | undefined {
     return getBuildSetting(this.bitbakeSettings, this.activeBuildConfiguration, property)
+  }
+
+  isBitbakeSettingsSane (): boolean {
+    return this.bitbakeSettingsSane
+  }
+
+  getBitbakeSettingsError (): string | undefined {
+    return this.bitbakeSettingsError
+  }
+
+  private setBitbakeSettingsSanity (sane: boolean, error?: string): void {
+    this.bitbakeSettingsSane = sane
+    this.bitbakeSettingsError = error
+    this.onBitbakeSettingsSanityChange.emit('change', { sane, error })
   }
 
   /// Execute a command in the bitbake environment
@@ -126,14 +143,14 @@ export class BitbakeDriver {
 
   async checkBitbakeSettingsSanity (): Promise<boolean> {
     if (!fs.existsSync(this.bitbakeSettings.pathToBitbakeFolder)) {
-      clientNotificationManager.showBitbakeSettingsError('Bitbake folder not found on disk.')
+      this.setBitbakeSettingsSanity(false, 'Bitbake folder not found on disk.')
       return false
     }
 
     const workingDirectory = this.getBuildConfig('workingDirectory')
     if (typeof workingDirectory === 'string' && !fs.existsSync(workingDirectory)) {
       // If it is not defined, then we will use the workspace folder which is always valid
-      clientNotificationManager.showBitbakeSettingsError('Working directory does not exist.')
+      this.setBitbakeSettingsSanity(false, 'Working directory does not exist.')
       return false
     }
 
@@ -144,7 +161,7 @@ export class BitbakeDriver {
     const outLines = ret.stdout.toString().split(/\r?\n/g)
 
     if (outLines.filter((line) => /devtool$/.test(line)).length === 0) {
-      clientNotificationManager.showBitbakeSettingsError('devtool not found in $PATH\nSee Bitbake Terminal for command output.')
+      this.setBitbakeSettingsSanity(false, 'devtool not found in $PATH\nSee Bitbake Terminal for command output.')
       return false
     }
 
@@ -154,6 +171,7 @@ export class BitbakeDriver {
       setBitbakeESDKMode(false)
     }
     logger.info(`Bitbake settings are sane, eSDK mode: ${bitbakeESDKMode}`)
+    this.setBitbakeSettingsSanity(true)
 
     return true
   }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -193,11 +193,10 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
         event.affectsConfiguration('bitbake.commandWrapper') ||
         event.affectsConfiguration('bitbake.buildConfigurations')) {
       bitbakeConfigPicker.updateStatusBar(bitbakeDriver.bitbakeSettings)
-      await clientNotificationManager.resetNeverShowAgain('bitbake/bitbakeSettingsError')
       logger.debug('Bitbake settings changed')
       updatePythonPath()
       if (!scanContainsData(bitBakeProjectScanner.activeScanResult)) {
-        void vscode.commands.executeCommand('bitbake.rescan-project')
+        void vscode.commands.executeCommand('bitbake.rescan-project', false)
       } else {
         void vscode.commands.executeCommand('bitbake.parse-recipes')
         bitBakeProjectScanner.onChange.emit(BitBakeProjectScanner.EventType.SCAN_COMPLETE, bitBakeProjectScanner.activeScanResult)
@@ -221,7 +220,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
   context.subscriptions.push(bitbakeConfigPicker.onActiveConfigChanged.event((config) => {
     bitbakeDriver.activeBuildConfiguration = config
     if (!scanContainsData(bitBakeProjectScanner.activeScanResult)) {
-      void vscode.commands.executeCommand('bitbake.rescan-project')
+      void vscode.commands.executeCommand('bitbake.rescan-project', false)
     } else {
       bitBakeProjectScanner.onChange.emit(BitBakeProjectScanner.EventType.SCAN_COMPLETE, bitBakeProjectScanner.activeScanResult)
     }
@@ -286,7 +285,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
   if (scanContainsData(bitBakeProjectScanner.activeScanResult)) {
     bitBakeProjectScanner.onChange.emit(BitBakeProjectScanner.EventType.SCAN_COMPLETE, bitBakeProjectScanner.activeScanResult)
   } else {
-    void vscode.commands.executeCommand('bitbake.rescan-project')
+    void vscode.commands.executeCommand('bitbake.rescan-project', false)
   }
   logger.info('Congratulations, your extension "BitBake" is now active!')
 }

--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -32,7 +32,6 @@ import { type LanguageClient } from 'vscode-languageclient/node'
 import { getVariableValue } from '../language/languageClient'
 
 let parsingPending = false
-let bitbakeSanity = false
 
 export function registerBitbakeCommands (context: vscode.ExtensionContext, bitbakeWorkspace: BitbakeWorkspace, bitbakeTaskProvider: BitbakeTaskProvider, bitBakeProjectScanner: BitBakeProjectScanner, bitbakeTerminalProfileProvider: BitbakeTerminalProfileProvider, client: LanguageClient): void {
   context.subscriptions.push(
@@ -45,7 +44,7 @@ export function registerBitbakeCommands (context: vscode.ExtensionContext, bitba
     vscode.commands.registerCommand('bitbake.drop-recipe', async (uri) => { await dropRecipe(bitbakeWorkspace, bitBakeProjectScanner, uri) }),
     vscode.commands.registerCommand('bitbake.drop-all-recipes', async () => { await dropAllRecipes(bitbakeWorkspace) }),
     vscode.commands.registerCommand('bitbake.watch-recipe', async (recipe) => { await addActiveRecipe(bitbakeWorkspace, bitBakeProjectScanner, recipe) }),
-    vscode.commands.registerCommand('bitbake.rescan-project', async () => { await rescanProject(bitBakeProjectScanner) }),
+    vscode.commands.registerCommand('bitbake.rescan-project', async (focusOnError = true) => { await rescanProject(bitBakeProjectScanner, focusOnError) }),
     vscode.commands.registerCommand('bitbake.terminal-profile', async () => { await openBitbakeTerminalProfile(bitbakeTerminalProfileProvider) }),
     vscode.commands.registerCommand('bitbake.open-recipe-workdir', async (uri) => { await openRecipeWorkdirCommand(bitbakeWorkspace, bitBakeProjectScanner, client, uri) }),
     vscode.commands.registerCommand('bitbake.recipe-devshell', async (uri) => { await openBitbakeDevshell(bitbakeTerminalProfileProvider, bitbakeWorkspace, bitBakeProjectScanner, uri) }),
@@ -94,14 +93,25 @@ export function registerDevtoolCommands (context: vscode.ExtensionContext, bitba
   )
 }
 
+async function ensureBitbakeSettingsSane (bitbakeDriver: BitbakeDriver, focusOnError: boolean): Promise<boolean> {
+  if (bitbakeDriver.isBitbakeSettingsSane() || await bitbakeDriver.checkBitbakeSettingsSanity()) {
+    return true
+  }
+
+  if (focusOnError) {
+    await vscode.commands.executeCommand('bitbakeRecipes.focus')
+  }
+
+  return false
+}
+
 async function parseAllrecipes (bitbakeWorkspace: BitbakeWorkspace, taskProvider: BitbakeTaskProvider): Promise<void> {
   logger.debug('Command: parse-recipes')
 
-  if (!bitbakeSanity && !(await taskProvider.bitbakeDriver?.checkBitbakeSettingsSanity())) {
+  if (!(await ensureBitbakeSettingsSane(taskProvider.bitbakeDriver, true))) {
     logger.warn('bitbake settings are not sane, skip parse')
     return
   }
-  bitbakeSanity = true
 
   if (bitbakeESDKMode) {
     return
@@ -154,12 +164,10 @@ async function cleanRecipeCommand (bitbakeWorkspace: BitbakeWorkspace, bitBakePr
 async function scanEnvironmentCommand (taskProvider: BitbakeTaskProvider): Promise<void> {
   logger.debug('Executing command: scan-global-env')
 
-  if (!bitbakeSanity && !(await taskProvider.bitbakeDriver?.checkBitbakeSettingsSanity())) {
+  if (!(await ensureBitbakeSettingsSane(taskProvider.bitbakeDriver, true))) {
     logger.warn('bitbake settings are not sane, Abort scan')
     return
   }
-
-  bitbakeSanity = true
 
   if (bitbakeESDKMode) {
     return
@@ -178,12 +186,10 @@ async function scanRecipeCommand (bitbakeWorkspace: BitbakeWorkspace, taskProvid
 
   logger.debug('Command: scan-recipe-env')
 
-  if (!bitbakeSanity && !(await taskProvider.bitbakeDriver?.checkBitbakeSettingsSanity())) {
+  if (!(await ensureBitbakeSettingsSane(taskProvider.bitbakeDriver, true))) {
     logger.warn('bitbake settings are not sane, Abort scan')
     return
   }
-
-  bitbakeSanity = true
 
   if (bitbakeESDKMode) {
     return
@@ -374,13 +380,11 @@ export async function runBitbakeTask (task: vscode.Task, taskProvider: vscode.Ta
   }
 }
 
-async function rescanProject (bitBakeProjectScanner: BitBakeProjectScanner): Promise<void> {
-  bitbakeSanity = false
-  if (!(await bitBakeProjectScanner.bitbakeDriver?.checkBitbakeSettingsSanity())) {
+async function rescanProject (bitBakeProjectScanner: BitBakeProjectScanner, focusOnError: boolean): Promise<void> {
+  if (!(await ensureBitbakeSettingsSane(bitBakeProjectScanner.bitbakeDriver, focusOnError))) {
     logger.warn('bitbake settings are not sane, skip rescan')
     return
   }
-  bitbakeSanity = true
 
   await bitBakeProjectScanner.rescanProject()
 }

--- a/client/src/ui/BitbakeRecipesView.ts
+++ b/client/src/ui/BitbakeRecipesView.ts
@@ -8,6 +8,7 @@ import { BitbakeWorkspace } from './BitbakeWorkspace'
 import { type ElementInfo, type BitbakeScanResult, scanContainsRecipes } from '../lib/src/types/BitbakeScanResult'
 import path from 'path'
 import { BitBakeProjectScanner } from '../driver/BitBakeProjectScanner'
+import { type BitbakeDriver } from '../driver/BitbakeDriver'
 
 export class BitbakeRecipesView {
   private readonly bitbakeTreeProvider: BitbakeTreeDataProvider
@@ -15,6 +16,7 @@ export class BitbakeRecipesView {
 
   constructor (bitbakeWorkspace: BitbakeWorkspace, bitbakeProjectScanner: BitBakeProjectScanner) {
     this.bitbakeTreeProvider = new BitbakeTreeDataProvider(bitbakeWorkspace, bitbakeProjectScanner)
+    this.registerBitbakeSettingsErrorContext(bitbakeProjectScanner.bitbakeDriver)
   }
 
   registerView (context: vscode.ExtensionContext): void {
@@ -31,6 +33,17 @@ export class BitbakeRecipesView {
         this.view.title = 'BitBake recipes [' + activeConfigName + ']';
       }
     }
+  }
+
+  private registerBitbakeSettingsErrorContext (bitbakeDriver: BitbakeDriver): void {
+    const updateContext = (): void => {
+      const hasSettingsError = !bitbakeDriver.isBitbakeSettingsSane()
+      void vscode.commands.executeCommand('setContext', 'bitbake.settingsError', hasSettingsError)
+      this.bitbakeTreeProvider.setHideRecipes(hasSettingsError)
+    }
+
+    bitbakeDriver.onBitbakeSettingsSanityChange.on('change', updateContext)
+    updateContext()
   }
 }
 
@@ -72,6 +85,7 @@ class BitbakeTreeDataProvider implements vscode.TreeDataProvider<BitbakeRecipeTr
   readonly onDidChangeTreeData: vscode.Event<BitbakeRecipeTreeItem | undefined> = this._onDidChangeTreeData.event
   private readonly bitbakeProjectScanner: BitBakeProjectScanner
   private bitbakeScanResults: BitbakeScanResult
+  private hideRecipes = false
   private scanCompletePromise: Promise<void> | undefined
   private resolveScanCompletePromise: (() => void) | undefined
 
@@ -111,12 +125,21 @@ class BitbakeTreeDataProvider implements vscode.TreeDataProvider<BitbakeRecipeTr
     return element
   }
 
+  setHideRecipes (hideRecipes: boolean): void {
+    this.hideRecipes = hideRecipes
+    this._onDidChangeTreeData.fire(undefined)
+  }
+
   async getChildren (element?: BitbakeRecipeTreeItem | undefined): Promise<BitbakeRecipeTreeItem[]> {
     if (this.scanCompletePromise !== undefined) {
       await this.scanCompletePromise
       this.scanCompletePromise = undefined
     }
     if (element === undefined) {
+      if (this.hideRecipes) {
+        return []
+      }
+
       const items = this.getBitbakeRecipes()
       items.push(this.getAddRecipeItem())
       return items

--- a/client/src/ui/BitbakeStatusBar.ts
+++ b/client/src/ui/BitbakeStatusBar.ts
@@ -36,6 +36,10 @@ export class BitbakeStatusBar {
       this.updateStatusBar()
     })
 
+    this.bitbakeProjectScanner.bitbakeDriver.onBitbakeSettingsSanityChange.on('change', () => {
+      this.updateStatusBar()
+    })
+
     this.bitbakeProjectScanner.bitbakeDriver.onBitbakeProcessChange.on('spawn', (command) => {
       this.commandInProgress = command
       this.updateStatusBar()
@@ -104,7 +108,12 @@ export class BitbakeStatusBar {
       this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.prominentBackground')
       return
     }
-    if (this.scanExitCode !== 0) {
+    if (!this.bitbakeProjectScanner.bitbakeDriver.isBitbakeSettingsSane()) {
+      this.statusBarItem.text = '$(warning) BitBake: not configured'
+      this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
+      this.statusBarItem.command = 'bitbakeRecipes.focus'
+      this.statusBarItem.tooltip = this.bitbakeProjectScanner.bitbakeDriver.getBitbakeSettingsError() ?? 'BitBake settings have not been validated yet'
+    } else if (this.scanExitCode !== 0) {
       this.statusBarItem.text = '$(error) BitBake: Parsing error'
       this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground')
       this.statusBarItem.command = 'workbench.action.problems.focus'

--- a/client/src/ui/ClientNotificationManager.ts
+++ b/client/src/ui/ClientNotificationManager.ts
@@ -13,27 +13,6 @@ export class ClientNotificationManager {
     this._memento = memento
   }
 
-  showBitbakeSettingsError (message?: string): void {
-    logger.error('BitBake settings error: ' + message)
-    if (!this.checkIsNeverShowAgain('bitbake/bitbakeSettingsError')) {
-      void window.showErrorMessage(
-        'BitBake could not be configured and started. To enable advanced Bitbake features, please configure the Bitbake extension.\n\n' + message,
-        'Open Settings',
-        'Close',
-        'Don\'t Show Again'
-      )
-        .then((item) => {
-          if (item === 'Open Settings') {
-            void commands.executeCommand('workbench.action.openWorkspaceSettings', '@ext:yocto-project.yocto-bitbake')
-          } else if (item === 'Don\'t Show Again') {
-            void this.neverShowAgain('bitbake/bitbakeSettingsError')
-          }
-        }, (reason) => {
-          logger.warn('Could not show bitbake error dialog: ' + reason)
-        })
-    }
-  }
-
   showSDKUnavailableError (recipe: string): void {
     void window.showErrorMessage('Your version of devtool does not seem to support the `ide-sdk` command. Please update poky to enable SDK features. Alternatively, use the "Devtool: SDK fallback" command with less features.',
       'Run devtool SDK fallback',

--- a/package.json
+++ b/package.json
@@ -940,7 +940,14 @@
           "title": "bitbake"
         }
       ]
-    }
+    },
+    "viewsWelcome": [
+      {
+        "view": "bitbakeRecipes",
+        "contents": "BitBake could not be configured and started. Configure the extension to enable recipe scanning, navigation, and task commands.\n[Open BitBake walkthrough](command:workbench.action.openWalkthrough?%5B%22yocto-project.yocto-bitbake%23bitbake.getStarted%22%2Cfalse%5D)\n[Open BitBake settings](command:workbench.action.openWorkspaceSettings?%5B%22%40ext%3Ayocto-project.yocto-bitbake%22%5D)",
+        "when": "bitbake.settingsError"
+      }
+    ]
   },
   "scripts": {
     "postinstall": "cd server && npm install && cd ../client && npm install && cd ..",


### PR DESCRIPTION
## Summary

- move the BitBake settings/configuration startup error out of a recurring pop-up
- keep the error visible in the BitBake Recipes view instead
- add Recipes view actions to open the BitBake getting started walkthrough and workspace settings
- clear the Recipes view error when BitBake-related settings change
- add a unit test for the Recipes view error actions

## Notes

This follows the #360 follow-up item about revamping the "BitBake cannot be started" error into the recipes panel with a link to the walkthrough.

## Tests

Not run locally: `npm run jest -- client/src/__tests__/unit-tests/ui/bitbake-recipes-view.test.ts --runInBand`

Local dependencies are not installed in this checkout (`jest: not found`).