### PR TITLE
fix(ui): avoid modal path mapping errors

### DIFF
--- a/client/src/__tests__/unit-tests/driver/scanner-unit.test.ts
+++ b/client/src/__tests__/unit-tests/driver/scanner-unit.test.ts
@@ -3,9 +3,17 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { parseRecipesOutput } from '../../../driver/BitBakeProjectScanner'
+import * as vscode from 'vscode'
+import { BitBakeProjectScanner, parseRecipesOutput } from '../../../driver/BitBakeProjectScanner'
+import { BitbakeDriver } from '../../../driver/BitbakeDriver'
+
+jest.mock('vscode')
 
 describe('BitBakeProjectScanner unit tests', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   const layers = [
     {
       name: 'meta-variscite-bsp-imx',
@@ -68,4 +76,35 @@ systemd:
       })
     )
   })
+  it('shows a non-modal error when path mapping fails', async () => {
+    const scanner = new BitBakeProjectScanner(new BitbakeDriver())
+
+    const scannerInternals = scanner as unknown as {
+      hostMountPoint: string
+      containerMountPoint: string
+      existsInContainer: (containerPath: string) => Promise<boolean>
+    }
+
+    scannerInternals.hostMountPoint = '/host'
+    scannerInternals.containerMountPoint = '/container'
+
+    jest.spyOn(scannerInternals, 'existsInContainer').mockResolvedValue(false)
+
+    const errorSpy = jest.spyOn(vscode.window, 'showErrorMessage')
+      .mockResolvedValue(undefined)
+
+    await scanner.resolveHostPath('/container/test.bb')
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Bitbake extension couldn\'t locate a file')
+    )
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('bitbake.commandWrapper')
+    )
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/container/test.bb')
+    )
+    expect(errorSpy.mock.calls[0]).toHaveLength(1)
+  })
+
 })

--- a/client/src/driver/BitBakeProjectScanner.ts
+++ b/client/src/driver/BitBakeProjectScanner.ts
@@ -292,15 +292,12 @@ export class BitBakeProjectScanner {
       resolvedPath = path.resolve(destMountPoint, relativePath.replace('../', ''))
     }
     if (!await fileExistsFn(resolvedPath)) {
-      // Showing a modal here because this can only happend through the command devtool-update-recipe which is not used often
       if (!quiet) {
-        await vscode.window.showErrorMessage(
-          'Bitbake extension couldn\'t locate a file.', {
-            modal: true,
-            detail: `It looks like you are using the bitbake.commandWrapper setting to use a docker container.\n
-Couldn't find ${inputPath} corresponding paths inside and outside of the container.\n
-You should adjust your docker volumes to use the same URIs as those present on your host machine.`
-          })
+        const message = 'Bitbake extension couldn\'t locate a file. ' +
+          'It looks like you are using the bitbake.commandWrapper setting to use a docker container. ' +
+          `Couldn't find ${inputPath} corresponding paths inside and outside of the container. ` +
+          'You should adjust your docker volumes to use the same URIs as those present on your host machine.'
+        await vscode.window.showErrorMessage(message)
       }
       return resolvedPath
     }


### PR DESCRIPTION
Fixes #441.

The container path mapping error was displayed as a modal VS Code error dialog.

If that dialog cannot be dismissed correctly, it can block the full VS Code UI and force the user to kill the application.

This change keeps the existing error notification and diagnostic details, but avoids using a modal dialog for the container path mapping failure.

Only the path mapping error in BitBakeProjectScanner was changed. Other modal dialogs remain unchanged.

Validation:
- npm run compile
- npm run jest -- client/src/__tests__/unit-tests/driver/path-mapping-errors.test.ts