### PR TITLE
test: fetch split Yocto 6.0 repositories

### DIFF
--- a/client/src/__tests__/unit-tests/driver/scanner.test.ts
+++ b/client/src/__tests__/unit-tests/driver/scanner.test.ts
@@ -174,7 +174,9 @@ describe('BitBakeProjectScanner', () => {
         })
       })
     )
-    const goCrossRecipe = recipes.find((recipe) => recipe.name.includes('go-cross-core2-64'))
+    const goCrossRecipe = recipes.find(
+      (recipe) => recipe.name.startsWith('go-cross-') && recipe.path?.base.includes('go-cross_')
+    )
     expect(goCrossRecipe).toEqual(
       expect.objectContaining({
         path: expect.objectContaining({

--- a/scripts/fetch-poky.sh
+++ b/scripts/fetch-poky.sh
@@ -1,12 +1,30 @@
 #!/bin/bash
 
-# Tag: yocto-5.2.2
-COMMIT=41038342a471b4a8884548568ad147a1704253a3
+BITBAKE_TAG=yocto-6.0
+BITBAKE_COMMIT=33581c84f3a85008239acbd940501a35de48dc91
+OE_CORE_TAG=yocto-6.0
+OE_CORE_COMMIT=42fa856a00ac16b2a7a83d7ecfa60a5be192b16c
+META_YOCTO_TAG=yocto-6.0
+META_YOCTO_COMMIT=904846ae078ee20de073040ebb77c86e19250f56
 
 set -e
 
-mkdir -p resources/poky
-cd resources/poky
-git clone https://github.com/yoctoproject/poky.git .
-git fetch origin
-git checkout $COMMIT
+cd "$(dirname "$(readlink -f "$0")")/.."
+
+YOCTO_DIR="resources/poky"
+
+clone_repo() {
+    local url="$1"
+    local tag="$2"
+    local commit="$3"
+    local destination="$4"
+
+    git clone --depth 1 --branch "$tag" "$url" "$destination"
+    git -C "$destination" checkout --detach "$commit"
+}
+
+mkdir -p "$YOCTO_DIR"
+
+clone_repo https://git.openembedded.org/bitbake "$BITBAKE_TAG" "$BITBAKE_COMMIT" "$YOCTO_DIR/bitbake"
+clone_repo https://git.openembedded.org/openembedded-core "$OE_CORE_TAG" "$OE_CORE_COMMIT" "$YOCTO_DIR/openembedded-core"
+clone_repo https://git.yoctoproject.org/meta-yocto "$META_YOCTO_TAG" "$META_YOCTO_COMMIT" "$YOCTO_DIR/meta-yocto"

--- a/scripts/fetch-poky.sh
+++ b/scripts/fetch-poky.sh
@@ -28,3 +28,42 @@ mkdir -p "$YOCTO_DIR"
 clone_repo https://git.openembedded.org/bitbake "$BITBAKE_TAG" "$BITBAKE_COMMIT" "$YOCTO_DIR/bitbake"
 clone_repo https://git.openembedded.org/openembedded-core "$OE_CORE_TAG" "$OE_CORE_COMMIT" "$YOCTO_DIR/openembedded-core"
 clone_repo https://git.yoctoproject.org/meta-yocto "$META_YOCTO_TAG" "$META_YOCTO_COMMIT" "$YOCTO_DIR/meta-yocto"
+
+ln -s openembedded-core/oe-init-build-env "$YOCTO_DIR/oe-init-build-env"
+ln -s openembedded-core/meta "$YOCTO_DIR/meta"
+ln -s openembedded-core/scripts "$YOCTO_DIR/scripts"
+ln -s meta-yocto/meta-poky "$YOCTO_DIR/meta-poky"
+ln -s meta-yocto/meta-yocto-bsp "$YOCTO_DIR/meta-yocto-bsp"
+
+TEMPLATE_DIR="$YOCTO_DIR/meta-poky/conf/templates/vscode-bitbake"
+mkdir -p "$TEMPLATE_DIR"
+cp -R "$YOCTO_DIR/meta/conf/templates/default/." "$TEMPLATE_DIR/"
+
+cat > "$TEMPLATE_DIR/bblayers.conf.sample" <<'BBLAYERS_EOF'
+# LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+LCONF_VERSION = "7"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  ##OEROOT##/meta \
+  ##OEROOT##/meta-poky \
+  ##OEROOT##/meta-yocto-bsp \
+  "
+BBLAYERS_EOF
+
+cat >> "$TEMPLATE_DIR/local.conf.sample" <<'LOCALCONF_EOF'
+
+#
+# Keep the vscode-bitbake integration workspace aligned with the Yocto Project
+# reference distro assumptions exercised by the scanner tests.
+#
+DISTRO ?= "poky"
+LOCALCONF_EOF
+
+cat > "$YOCTO_DIR/.templateconf" <<'TEMPLATECONF_EOF'
+# Template settings
+TEMPLATECONF=${TEMPLATECONF:-meta-poky/conf/templates/vscode-bitbake}
+TEMPLATECONF_EOF

--- a/scripts/update-ref.sh
+++ b/scripts/update-ref.sh
@@ -2,12 +2,41 @@
 
 # Update the fetch-poky.sh script
 FILE="scripts/fetch-poky.sh"
-LATEST_REF=$(git ls-remote --tags https://github.com/yoctoproject/poky.git | grep "yocto-" | tail -n 1)
-LATEST_COMMIT=$(echo $LATEST_REF | awk '{print $1}')
-LATEST_TAG=$(echo $LATEST_REF | awk '{print $2}' |  sed -e "s/refs\\/tags\\///" -e "s/\^.*//")
-sed -i $FILE \
-    -e "s/^\(# Tag: \).*/\1$LATEST_TAG/" \
-    -e "s/^\(COMMIT=\).*/\1$LATEST_COMMIT/"
+
+latest_yocto_release_ref() {
+    git ls-remote --tags "$1" 'refs/tags/yocto-*^{}' \
+        | awk '$2 ~ /^refs\/tags\/yocto-[0-9]+(\.[0-9]+)*\^\{\}$/ { print $0 }' \
+        | sort -V -k2 \
+        | tail -n 1
+}
+
+update_yocto_ref() {
+    local url="$1"
+    local tag_variable="$2"
+    local commit_variable="$3"
+
+    local latest_ref
+    latest_ref=$(latest_yocto_release_ref "$url")
+
+    if [ -z "$latest_ref" ]; then
+        echo "Could not find Yocto release tags for $url" >&2
+        exit 1
+    fi
+
+    local latest_commit
+    latest_commit=$(echo "$latest_ref" | awk '{print $1}')
+
+    local latest_tag
+    latest_tag=$(echo "$latest_ref" | awk '{print $2}' | sed -e "s/refs\\/tags\\///" -e "s/\^{}//")
+
+    sed -i "$FILE" \
+        -e "s/^\(${tag_variable}=\).*/\1$latest_tag/" \
+        -e "s/^\(${commit_variable}=\).*/\1$latest_commit/"
+}
+
+update_yocto_ref https://git.openembedded.org/bitbake BITBAKE_TAG BITBAKE_COMMIT
+update_yocto_ref https://git.openembedded.org/openembedded-core OE_CORE_TAG OE_CORE_COMMIT
+update_yocto_ref https://git.yoctoproject.org/meta-yocto META_YOCTO_TAG META_YOCTO_COMMIT
 
 # Update the version.ts
 FILE="integration-tests/src/utils/version.ts"


### PR DESCRIPTION
## Summary

- Fetch the Yocto 6.0 Wrynose integration test workspace from the split BitBake, OE-Core, and meta-yocto repositories.
- Preserve the existing `resources/poky` compatibility layout for the current integration tests by adding symlinks and a temporary vscode-bitbake template.
- Update the scanner test expectation for the Wrynose `go-cross-*` recipe naming.

## Notes

The compatibility layout is intentionally kept separate from the split-repository fetch change so it can be revisited later, likely alongside a setup aligned with the Wrynose quick-start / `bitbake-setup` workflow.

The `yocto-docs` fetch script is not changed in this PR; I can handle that separately.

## Testing

- `bash -n scripts/fetch-poky.sh`
- `bash -n scripts/update-ref.sh`
- `npm run clean`
- `npm run fetch:poky`
- `npm run compile`
- `npm run lint -- client/src/__tests__/unit-tests/driver/scanner.test.ts`
- `npm run jest -- --runTestsByPath client/src/__tests__/unit-tests/driver/scanner.test.ts --runInBand`
- `git diff --check`
