### PR TITLE
fix(ui): hide ide-sdk command in eSDK mode

### DIFF
--- a/client/src/__tests__/unit-tests/driver/eSDKMode.test.ts
+++ b/client/src/__tests__/unit-tests/driver/eSDKMode.test.ts
@@ -10,12 +10,23 @@ import * as ProcessUtils from '../../../utils/ProcessUtils'
 import { bitbakeESDKMode, setBitbakeESDKMode } from '../../../driver/BitbakeESDK'
 import { SpawnSyncReturns } from 'child_process'
 import { IPty } from 'node-pty'
+import * as vscode from 'vscode'
 
 // Yocto's eSDKs contain devtool but not bitbake. These tests ensure we can still provide devtool functionalities without bitbake.
 describe('Devtool eSDK Mode Test Suite', () => {
   afterEach(() => {
-    jest.clearAllMocks()
     setBitbakeESDKMode(false)
+    jest.clearAllMocks()
+  })
+
+  it('updates the VS Code eSDK mode context', () => {
+    setBitbakeESDKMode(true)
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith('setContext', 'bitbake.eSDKMode', true)
+
+    jest.clearAllMocks()
+
+    setBitbakeESDKMode(false)
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith('setContext', 'bitbake.eSDKMode', false)
   })
 
   it('should scan devtool without bitbake', async () => {

--- a/client/src/driver/BitbakeESDK.ts
+++ b/client/src/driver/BitbakeESDK.ts
@@ -4,6 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import path from 'path'
+import * as vscode from 'vscode'
 import { getBuildSetting, type BitbakeSettings } from '../lib/src/BitbakeSettings'
 import { type DevtoolWorkspaceInfo } from '../lib/src/types/BitbakeScanResult'
 import { loadJsonFile, setJsonProperty, saveJsonFile, mergeJsonArray } from '../utils/JSONFile'
@@ -17,6 +18,7 @@ export let bitbakeESDKMode: boolean = false
 
 export function setBitbakeESDKMode (mode: boolean): void {
   bitbakeESDKMode = mode
+  void vscode.commands.executeCommand('setContext', 'bitbake.eSDKMode', mode)
 }
 
 function createVSCodeFolderIfNotExists (workspace: string): void {

--- a/package.json
+++ b/package.json
@@ -535,7 +535,8 @@
       {
         "command": "bitbake.devtool-ide-sdk",
         "title": "BitBake: Devtool: Configure VSCode SDK",
-        "description": "Configure a devtool sources' workspace for cross-compilation and debugging."
+        "description": "Configure a devtool sources' workspace for cross-compilation and debugging.",
+        "enablement": "!bitbake.eSDKMode"
       },
       {
         "command": "bitbake.devtool-sdk-fallback",
@@ -709,7 +710,8 @@
         },
         {
           "command": "bitbake.devtool-ide-sdk",
-          "group": "1@devtool_dev@1"
+          "group": "1@devtool_dev@1",
+          "when": "!bitbake.eSDKMode"
         },
         {
           "command": "bitbake.devtool-sdk-fallback",
@@ -905,7 +907,7 @@
         {
           "command": "bitbake.devtool-ide-sdk",
           "group": "1@devtool_dev@1",
-          "when": "viewItem == devtoolWorskpaceCtx"
+          "when": "viewItem == devtoolWorskpaceCtx && !bitbake.eSDKMode"
         },
         {
           "command": "bitbake.devtool-sdk-fallback",


### PR DESCRIPTION
Fixes #490.

`devtool ide-sdk` is not available in eSDK mode, so the corresponding VS Code command should not be exposed in the UI when the extension detects an eSDK environment.

This updates the eSDK mode setter to publish a VS Code context key and uses that context to disable/hide `bitbake.devtool-ide-sdk` from the command contribution and devtool menus while in eSDK mode.

Validation:
- `npm run compile`
- `npm run jest -- client/src/__tests__/unit-tests/driver/eSDKMode.test.ts`