### PR TITLE
test: finish integration run on success

### DIFF
--- a/integration-tests/src/index.ts
+++ b/integration-tests/src/index.ts
@@ -20,12 +20,14 @@ export async function run (): Promise<void> {
   files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)))
 
   // Run the mocha test
-  mocha.run(failures => {
-    if (failures > 0) {
-      throw new Error('Tests failed: ' + failures)
-    } else {
-      // Say that the tests passed
-      console.log('All tests passed.')
-    }
+  await new Promise<void>((resolve, reject) => {
+    mocha.run(failures => {
+      if (failures > 0) {
+        reject(new Error('Tests failed: ' + failures))
+      } else {
+        console.log('All tests passed.')
+        resolve()
+      }
+    })
   })
 }

--- a/integration-tests/src/tests/bitbake-parse.test.ts
+++ b/integration-tests/src/tests/bitbake-parse.test.ts
@@ -40,27 +40,16 @@ suite('Bitbake Parsing Test Suite', () => {
     await vscode.commands.executeCommand('bitbake.parse-recipes')
     await parsingResult
 
-    await assertWillComeTrue(async () => {
-      const diagnostics = vscode.languages.getDiagnostics()
+      await assertWillComeTrue(async () => {
+        const diagnostics = vscode.languages.getDiagnostics()
 
-      // Only 1 file has problem(s)
-      if (diagnostics.length !== 1) {
-        return false
-      }
-      // Only 1 problem on the file
-      if (diagnostics[0][1].length !== 1) {
-        return false
-      }
-
-      if (!diagnostics[0][0].path.includes('recipes-core/base-files/unparsed-line.bb')) {
-        return false
-      }
-      if (!diagnostics[0][1][0].message.includes('unparsed line: \'undefinedvariable\'')) {
-        return false
-      }
-
-      return true
-    })
+        return diagnostics.some(([uri, uriDiagnostics]) =>
+          uri.path.includes('recipes-core/base-files/unparsed-line.bb') &&
+          uriDiagnostics.some(diagnostic =>
+            diagnostic.message.includes('unparsed line: \'undefinedvariable\'')
+          )
+        )
+      })
 
     await removeRecipe(errorRecipePath, pokyPath)
   }).timeout(BITBAKE_TIMEOUT)

--- a/integration-tests/src/tests/bitbake-parse.test.ts
+++ b/integration-tests/src/tests/bitbake-parse.test.ts
@@ -36,8 +36,9 @@ suite('Bitbake Parsing Test Suite', () => {
   test('Bitbake can detect parsing errors', async () => {
     await importRecipe(errorRecipePath, pokyPath)
 
+    const parsingResult = awaitBitbakeParsingResult()
     await vscode.commands.executeCommand('bitbake.parse-recipes')
-    await awaitBitbakeParsingResult()
+    await parsingResult
 
     await assertWillComeTrue(async () => {
       const diagnostics = vscode.languages.getDiagnostics()


### PR DESCRIPTION
This updates the integration test runner so the async run() function waits for the Mocha run to complete.

Without wrapping mocha.run() in a Promise, the extension test entrypoint can report completion before Mocha has actually finished. The change keeps the existing failure behavior, but resolves on success only after Mocha reports zero failures.

This also fixes a race in the BitBake parsing integration test. The test previously started waiting for the parse task after executing bitbake.parse-recipes. In CI, the parse task could already be running by then, so the test could miss the task lifecycle event and eventually time out. The wait is now armed before triggering the command.

Finally, the parsing test now searches for the expected unparsed-line diagnostic instead of requiring it to be the only diagnostic in the whole workspace. CI can expose additional diagnostics or a different diagnostic ordering, so the test should assert the diagnostic it owns rather than assuming global diagnostic state.

During the triage for this PR, I also noticed a separate issue around Python/Pylance diagnostics for embedded BitBake Python documents in headless VS Code. I confirmed that Pylance can report reportUndefinedVariable in a normal workspace Python file, while the embedded BitBake Python documents were not consistently producing the expected diagnostics/actions in that investigation. I kept that out of this PR because it is a separate follow-up and tracked it separately in #514.
