### PR TITLE
fix: update status bar after picking config by name

### DIFF
--- a/client/src/ui/BitbakeConfigPicker.ts
+++ b/client/src/ui/BitbakeConfigPicker.ts
@@ -61,6 +61,7 @@ export class BitbakeConfigPicker {
     if (this.bitbakeSettings?.buildConfigurations !== undefined && this.bitbakeSettings?.buildConfigurations?.length > 0) {
       if (name !== undefined && this.bitbakeSettings.buildConfigurations.find((config) => config.name === name) !== undefined) {
         this.activeBuildConfiguration = name
+        this.updateStatusBar(this.bitbakeSettings)
       } else {
         const options = this.bitbakeSettings.buildConfigurations.map((config) => config.name)
         const filteredOptions = options.filter((option) => typeof option === 'string') as string[] // Always all according to the definition in client/package.json


### PR DESCRIPTION
## Summary

- Update the BitBake configuration status bar when `bitbake.pick-configuration` is called with a configuration name.
- Keep the existing QuickPick behavior unchanged.

## Testing

- `npm run compile`
- `npm run lint -- client/src/ui/BitbakeConfigPicker.ts`
- `git diff --check`

Fixes #531.