### PR TITLE
refactor: simplify BitBake config picker flow

### DIFF
--- a/client/src/__tests__/unit-tests/ui/bitbake-config-picker.test.ts
+++ b/client/src/__tests__/unit-tests/ui/bitbake-config-picker.test.ts
@@ -1,0 +1,105 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode'
+import { BitbakeConfigPicker } from '../../../ui/BitbakeConfigPicker'
+import { type BitbakeSettings } from '../../../lib/src/BitbakeSettings'
+import { createStatusBarItemMock, mockVscodeExtensionContext, type StatusBarItemMock } from '../../utils/vscodeMock'
+
+jest.mock('vscode')
+
+
+function createBitbakeSettings (): BitbakeSettings {
+  return {
+    pathToBitbakeFolder: '',
+    buildConfigurations: [
+      {
+        name: 'Default',
+        pathToBuildFolder: '/tmp/default-build'
+      },
+      {
+        name: 'Alternative',
+        pathToBuildFolder: '/tmp/alternative-build'
+      }
+    ]
+  }
+}
+
+function mockShowQuickPickSelection (selection: string | undefined): void {
+  jest.spyOn(vscode.window, 'showQuickPick').mockResolvedValue(
+    selection as unknown as vscode.QuickPickItem
+  )
+}
+
+function createPicker (): {
+  picker: BitbakeConfigPicker
+  statusBarItem: StatusBarItemMock
+} {
+  const statusBarItem = createStatusBarItemMock()
+  jest.spyOn(vscode.window, 'createStatusBarItem').mockReturnValue(statusBarItem)
+
+  const extensionContext = mockVscodeExtensionContext()
+  extensionContext.workspaceState.get.mockReturnValue('No BitBake configuration')
+  extensionContext.workspaceState.update.mockResolvedValue(undefined)
+
+  const picker = new BitbakeConfigPicker(createBitbakeSettings(), extensionContext)
+
+  return {
+    picker,
+    statusBarItem
+  }
+}
+
+describe('BitbakeConfigPicker', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('selects and shows the first build configuration by default', () => {
+    const { picker, statusBarItem } = createPicker()
+
+    expect(picker.activeBuildConfiguration).toBe('Default')
+    expect(statusBarItem.text).toBe('$(list-selection) Default')
+    expect(statusBarItem.command).toBe('bitbake.pick-configuration')
+    expect(statusBarItem.tooltip).toBe('Select BitBake buildConfiguration')
+    expect(statusBarItem.show).toHaveBeenCalled()
+  })
+
+  it('updates the status bar when picking a configuration by name', async () => {
+    const { picker, statusBarItem } = createPicker()
+
+    await picker.pickConfiguration('Alternative')
+
+    expect(picker.activeBuildConfiguration).toBe('Alternative')
+    expect(statusBarItem.text).toBe('$(list-selection) Alternative')
+    expect(statusBarItem.show).toHaveBeenCalled()
+    expect(vscode.window.showQuickPick).not.toHaveBeenCalled()
+  })
+
+  it('updates the status bar when picking a configuration from the QuickPick', async () => {
+    const { picker, statusBarItem } = createPicker()
+    mockShowQuickPickSelection('Alternative')
+
+    await picker.pickConfiguration()
+
+    expect(vscode.window.showQuickPick).toHaveBeenCalledWith(
+      ['Default', 'Alternative'],
+      { placeHolder: 'Select a BitBake configuration' }
+    )
+    expect(picker.activeBuildConfiguration).toBe('Alternative')
+    expect(statusBarItem.text).toBe('$(list-selection) Alternative')
+  })
+
+  it('keeps the current configuration when the QuickPick is cancelled', async () => {
+    const { picker, statusBarItem } = createPicker()
+    mockShowQuickPickSelection(undefined)
+
+    await picker.pickConfiguration('Unknown')
+
+    expect(vscode.window.showQuickPick).toHaveBeenCalled()
+    expect(picker.activeBuildConfiguration).toBe('Default')
+    expect(statusBarItem.text).toBe('$(list-selection) Default')
+  })
+})

--- a/client/src/__tests__/utils/vscodeMock.ts
+++ b/client/src/__tests__/utils/vscodeMock.ts
@@ -5,6 +5,31 @@
 
 import * as vscode from 'vscode'
 
+export type StatusBarItemMock = vscode.StatusBarItem & {
+  text: string
+  command: string
+  tooltip: string
+  show: jest.Mock
+  hide: jest.Mock
+}
+
+export type VscodeExtensionContextMock = vscode.ExtensionContext & {
+  workspaceState: {
+    get: jest.Mock
+    update: jest.Mock
+  }
+}
+
+export function createStatusBarItemMock (): StatusBarItemMock {
+  return {
+    text: '',
+    command: '',
+    tooltip: '',
+    show: jest.fn(),
+    hide: jest.fn()
+  } as unknown as StatusBarItemMock
+}
+
 // This sets up a mock that will simulate the firing of vscode events
 // The events are fired automatically when the event is created
 export function mockVscodeEvents (): void {
@@ -16,10 +41,14 @@ export function mockVscodeEvents (): void {
   })
 }
 
-export function mockVscodeExtensionContext (): vscode.ExtensionContext {
+export function mockVscodeExtensionContext (): VscodeExtensionContextMock {
   return {
     subscriptions: {
       push: jest.fn()
+    },
+    workspaceState: {
+      get: jest.fn(),
+      update: jest.fn()
     }
-  } as unknown as vscode.ExtensionContext
+  } as unknown as VscodeExtensionContextMock
 }

--- a/client/src/ui/BitbakeConfigPicker.ts
+++ b/client/src/ui/BitbakeConfigPicker.ts
@@ -58,19 +58,23 @@ export class BitbakeConfigPicker {
   }
 
   public async pickConfiguration (name?: string): Promise<void> {
-    if (this.bitbakeSettings?.buildConfigurations !== undefined && this.bitbakeSettings?.buildConfigurations?.length > 0) {
-      if (name !== undefined && this.bitbakeSettings.buildConfigurations.find((config) => config.name === name) !== undefined) {
-        this.activeBuildConfiguration = name
-        this.updateStatusBar(this.bitbakeSettings)
-      } else {
-        const options = this.bitbakeSettings.buildConfigurations.map((config) => config.name)
-        const filteredOptions = options.filter((option) => typeof option === 'string') as string[] // Always all according to the definition in client/package.json
-        const selection = await vscode.window.showQuickPick(filteredOptions, { placeHolder: 'Select a BitBake configuration' })
-        if (selection !== undefined) {
-          this.activeBuildConfiguration = selection
-          this.updateStatusBar(this.bitbakeSettings)
-        }
-      }
+    const buildConfigurations = this.bitbakeSettings?.buildConfigurations
+    if (buildConfigurations === undefined || buildConfigurations.length === 0) {
+      return
     }
+
+    let selection = name
+    if (selection === undefined || buildConfigurations.find((config) => config.name === selection) === undefined) {
+      const options = buildConfigurations.map((config) => config.name)
+      const filteredOptions = options.filter((option) => typeof option === 'string') as string[] // Always all according to the definition in client/package.json
+      selection = await vscode.window.showQuickPick(filteredOptions, { placeHolder: 'Select a BitBake configuration' })
+    }
+
+    if (selection === undefined) {
+      return
+    }
+
+    this.activeBuildConfiguration = selection
+    this.updateStatusBar(this.bitbakeSettings)
   }
 }


### PR DESCRIPTION
## Summary

- Add characterization tests for `BitbakeConfigPicker`.
- Simplify `pickConfiguration` with early returns.
- Apply the selected build configuration and update the status bar in a single shared path.

This is a follow-up to #532. It does not intend to change behavior; it makes the configuration selection flow easier to read and less likely to miss status bar updates in one branch.

## Testing

- `npm run compile`
- `npm run lint -- client/src/ui/BitbakeConfigPicker.ts client/src/__tests__/unit-tests/ui/bitbake-config-picker.test.ts`
- `npm run jest -- client/src/__tests__/unit-tests/ui/bitbake-config-picker.test.ts`
- `git diff --check`