### PR TITLE
Add BitBake walkthrough setup check

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,16 +247,12 @@
           {
             "id": "bitbake.getStarted.settings",
             "title": "Configure BitBake settings",
-            "description": "Open VS Code Settings and search for `BitBake`. Configure the basic workspace settings needed to start BitBake, such as `bitbake.pathToBuildFolder`, `bitbake.pathToEnvScript`, and `bitbake.pathToBitbakeFolder`.",
+            "description": "Configure the basic workspace settings needed to start BitBake.\n[Open BitBake settings](command:workbench.action.openWorkspaceSettings?%5B%22%40ext%3Ayocto-project.yocto-bitbake%22%5D)",
             "media": {
-              "image": "images/config-picker.png",
-              "altText": "BitBake configuration picker"
+              "markdown": "walkthroughs/bitbake-settings.md"
             },
             "completionEvents": [
-              "onCommand:bitbake.pick-configuration",
-              "onSettingChanged:bitbake.pathToBuildFolder",
-              "onSettingChanged:bitbake.pathToEnvScript",
-              "onSettingChanged:bitbake.pathToBitbakeFolder"
+              "onContext:!bitbake.settingsError"
             ]
           },
           {

--- a/walkthroughs/bitbake-settings.md
+++ b/walkthroughs/bitbake-settings.md
@@ -1,0 +1,11 @@
+# Configure BitBake settings
+
+Configure the basic workspace settings required to start BitBake from the extension.
+
+The most common manual setup path uses:
+
+- `bitbake.pathToBitbakeFolder`
+- `bitbake.pathToEnvScript`
+- `bitbake.pathToBuildFolder`
+
+The settings editor contains the detailed descriptions for each setting. After the settings are changed, the extension automatically checks whether BitBake can be started and updates the Recipes Explorer and status bar.


### PR DESCRIPTION
## Summary

Add a small interactive setup check command to the BitBake getting started walkthrough.

The new `bitbake.check-setup` command performs a read-only validation of the current workspace setup by reusing the existing BitBake settings sanity check. It is linked from the walkthrough dependency/setup page and added as a walkthrough completion event.

When the setup looks valid, the command shows a success message. When it is incomplete, it offers to focus the Recipes Explorer so users can see the configuration guidance already shown there.

## Scope

This intentionally keeps the first interactive layer small and non-invasive:
- no package installation automation
- no sudo/AppArmor automation
- no settings mutation
- no webview/form helper yet

## Tests

- `npm run jest -- client/src/__tests__/unit-tests/ui/bitbake-recipes-view.test.ts --runInBand`
- `npm run jest -- client/src/__tests__/unit-tests/ui/bitbake-commands.test.ts --runInBand`