### PR TITLE
test: avoid localized code action titles

### DIFF
--- a/integration-tests/src/tests/code-actions.test.ts
+++ b/integration-tests/src/tests/code-actions.test.ts
@@ -25,7 +25,6 @@ suite('Bitbake CodeAction Test Suite', () => {
 
   const testPythonAddImport = async (
     targetRange: vscode.Range,
-    expectedTitle: string,
     expectedNewText: string,
     expectedRange: vscode.Range
   ): Promise<void> => {
@@ -40,37 +39,39 @@ suite('Bitbake CodeAction Test Suite', () => {
       return actionResult.length > 0
     })
 
-    const expectedAction = actionResult.find(action => action.title === expectedTitle)
-    if (expectedAction === undefined) {
-      assert.fail('expectedAction is undefined')
-    }
-    assert.notEqual(expectedAction, undefined)
-    const workspaceEdit = expectedAction.edit
-    if (workspaceEdit === undefined) {
-      assert.fail('edit is undefined')
-    }
-    assert.strictEqual(workspaceEdit.entries().length, 1)
-    const [uri, textEdit] = workspaceEdit.entries()[0]
-    assert.strictEqual(uri.fsPath, docUri.fsPath)
-    assert.strictEqual(textEdit.length, 1)
-    assert.strictEqual(textEdit[0].newText, expectedNewText)
-    const range = textEdit[0].range
-    assert.strictEqual(range.start.isEqual(expectedRange.start), true)
+    // Code action titles are user-facing and can be localized by VS Code/Pylance.
+    // Assert the stable edit instead of matching a locale-dependent title.
+    const expectedAction = actionResult.find(action => {
+      const entries = action.edit?.entries()
+      if (entries === undefined || entries.length !== 1) {
+        return false
+      }
+
+      const [uri, textEdit] = entries[0]
+      return uri.fsPath === docUri.fsPath &&
+        textEdit.length === 1 &&
+        textEdit[0].newText === expectedNewText &&
+        textEdit[0].range.isEqual(expectedRange)
+    })
+
+    assert.notStrictEqual(
+      expectedAction,
+      undefined,
+      `No code action produced the expected edit: ${JSON.stringify(expectedNewText)}`
+    )
   }
 
   test('CodeAction can properly show "import random"', async () => {
     const targetRange = new vscode.Range(1, 4, 1, 10)
-    const expectedTitle = 'Add "import random"'
     const expectedNewText = '    import random\n'
     const expectedRange = new vscode.Range(1, 0, 1, 0)
-    await testPythonAddImport(targetRange, expectedTitle, expectedNewText, expectedRange)
+    await testPythonAddImport(targetRange, expectedNewText, expectedRange)
   }).timeout(BITBAKE_TIMEOUT)
 
   test('CodeAction can properly show "from random import random"', async () => {
     const targetRange = new vscode.Range(1, 4, 1, 10)
-    const expectedTitle = 'Add "from random import random"'
     const expectedNewText = '    from random import random\n'
     const expectedRange = new vscode.Range(1, 0, 1, 0)
-    await testPythonAddImport(targetRange, expectedTitle, expectedNewText, expectedRange)
+    await testPythonAddImport(targetRange, expectedNewText, expectedRange)
   }).timeout(BITBAKE_TIMEOUT)
 })


### PR DESCRIPTION
This fixes #514.

The code-action integration test was matching the user-facing CodeAction title returned by VS Code/Pylance. Those titles can be localized; for example, on my local environment the actions were returned as:

- `Aggiungi "import random"`
- `Aggiungi "from random import random"`

while the test expected the English titles:

- `Add "import random"`
- `Add "from random import random"`

The test now matches the stable workspace edit produced by the action instead of matching the localized title.

Validation performed locally before opening the clean PR branch:

- `npm run compile`
- `npm run lint --if-present`
- full integration suite with this change stacked on the now-merged #513 fixes: `36 passing`, `All tests passed.`, `Exit code: 0`

Closes #514.