### PR TITLE
feat: hover over operators and override operators

### DIFF
--- a/server/src/BitBakeDocScanner.ts
+++ b/server/src/BitBakeDocScanner.ts
@@ -76,6 +76,7 @@ export class BitBakeDocScanner {
   private _pythonDatastoreFunction: string[] = []
   private readonly _docPath: string = path.join(__dirname, '../resources/docs')
   private readonly _keywordInfo: DocInfo[] = KEYWORDS
+  private _operatorInfo: DocInfo[] = []
 
   get bitbakeVariableInfo (): VariableInfo[] {
     return this._bitbakeVariableInfo
@@ -97,6 +98,10 @@ export class BitBakeDocScanner {
     return this._keywordInfo
   }
 
+  get operatorInfo (): DocInfo[] {
+    return this._operatorInfo
+  }
+
   get pythonDatastoreFunction (): string[] {
     return this._pythonDatastoreFunction
   }
@@ -107,6 +112,7 @@ export class BitBakeDocScanner {
     this._variableFlagInfo = []
     this._yoctoTaskInfo = []
     this._pythonDatastoreFunction = []
+    this._operatorInfo = []
   }
 
   public parseDocs (): void {
@@ -115,6 +121,7 @@ export class BitBakeDocScanner {
     this.parseYoctoVariablesFile()
     this.parseYoctoTaskFile()
     this.parsePythonDatastoreFunction()
+    this.parseBitbakeOperatorsFile()
   }
 
   // TODO: Generalize these parse functions. They all read a file, match some content and store it.
@@ -290,6 +297,75 @@ export class BitBakeDocScanner {
       pythonDatastoreFunction.push(name)
     }
     this._pythonDatastoreFunction = pythonDatastoreFunction
+  }
+
+  public parseBitbakeOperatorsFile (): void {
+    const filePath = path.join(this._docPath, 'bitbake-user-manual-metadata.rst')
+    let file = ''
+    try {
+      file = fs.readFileSync(filePath, 'utf8')
+    } catch {
+      logger.warn(`Failed to read file at ${filePath}`)
+    }
+
+    const sectionNameToOperators: Record<string, string[]> = {
+      'Basic Variable Setting': ['='],
+      'Setting a default value (?=)': ['?='],
+      'Setting a weak default value (??=)': ['??='],
+      'Immediate variable expansion (:=)': [':='],
+      'Appending (+=) and prepending (=+) With Spaces': ['+=', '=+'],
+      'Appending (.=) and Prepending (=.) Without Spaces': ['.=', '=.'],
+      'Appending and Prepending (Override Style Syntax)': ['append', 'prepend'],
+      'Removal (Override Style Syntax)': ['remove']
+    }
+
+    // Override the auto-derived URL for sections whose RST anchor differs from their title
+    const overriddenUrls: Partial<Record<string, string>> = {
+      'Appending (+=) and prepending (=+) With Spaces': 'https://docs.yoctoproject.org/bitbake/bitbake-user-manual/bitbake-user-manual-metadata.html#appending-and-prepending',
+      'Removal (Override Style Syntax)': 'https://docs.yoctoproject.org/bitbake/bitbake-user-manual/bitbake-user-manual-metadata.html#removing-override-style-syntax'
+    }
+
+    // Find all dash-underlined section headers
+    const headerRegex = /^[^\n]+\n-{3,}\n\n/gm
+    const headerMatches = Array.from(file.matchAll(headerRegex))
+
+    const operatorInfo: DocInfo[] = []
+    for (const [i, match] of headerMatches.entries()) {
+      const title = match[0].split('\n')[0]
+      if (!(title in sectionNameToOperators)) continue
+      const operators = sectionNameToOperators[title]
+
+      // Extract content from this header to the next
+      const contentStart = match.index + match[0].length
+      const contentEnd = i + 1 < headerMatches.length ? headerMatches[i + 1].index : file.length
+      const rawContent = file.slice(contentStart, contentEnd)
+
+      const definition = rawContent
+        .replace(/^ {3}/gm, '')
+        .replace(/:term:|:ref:/g, '')
+        .replace(/\.\. (note|important|tip)::/g, (_match, p1) => { return `**${p1}**` })
+        .replace(/::/g, ':')
+        .replace(/``/g, '`')
+        .replace(/^\n(\s{5,})/gm, ' ')
+        .replace(/^(\s{5,})/gm, ' ')
+
+      const anchor = title
+        .toLowerCase()
+        .replace(/[^a-z0-9 -]/g, '')
+        .replace(/ +/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-+|-+$/g, '')
+      const referenceUrl = overriddenUrls[title] ?? `https://docs.yoctoproject.org/bitbake/bitbake-user-manual/bitbake-user-manual-metadata.html#${anchor}`
+      for (const name of operators) {
+        operatorInfo.push({
+          name,
+          definition,
+          referenceUrl,
+          docSource: 'Bitbake'
+        })
+      }
+    }
+    this._operatorInfo = operatorInfo
   }
 }
 

--- a/server/src/__tests__/fixtures/hover.bb
+++ b/server/src/__tests__/fixtures/hover.bb
@@ -54,4 +54,16 @@ do_foo() {
 
 LICENSE = "GPL-2.0-only & GPL-2.0-with-bison-exception"
 
+MYVAR = "value"
+MYVAR ?= "default"
+MYVAR ??= "weakdefault"
+MYVAR := "immediate"
+MYVAR += "appended"
+MYVAR =+ "prepended"
+MYVAR .= "appendednospace"
+MYVAR =. "prependednospace"
+MYVAR:append = " append"
+MYVAR:prepend = "prepend "
+MYVAR:remove = "remove"
+
 d.getVar("DESCRIPTION")

--- a/server/src/__tests__/hover.test.ts
+++ b/server/src/__tests__/hover.test.ts
@@ -735,6 +735,78 @@ describe('on hover', () => {
     )
   })
 
+  it('should show hover documentation for assignment operators', async () => {
+    bitBakeDocScanner.parseBitbakeOperatorsFile()
+    analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.HOVER
+    })
+
+    const shouldShow = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 56,
+        character: 6
+      }
+    })
+
+    expect(shouldShow).toEqual(
+      expect.objectContaining({
+        contents: expect.objectContaining({
+          value: expect.stringContaining('occurs immediately as the statement is parsed')
+        })
+      })
+    )
+  })
+
+  it('should show hover documentation for override style operators', async () => {
+    bitBakeDocScanner.parseBitbakeOperatorsFile()
+    analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.HOVER
+    })
+
+    const shouldShow = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 64,
+        character: 6
+      }
+    })
+
+    expect(shouldShow).toEqual(
+      expect.objectContaining({
+        contents: expect.objectContaining({
+          value: expect.stringContaining('You can also append and prepend a variable')
+        })
+      })
+    )
+  })
+
+  it('should not show hover for append when not used as an operator', async () => {
+    bitBakeDocScanner.parseBitbakeOperatorsFile()
+    analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.HOVER
+    })
+
+    const shouldNotShow = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 64,
+        character: 20
+      }
+    })
+
+    expect(shouldNotShow).toBe(null)
+  })
+
   it('should show description of license on hover', async () => {
     analyzer.analyze({
       uri: DUMMY_URI,

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -97,6 +97,21 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
     }
   }
 
+  // Bitbake operators
+  const ASSIGNMENT_OPERATORS = new Set(['=', '?=', '??=', ':=', '+=', '=+', '.=', '=.'])
+  const OVERRIDE_OPERATORS = new Set(['append', 'prepend', 'remove'])
+  if (bitbakeNode !== null) {
+    const isAssignmentOperator = bitbakeNode.parent?.type === 'variable_assignment' && ASSIGNMENT_OPERATORS.has(bitbakeNode.type)
+    const isOverrideOperator = bitbakeNode.parent?.type === 'override' && OVERRIDE_OPERATORS.has(bitbakeNode.type)
+    if (isAssignmentOperator || isOverrideOperator) {
+      const operatorInfo = bitBakeDocScanner.operatorInfo.find(item => item.name === bitbakeNode.text.trim())
+      if (operatorInfo !== undefined) {
+        logger.debug(`[onHover] Found operator: ${operatorInfo.name}`)
+        hoverValue = `**${operatorInfo.name}**\n___\n${operatorInfo.definition}`
+      }
+    }
+  }
+
   let comments: string | null = null
   if (exactSymbol !== undefined) {
     comments = getGlobalSymbolComments(textDocument.uri, word)


### PR DESCRIPTION
Add hover documentation verbatim for all operators and override style operators '=', '?=', '??=', ':=', '+=', '=+', '.=', '=.', ':append', ':prepend', and ':remove'.

I didn't see an AI policy for this repo so I just used the AI policy of the [Linux kernel](https://docs.kernel.org/process/coding-assistants.html)

Assisted-by: OpenCode:big-pickle

<img width="1920" height="1080" alt="weak-default-operator" src="https://github.com/user-attachments/assets/c939f41e-09e3-4743-8d74-c786921c062b" />
