### PR TITLE
fix: keep parse-on-save scans quiet on config errors

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -257,6 +257,9 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
       if (parseOnSave !== true) {
         return
       }
+      if (!bitbakeDriver.isBitbakeSettingsSane() && !await bitbakeDriver.checkBitbakeSettingsSanity()) {
+        return
+      }
       const recipeExts = ['.bb', '.bbappend', '.inc']
       const extsForGlobalEnvScan = ['.conf', '.bbclass']
       const { fsPath } = document.uri

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -257,6 +257,8 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
       if (parseOnSave !== true) {
         return
       }
+      // Parse-on-save is automatic: skip invalid settings instead of running
+      // commands that would focus the BitBake view on every save.
       if (!bitbakeDriver.isBitbakeSettingsSane() && !await bitbakeDriver.checkBitbakeSettingsSanity()) {
         return
       }


### PR DESCRIPTION
## Summary

- Skip automatic parse-on-save scans when the BitBake settings are not sane.
- Keep manually invoked commands unchanged, so they can still focus the BitBake view on configuration errors.

## Testing

- `npm run compile`
- `npm run lint -- client/src/extension.ts`
- `git diff --check`

Fixes #525.
