### PR TITLE
Preserve sane BitBake state for restored scan cache

### DIFF
--- a/client/src/__tests__/unit-tests/driver/bitbake-driver.test.ts
+++ b/client/src/__tests__/unit-tests/driver/bitbake-driver.test.ts
@@ -171,6 +171,18 @@ describe('BitbakeDriver Tests', () => {
         error: 'devtool not found in $PATH\nSee Bitbake Terminal for command output.'
       })
     })
+
+    it('can mark cached BitBake settings as sane', () => {
+      const bitbakeDriver = new BitbakeDriver()
+      const onSanityChange = jest.fn()
+      bitbakeDriver.onBitbakeSettingsSanityChange.on('change', onSanityChange)
+
+      bitbakeDriver.markBitbakeSettingsSane()
+
+      expect(bitbakeDriver.isBitbakeSettingsSane()).toStrictEqual(true)
+      expect(bitbakeDriver.getBitbakeSettingsError()).toBeUndefined()
+      expect(onSanityChange).toHaveBeenCalledWith({ sane: true, error: undefined })
+    })
   })
 
   describe('composeBitbakeCommand', () => {

--- a/client/src/driver/BitbakeDriver.ts
+++ b/client/src/driver/BitbakeDriver.ts
@@ -55,6 +55,10 @@ export class BitbakeDriver {
     return this.bitbakeSettingsError
   }
 
+  markBitbakeSettingsSane (): void {
+    this.setBitbakeSettingsSanity(true)
+  }
+
   private setBitbakeSettingsSanity (sane: boolean, error?: string): void {
     this.bitbakeSettingsSane = sane
     this.bitbakeSettingsError = error

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -184,14 +184,17 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
   // Handle settings change for bitbake driver
   context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async (event) => {
     const currentSettings = vscode.workspace.getConfiguration('bitbake')
+    const wasBitbakeSettingsSane = bitbakeDriver.isBitbakeSettingsSane()
     bitbakeDriver.loadSettings(currentSettings, vscode.workspace.workspaceFolders?.[0].uri.fsPath)
-    if (event.affectsConfiguration('bitbake.shellEnv') ||
-        event.affectsConfiguration('bitbake.workingDirectory') ||
-        event.affectsConfiguration('bitbake.pathToEnvScript') ||
-        event.affectsConfiguration('bitbake.pathToBitbakeFolder') ||
-        event.affectsConfiguration('bitbake.pathToBuildFolder') ||
-        event.affectsConfiguration('bitbake.commandWrapper') ||
-        event.affectsConfiguration('bitbake.buildConfigurations')) {
+    const bitbakeSettingsChanged = event.affectsConfiguration('bitbake.shellEnv') ||
+      event.affectsConfiguration('bitbake.workingDirectory') ||
+      event.affectsConfiguration('bitbake.pathToEnvScript') ||
+      event.affectsConfiguration('bitbake.pathToBitbakeFolder') ||
+      event.affectsConfiguration('bitbake.pathToBuildFolder') ||
+      event.affectsConfiguration('bitbake.commandWrapper') ||
+      event.affectsConfiguration('bitbake.buildConfigurations')
+
+    if (bitbakeSettingsChanged) {
       bitbakeConfigPicker.updateStatusBar(bitbakeDriver.bitbakeSettings)
       logger.debug('Bitbake settings changed')
       updatePythonPath()
@@ -201,6 +204,8 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
         void vscode.commands.executeCommand('bitbake.parse-recipes')
         bitBakeProjectScanner.onChange.emit(BitBakeProjectScanner.EventType.SCAN_COMPLETE, bitBakeProjectScanner.activeScanResult)
       }
+    } else if (wasBitbakeSettingsSane && scanContainsData(bitBakeProjectScanner.activeScanResult)) {
+      bitbakeDriver.markBitbakeSettingsSane()
     }
     if (event.affectsConfiguration('bitbake.loggingLevel')) {
       loadLoggerSettings()
@@ -283,6 +288,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
   // In case we restored a scan from the cache, tell all listeners about it
   // FIXME it would be better if all UI participants directly read the cache at initialization than refreshing them here
   if (scanContainsData(bitBakeProjectScanner.activeScanResult)) {
+    bitbakeDriver.markBitbakeSettingsSane()
     bitBakeProjectScanner.onChange.emit(BitBakeProjectScanner.EventType.SCAN_COMPLETE, bitBakeProjectScanner.activeScanResult)
   } else {
     void vscode.commands.executeCommand('bitbake.rescan-project', false)


### PR DESCRIPTION
## Summary

Fix #509.

When a workspace is reopened with a valid restored scan cache, the extension should not initialize the BitBake UI in the “not configured” state.

The fix marks the BitBake settings sanity state as sane when restored scan data is available, before emitting the cached `SCAN_COMPLETE` event to UI listeners.

## Tests

- `npm run jest -- client/src/__tests__/unit-tests/driver/bitbake-driver.test.ts --runInBand`
- `npm run jest -- client/src/__tests__/unit-tests/ui/bitbake-recipes-view.test.ts --runInBand`
- `npm run jest -- client/src/__tests__/unit-tests/ui/bitbake-commands.test.ts --runInBand`