### PR TITLE
Fix unbounded recipe-local file discovery

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -34,6 +34,7 @@ const languages = {
     getConfiguration: jest.fn(),
     workspaceFolders: [],
     getWorkspaceFolder: jest.fn(),
+    findFiles: jest.fn(),
 
     onDidChangeConfiguration: jest.fn(),
     onDidChangeTextDocument: jest.fn(),
@@ -55,6 +56,9 @@ const languages = {
     parse: jest.fn(),
     joinPath: jest.fn(),
   };
+  const RelativePattern = jest.fn(
+    (base: string, pattern: string) => ({ base, pattern })
+  );
   const Range = jest.fn();
   const Location = jest.fn();
   const Position = jest.fn();
@@ -145,6 +149,7 @@ const languages = {
     workspace,
     OverviewRulerLane,
     Uri,
+    RelativePattern,
     Range,
     Location,
     Position,

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -34,7 +34,6 @@ const languages = {
     getConfiguration: jest.fn(),
     workspaceFolders: [],
     getWorkspaceFolder: jest.fn(),
-    findFiles: jest.fn(),
 
     onDidChangeConfiguration: jest.fn(),
     onDidChangeTextDocument: jest.fn(),
@@ -56,9 +55,6 @@ const languages = {
     parse: jest.fn(),
     joinPath: jest.fn(),
   };
-  const RelativePattern = jest.fn(
-    (base: string, pattern: string) => ({ base, pattern })
-  );
   const Range = jest.fn();
   const Location = jest.fn();
   const Position = jest.fn();
@@ -149,7 +145,6 @@ const languages = {
     workspace,
     OverviewRulerLane,
     Uri,
-    RelativePattern,
     Range,
     Location,
     Position,

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "src/lib"
       ],
       "dependencies": {
+        "fast-glob": "^3.3.3",
         "find": "^0.3.0",
         "node-pty": "^1.0.0",
         "semver": "^7.6.3",
@@ -24,6 +25,41 @@
       },
       "engines": {
         "vscode": "^1.92.0"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@types/find": {
@@ -57,12 +93,125 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/find": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/find/-/find-0.3.0.tgz",
       "integrity": "sha512-iSd+O4OEYV/I36Zl8MdYJO0xD82wH528SaCieTVHhclgiYNe9y+yPKSwK+A7/WsmHL1EZ+pYUJBXWTL5qofksw==",
       "dependencies": {
         "traverse-chain": "~0.1.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/minimatch": {
@@ -90,6 +239,71 @@
         "node-addon-api": "^7.1.0"
       }
     },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -99,6 +313,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/traverse-chain": {

--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,7 @@
     "vscode": "^1.92.0"
   },
   "dependencies": {
+    "fast-glob": "^3.3.3",
     "find": "^0.3.0",
     "node-pty": "^1.0.0",
     "semver": "^7.6.3",

--- a/client/src/__tests__/unit-tests/document-link-provider.test.ts
+++ b/client/src/__tests__/unit-tests/document-link-provider.test.ts
@@ -1,0 +1,161 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import find from 'find'
+import fs from 'fs'
+import path from 'path'
+import vscode, {
+  type CancellationToken,
+  type TextDocument
+} from 'vscode'
+import { type LanguageClient } from 'vscode-languageclient/node'
+import { BitbakeDocumentLinkProvider } from '../../documentLinkProvider'
+import { RequestMethod } from '../../lib/src/types/requests'
+
+jest.mock('vscode')
+
+describe('BitbakeDocumentLinkProvider', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  it('provides links for recipe-local files and directories', async () => {
+    const recipePath = '/workspace/busybox_1.36.1.bb'
+    const recipeUri = `file://${recipePath}`
+    const filePath = '/workspace/busybox/defconfig'
+    const directoryPath = '/workspace/busybox/patches'
+
+    const fileRange = { id: 'file-range' } as unknown as vscode.Range
+    const directoryRange = {
+      id: 'directory-range'
+    } as unknown as vscode.Range
+
+    const fileUri = {
+      fsPath: filePath
+    } as unknown as vscode.Uri
+
+    const directoryUri = {
+      fsPath: directoryPath
+    } as unknown as vscode.Uri
+
+    const commandUri = {
+      scheme: 'command'
+    } as unknown as vscode.Uri
+
+    const sendRequest = jest.fn().mockResolvedValue([
+      {
+        value: 'defconfig;subdir=source',
+        range: fileRange
+      },
+      {
+        value: 'patches',
+        range: directoryRange
+      }
+    ])
+
+    const findFiles =
+      vscode.workspace.findFiles as unknown as jest.Mock
+
+    findFiles
+      .mockResolvedValueOnce([fileUri])
+      .mockResolvedValueOnce([])
+
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true)
+
+    const findDirectories =
+      jest.spyOn(find, 'dirSync') as unknown as jest.Mock
+
+    findDirectories
+      .mockReturnValueOnce([directoryPath])
+      .mockReturnValueOnce([])
+
+    const parseUri = vscode.Uri.parse as unknown as jest.Mock
+
+    parseUri
+      .mockReturnValueOnce(directoryUri)
+      .mockReturnValueOnce(commandUri)
+
+    const createDocumentLink =
+      vscode.DocumentLink as unknown as jest.Mock
+
+    createDocumentLink.mockImplementation(
+      (range: vscode.Range, target: vscode.Uri) => ({
+        range,
+        target
+      })
+    )
+
+    const provider = new BitbakeDocumentLinkProvider({
+      sendRequest
+    } as unknown as LanguageClient)
+
+    const document = {
+      uri: {
+        fsPath: recipePath,
+        toString: () => recipeUri
+      }
+    } as unknown as TextDocument
+
+    const token = {} as CancellationToken
+
+    const result = await provider.provideDocumentLinks(
+      document,
+      token
+    )
+
+    expect(sendRequest).toHaveBeenCalledWith(
+      RequestMethod.getLinksInDocument,
+      {
+        documentUri: recipeUri
+      }
+    )
+
+    expect(findFiles).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        base: path.join('/workspace', 'busybox'),
+        pattern: '**/{defconfig,patches}'
+      }),
+      undefined,
+      2,
+      token
+    )
+
+    expect(findFiles).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        base: path.join('/workspace', 'files'),
+        pattern: '**/{defconfig,patches}'
+      }),
+      undefined,
+      2,
+      token
+    )
+
+    expect(findDirectories).toHaveBeenNthCalledWith(
+      1,
+      path.join('/workspace', 'busybox')
+    )
+
+    expect(findDirectories).toHaveBeenNthCalledWith(
+      2,
+      path.join('/workspace', 'files')
+    )
+
+    expect(result).toEqual([
+      {
+        range: fileRange,
+        target: fileUri,
+        tooltip: 'Bitbake: Go to file'
+      },
+      {
+        range: directoryRange,
+        target: commandUri,
+        tooltip: 'Bitbake: Reveal in explorer'
+      }
+    ])
+  })
+})

--- a/client/src/__tests__/unit-tests/document-link-provider.test.ts
+++ b/client/src/__tests__/unit-tests/document-link-provider.test.ts
@@ -3,9 +3,10 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import find from 'find'
+import fg from 'fast-glob'
 import fs from 'fs'
 import path from 'path'
+import { Readable } from 'stream'
 import vscode, {
   type CancellationToken,
   type TextDocument
@@ -28,7 +29,10 @@ describe('BitbakeDocumentLinkProvider', () => {
     const filePath = '/workspace/busybox/defconfig'
     const directoryPath = '/workspace/busybox/patches'
 
-    const fileRange = { id: 'file-range' } as unknown as vscode.Range
+    const fileRange = {
+      id: 'file-range'
+    } as unknown as vscode.Range
+
     const directoryRange = {
       id: 'directory-range'
     } as unknown as vscode.Range
@@ -45,32 +49,35 @@ describe('BitbakeDocumentLinkProvider', () => {
       scheme: 'command'
     } as unknown as vscode.Uri
 
-    const sendRequest = jest.fn().mockResolvedValue([
+    const entries = [
       {
-        value: 'defconfig;subdir=source',
-        range: fileRange
+        name: 'defconfig',
+        path: filePath,
+        dirent: {
+          isDirectory: () => false,
+          isFile: () => true
+        }
       },
       {
-        value: 'patches',
-        range: directoryRange
+        name: 'patches',
+        path: directoryPath,
+        dirent: {
+          isDirectory: () => true,
+          isFile: () => false
+        }
       }
-    ])
+    ]
 
-    const findFiles =
-      vscode.workspace.findFiles as unknown as jest.Mock
+    const streamSpy = jest.spyOn(fg, 'stream')
+      .mockReturnValue(
+        Readable.from(
+          entries,
+          { objectMode: true }
+        ) as unknown as ReturnType<typeof fg.stream>
+      )
 
-    findFiles
-      .mockResolvedValueOnce([fileUri])
-      .mockResolvedValueOnce([])
-
-    jest.spyOn(fs, 'existsSync').mockReturnValue(true)
-
-    const findDirectories =
-      jest.spyOn(find, 'dirSync') as unknown as jest.Mock
-
-    findDirectories
-      .mockReturnValueOnce([directoryPath])
-      .mockReturnValueOnce([])
+    jest.spyOn(vscode.Uri, 'file')
+      .mockReturnValue(fileUri)
 
     const parseUri = vscode.Uri.parse as unknown as jest.Mock
 
@@ -88,6 +95,17 @@ describe('BitbakeDocumentLinkProvider', () => {
       })
     )
 
+    const sendRequest = jest.fn().mockResolvedValue([
+      {
+        value: 'defconfig;subdir=source',
+        range: fileRange
+      },
+      {
+        value: 'patches',
+        range: directoryRange
+      }
+    ])
+
     const provider = new BitbakeDocumentLinkProvider({
       sendRequest
     } as unknown as LanguageClient)
@@ -99,7 +117,12 @@ describe('BitbakeDocumentLinkProvider', () => {
       }
     } as unknown as TextDocument
 
-    const token = {} as CancellationToken
+    const token = {
+      isCancellationRequested: false,
+      onCancellationRequested: jest.fn(
+        () => ({ dispose: jest.fn() })
+      )
+    } as unknown as CancellationToken
 
     const result = await provider.provideDocumentLinks(
       document,
@@ -108,41 +131,39 @@ describe('BitbakeDocumentLinkProvider', () => {
 
     expect(sendRequest).toHaveBeenCalledWith(
       RequestMethod.getLinksInDocument,
-      {
-        documentUri: recipeUri
-      }
+      { documentUri: recipeUri }
     )
 
-    expect(findFiles).toHaveBeenNthCalledWith(
-      1,
+    expect(streamSpy).toHaveBeenCalledTimes(1)
+
+    expect(streamSpy).toHaveBeenCalledWith(
+      [
+        `${
+          fg.convertPathToPattern(
+            path.join('/workspace', 'busybox')
+          )
+        }/**/defconfig`,
+        `${
+          fg.convertPathToPattern(
+            path.join('/workspace', 'busybox')
+          )
+        }/**/patches`,
+        `${
+          fg.convertPathToPattern(
+            path.join('/workspace', 'files')
+          )
+        }/**/defconfig`,
+        `${
+          fg.convertPathToPattern(
+            path.join('/workspace', 'files')
+          )
+        }/**/patches`
+      ],
       expect.objectContaining({
-        base: path.join('/workspace', 'busybox'),
-        pattern: '**/{defconfig,patches}'
-      }),
-      undefined,
-      2,
-      token
-    )
-
-    expect(findFiles).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        base: path.join('/workspace', 'files'),
-        pattern: '**/{defconfig,patches}'
-      }),
-      undefined,
-      2,
-      token
-    )
-
-    expect(findDirectories).toHaveBeenNthCalledWith(
-      1,
-      path.join('/workspace', 'busybox')
-    )
-
-    expect(findDirectories).toHaveBeenNthCalledWith(
-      2,
-      path.join('/workspace', 'files')
+        absolute: true,
+        objectMode: true,
+        onlyFiles: false
+      })
     )
 
     expect(result).toEqual([
@@ -157,5 +178,108 @@ describe('BitbakeDocumentLinkProvider', () => {
         tooltip: 'Bitbake: Reveal in explorer'
       }
     ])
+  })
+
+  it('does not scan recipe-local files for .conf documents', async () => {
+    const sendRequest = jest.fn()
+    const streamSpy = jest.spyOn(fg, 'stream')
+    const readdirSpy = jest.spyOn(
+      fs.promises,
+      'readdir'
+    )
+
+    const provider = new BitbakeDocumentLinkProvider({
+      sendRequest
+    } as unknown as LanguageClient)
+
+    const document = {
+      uri: {
+        fsPath: '/workspace/build.conf'
+      }
+    } as unknown as TextDocument
+
+    const result = await provider.provideDocumentLinks(
+      document,
+      {} as CancellationToken
+    )
+
+    expect(result).toEqual([])
+    expect(sendRequest).not.toHaveBeenCalled()
+    expect(streamSpy).not.toHaveBeenCalled()
+    expect(readdirSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not start a scan when already cancelled', async () => {
+    const streamSpy = jest.spyOn(fg, 'stream')
+
+    const result =
+      await BitbakeDocumentLinkProvider.findFilesAndDirs(
+        ['/workspace/**/*'],
+        undefined,
+        {
+          isCancellationRequested: true
+        } as CancellationToken
+      )
+
+    expect(result).toEqual({
+      foundFiles: [],
+      foundDirs: []
+    })
+
+    expect(streamSpy).not.toHaveBeenCalled()
+  })
+
+  it('destroys an active scan when cancelled', async () => {
+    const scanStream = new Readable({
+      objectMode: true,
+      read: () => {}
+    })
+
+    const destroySpy = jest.spyOn(
+      scanStream,
+      'destroy'
+    )
+
+    jest.spyOn(fg, 'stream').mockReturnValue(
+      scanStream as unknown as ReturnType<typeof fg.stream>
+    )
+
+    let cancelled = false
+    let cancelScan: (() => void) | undefined
+    const dispose = jest.fn()
+
+    const token = {
+      get isCancellationRequested () {
+        return cancelled
+      },
+      onCancellationRequested: jest.fn(
+        (callback: () => void) => {
+          cancelScan = callback
+          return { dispose }
+        }
+      )
+    } as unknown as CancellationToken
+
+    const scan =
+      BitbakeDocumentLinkProvider.findFilesAndDirs(
+        ['/workspace/**/*'],
+        undefined,
+        token
+      )
+
+    expect(cancelScan).toBeDefined()
+
+    cancelled = true
+    cancelScan?.()
+
+    const result = await scan
+
+    expect(destroySpy).toHaveBeenCalledTimes(1)
+    expect(dispose).toHaveBeenCalledTimes(1)
+
+    expect(result).toEqual({
+      foundFiles: [],
+      foundDirs: []
+    })
   })
 })

--- a/client/src/documentLinkProvider.ts
+++ b/client/src/documentLinkProvider.ts
@@ -46,26 +46,27 @@ export class BitbakeDocumentLinkProvider implements vscode.DocumentLinkProvider 
   }
 
 
-public static getRecipeLocalPatterns (
-  search: RecipeLocalSearch,
-  filenames?: string[]
-): string[] {
-  if (filenames?.length === 0) {
-    return []
-  }
-
-  return search.roots.flatMap(root => {
-    const rootPattern = fg.convertPathToPattern(root)
-
-    if (filenames === undefined) {
-      return [`${rootPattern}/**/*`]
+  public static getRecipeLocalPatterns (
+    search: RecipeLocalSearch,
+    filenames?: string[]
+  ): string[] {
+    if (filenames?.length === 0) {
+      return []
     }
 
-    return filenames.map(filename => {
-      return `${rootPattern}/**/${fg.escapePath(filename)}`
+    return search.roots.flatMap(root => {
+      const rootPattern = fg.convertPathToPattern(root)
+
+      if (filenames === undefined) {
+        return [`${rootPattern}/**/*`]
+      }
+
+      return filenames.map(filename => {
+        return `${rootPattern}/**/${fg.escapePath(filename)}`
+      })
     })
-  })
-}
+  }
+
   public static async findFilesAndDirs (
     patterns: string[],
     maxFileResults?: number,
@@ -95,21 +96,28 @@ public static getRecipeLocalPatterns (
       unique: true
     }) as GlobStream
 
+    let streamDestroyed = false
+
+    const destroyStream = (): void => {
+      if (streamDestroyed) {
+        return
+      }
+
+      streamDestroyed = true
+      stream.destroy()
+    }
+
     const cancellationSubscription =
       typeof token?.onCancellationRequested === 'function'
         ? token.onCancellationRequested(() => {
-          stream.destroy()
+          destroyStream()
         })
         : undefined
-
-    if (isCancelled()) {
-      stream.destroy()
-    }
 
     try {
       for await (const entry of stream) {
         if (isCancelled()) {
-          stream.destroy()
+          destroyStream()
           break
         }
 
@@ -129,14 +137,13 @@ public static getRecipeLocalPatterns (
         }
       }
     } catch (error) {
-      if (!isCancelled()) {
-        logger.error(
-          `An error occurred while finding recipe-local entries. ${
-            JSON.stringify(error)
-          }`
-        )
-      }
+      logger.error(
+        `An error occurred while finding recipe-local entries. ${
+          JSON.stringify(error)
+        }`
+      )
     } finally {
+      destroyStream()
       cancellationSubscription?.dispose()
     }
 

--- a/client/src/documentLinkProvider.ts
+++ b/client/src/documentLinkProvider.ts
@@ -9,8 +9,17 @@ import { RequestMethod, type RequestResult } from './lib/src/types/requests'
 import { logger } from './lib/src/utils/OutputLogger'
 import path from 'path'
 import { extractRecipeName } from './lib/src/utils/files'
-import find from 'find'
-import fs from 'fs'
+import fg from 'fast-glob'
+
+interface RecipeLocalSearch {
+  roots: string[]
+}
+
+type GlobStream =
+  NodeJS.ReadableStream &
+  AsyncIterable<fg.Entry> & {
+    destroy: () => void
+  }
 
 export class BitbakeDocumentLinkProvider implements vscode.DocumentLinkProvider {
   private readonly client: LanguageClient
@@ -19,105 +28,210 @@ export class BitbakeDocumentLinkProvider implements vscode.DocumentLinkProvider 
     this.client = client
   }
 
-  public static async findFilesAndDirs (filePatterns: Array<{ base: string, pattern: string }>, dirPatterns: string[], maxFileResults?: number, token?: vscode.CancellationToken): Promise<{ foundFiles: vscode.Uri[], foundDirs: string[] }> {
+  public static getRecipeLocalSearch (
+    uri: string
+  ): RecipeLocalSearch | undefined {
+    if (path.extname(uri) === '.conf') {
+      return undefined
+    }
+
+    const parentDir = path.dirname(uri)
+
+    return {
+      roots: [
+        path.join(parentDir, extractRecipeName(uri)),
+        path.join(parentDir, 'files')
+      ]
+    }
+  }
+
+
+public static getRecipeLocalPatterns (
+  search: RecipeLocalSearch,
+  filenames?: string[]
+): string[] {
+  if (filenames?.length === 0) {
+    return []
+  }
+
+  return search.roots.flatMap(root => {
+    const rootPattern = fg.convertPathToPattern(root)
+
+    if (filenames === undefined) {
+      return [`${rootPattern}/**/*`]
+    }
+
+    return filenames.map(filename => {
+      return `${rootPattern}/**/${fg.escapePath(filename)}`
+    })
+  })
+}
+  public static async findFilesAndDirs (
+    patterns: string[],
+    maxFileResults?: number,
+    token?: vscode.CancellationToken
+  ): Promise<{
+      foundFiles: vscode.Uri[]
+      foundDirs: string[]
+    }> {
     const foundFiles: vscode.Uri[] = []
     const foundDirs: string[] = []
-    try {
-      for (let i = 0; i < filePatterns.length; i++) {
-        foundFiles.push(
-          ...(await vscode.workspace.findFiles(new vscode.RelativePattern(filePatterns[i].base, filePatterns[i].pattern), undefined, maxFileResults, token))
-        )
-      }
-    } catch (err) {
-      logger.error(`An error occurred while finding files. ${JSON.stringify(err)}`)
+
+    const isCancelled = (): boolean => {
+      return token?.isCancellationRequested === true
+    }
+
+    if (patterns.length === 0 || isCancelled()) {
+      return { foundFiles, foundDirs }
+    }
+
+    const stream = fg.stream(patterns, {
+      absolute: true,
+      concurrency: 4,
+      dot: true,
+      followSymbolicLinks: false,
+      objectMode: true,
+      onlyFiles: false,
+      unique: true
+    }) as GlobStream
+
+    const cancellationSubscription =
+      typeof token?.onCancellationRequested === 'function'
+        ? token.onCancellationRequested(() => {
+          stream.destroy()
+        })
+        : undefined
+
+    if (isCancelled()) {
+      stream.destroy()
     }
 
     try {
-      for (let i = 0; i < dirPatterns.length; i++) {
-        if (fs.existsSync(dirPatterns[i])) foundDirs.push(...find.dirSync(dirPatterns[i]))
+      for await (const entry of stream) {
+        if (isCancelled()) {
+          stream.destroy()
+          break
+        }
+
+        if (entry.dirent.isDirectory()) {
+          foundDirs.push(entry.path)
+          continue
+        }
+
+        if (
+          entry.dirent.isFile() &&
+          (
+            maxFileResults === undefined ||
+            foundFiles.length < maxFileResults
+          )
+        ) {
+          foundFiles.push(vscode.Uri.file(entry.path))
+        }
       }
     } catch (error) {
-      logger.error(`An error occurred while finding directories. ${JSON.stringify(error)}`)
+      if (!isCancelled()) {
+        logger.error(
+          `An error occurred while finding recipe-local entries. ${
+            JSON.stringify(error)
+          }`
+        )
+      }
+    } finally {
+      cancellationSubscription?.dispose()
     }
 
     return { foundFiles, foundDirs }
-  }
-
-  public static getLocalFoldersForRecipeUri (uri: string): { pnDir: string, filesDir: string } {
-    const parentDir = path.dirname(uri)
-    const pnDir = path.join(parentDir, extractRecipeName(uri))
-    const filesDir = path.join(parentDir, 'files')
-
-    return { pnDir, filesDir }
   }
 
   private basenameIsEqual (path1: string, path2: string): boolean {
     return path.basename(path1) === path.basename(path2)
   }
 
-  private async resolveUris (uri: vscode.Uri, linksData: Array<{ value: string, range: vscode.Range }>, token: vscode.CancellationToken): Promise<vscode.DocumentLink[]> {
+  private async resolveUris (
+    search: RecipeLocalSearch,
+    linksData: Array<{ value: string, range: vscode.Range }>,
+    token: vscode.CancellationToken
+  ): Promise<vscode.DocumentLink[]> {
     const documentLinks: vscode.DocumentLink[] = []
 
-    /* Corresponding file:// URI usually point to files in ${PN}/ or files/. Ex:
-      * recipes-core
-      * ├── busybox
-      * │   └── defconfig
-      * ├── busybox_1.36.1.bb
-      * ├── busybox.inc
-      * └── files
-      *     └── syslog-startup.conf
-    */
-    const LinksWithoutTails = linksData.map(link => {
+    const linksWithoutTails = linksData.map(link => {
       return {
         ...link,
         value: link.value.split(';')[0]
       }
     })
-    const filenames = LinksWithoutTails.map(link => link.value)
-    const filenamesRegex = '{' + filenames.join(',') + '}'
-    const { pnDir, filesDir } = BitbakeDocumentLinkProvider.getLocalFoldersForRecipeUri(uri.fsPath)
 
-    const filePatterns = [
-      { base: pnDir, pattern: '**/' + filenamesRegex },
-      { base: filesDir, pattern: '**/' + filenamesRegex }
-    ]
-    const { foundFiles, foundDirs } = await BitbakeDocumentLinkProvider.findFilesAndDirs(filePatterns, [pnDir, filesDir], filenames.length, token)
+    const filenames = linksWithoutTails.map(link => link.value)
+    const patterns =
+      BitbakeDocumentLinkProvider.getRecipeLocalPatterns(
+        search,
+        filenames
+      )
 
-    /**
-     * Important:
-     * This is building the vscode.documentLink array the same order as they appear in the document to prevent
-     * the results from the default provider from showing up as long as the links extracted from the document are in order.
-     * So the shortcut (e.g. ctrl+click) can always work on the link this provider returned.
-     * Reference: https://github.com/microsoft/vscode/blob/main/src/vs/editor/contrib/links/browser/getLinks.ts#L140
-     */
-    for (let i = 0; i < LinksWithoutTails.length; i++) {
-      const link = LinksWithoutTails[i]
+    const { foundFiles, foundDirs } =
+      await BitbakeDocumentLinkProvider.findFilesAndDirs(
+        patterns,
+        filenames.length,
+        token
+      )
 
-      // Handle files: provide a direct link to the file
-      const fileUri = foundFiles.find(file => this.basenameIsEqual(file.fsPath, link.value))
+    for (const link of linksWithoutTails) {
+      const fileUri = foundFiles.find(file => {
+        return this.basenameIsEqual(file.fsPath, link.value)
+      })
+
       if (fileUri !== undefined) {
-        documentLinks.push({ ...new vscode.DocumentLink(link.range, fileUri), tooltip: 'Bitbake: Go to file' })
+        documentLinks.push({
+          ...new vscode.DocumentLink(link.range, fileUri),
+          tooltip: 'Bitbake: Go to file'
+        })
         continue
       }
 
-      // Handle directories: provide a "Reveal in explorer" command
-      const foundDir = foundDirs.find(dir => this.basenameIsEqual(dir, link.value))
+      const foundDir = foundDirs.find(dir => {
+        return this.basenameIsEqual(dir, link.value)
+      })
+
       if (foundDir !== undefined) {
-        /*
-          commandArguments could be formatted into an array for intermediary command if needed.
-          Reference: https://code.visualstudio.com/api/extension-guides/command#command-uris
-        */
-        const targetUri = vscode.Uri.parse(`command:revealInExplorer?${encodeURIComponent(JSON.stringify(vscode.Uri.parse(foundDir)))}`)
-        // targetUri = vscode.Uri.parse('file://' + foundDir)
-        documentLinks.push({ ...new vscode.DocumentLink(link.range, targetUri), tooltip: 'Bitbake: Reveal in explorer' })
+        const targetUri = vscode.Uri.parse(
+          `command:revealInExplorer?${
+            encodeURIComponent(
+              JSON.stringify(vscode.Uri.parse(foundDir))
+            )
+          }`
+        )
+
+        documentLinks.push({
+          ...new vscode.DocumentLink(link.range, targetUri),
+          tooltip: 'Bitbake: Reveal in explorer'
+        })
       }
     }
 
     return documentLinks
   }
 
-  async provideDocumentLinks (document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.DocumentLink[]> {
-    const linksData = await this.client.sendRequest<RequestResult['getLinksInDocument']>(RequestMethod.getLinksInDocument, { documentUri: document.uri.toString() })
-    return await this.resolveUris(document.uri, linksData, token)
+  async provideDocumentLinks (
+    document: vscode.TextDocument,
+    token: vscode.CancellationToken
+  ): Promise<vscode.DocumentLink[]> {
+    const search =
+      BitbakeDocumentLinkProvider.getRecipeLocalSearch(
+        document.uri.fsPath
+      )
+
+    if (search === undefined) {
+      return []
+    }
+
+    const linksData =
+      await this.client.sendRequest<
+      RequestResult['getLinksInDocument']
+      >(
+        RequestMethod.getLinksInDocument,
+        { documentUri: document.uri.toString() }
+      )
+
+    return await this.resolveUris(search, linksData, token)
   }
 }

--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -98,15 +98,29 @@ export async function activateLanguageServer (context: ExtensionContext, bitBake
       return { foundFileUris: [], foundDirs: [] }
     }
 
-    const { pnDir, filesDir } = BitbakeDocumentLinkProvider.getLocalFoldersForRecipeUri(params.uri)
+    const search =
+      BitbakeDocumentLinkProvider.getRecipeLocalSearch(
+        params.uri
+      )
 
-    const filePatterns = [
-      { base: pnDir, pattern: '**/*' },
-      { base: filesDir, pattern: '**/*' }
-    ]
-    const { foundFiles, foundDirs } = await BitbakeDocumentLinkProvider.findFilesAndDirs(filePatterns, [pnDir, filesDir])
+    if (search === undefined) {
+      return { foundFileUris: [], foundDirs: [] }
+    }
 
-    return { foundFileUris: foundFiles.map(uri => uri.fsPath), foundDirs }
+    const patterns =
+      BitbakeDocumentLinkProvider.getRecipeLocalPatterns(
+        search
+      )
+
+    const { foundFiles, foundDirs } =
+      await BitbakeDocumentLinkProvider.findFilesAndDirs(
+        patterns
+      )
+
+    return {
+      foundFileUris: foundFiles.map(uri => uri.fsPath),
+      foundDirs
+    }
   })
 
   client.onNotification(NotificationMethod.EmbeddedLanguageDocs, (embeddedLanguageDocs: NotificationParams['EmbeddedLanguageDocs']) => {

--- a/server/src/__tests__/completions.test.ts
+++ b/server/src/__tests__/completions.test.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { onCompletionHandler, onCompletionResolveHandler } from '../connectionHandlers/onCompletion'
+import { onCompletionHandler, onCompletionResolveHandler, setCompletionConnection } from '../connectionHandlers/onCompletion'
 import { analyzer } from '../tree-sitter/analyzer'
 import { FIXTURE_DOCUMENT, DUMMY_URI, FIXTURE_URI } from './fixtures/fixtures'
 import { generateBashParser, generateBitBakeParser } from '../tree-sitter/parser'
@@ -13,6 +13,9 @@ import path from 'path'
 import { extractRecipeName } from '../lib/src/utils/files'
 import { licenseOperators } from '../completions/spdx-licenses'
 import { BitbakeScanResult } from '../lib/src/types/BitbakeScanResult'
+import { type Connection } from 'vscode-languageserver/node'
+import { RequestMethod } from '../lib/src/types/requests'
+import { logger } from '../lib/src/utils/OutputLogger'
 
 /**
  * The onCompletion handler doesn't allow other parameters, so we can't pass the analyzer and therefore the same
@@ -31,7 +34,9 @@ describe('On Completion', () => {
 
   beforeEach(() => {
     analyzer.resetAnalyzedDocuments()
+    analyzer.clearRecipeLocalFiles()
     bitBakeDocScanner.clearScannedDocs()
+    setCompletionConnection(undefined)
   })
 
   afterEach(() => {
@@ -241,6 +246,153 @@ describe('On Completion', () => {
           }
         )
       ])
+    )
+  })
+
+  it('requests recipe-local files lazily for SRC_URI completion', async () => {
+    analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.CORRECT
+    })
+
+    const recipeLocalFiles = {
+      foundFileUris: [
+        '/home/projects/poky/meta/recipes-core/busybox/foo'
+      ],
+      foundDirs: [
+        '/home/projects/poky/meta/recipes-core/busybox/images'
+      ]
+    }
+    const sendRequest = jest.fn().mockResolvedValue(recipeLocalFiles)
+
+    setCompletionConnection({
+      sendRequest
+    } as unknown as Connection)
+
+    const result = await onCompletionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 6,
+        character: 25
+      }
+    })
+
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(sendRequest).toHaveBeenCalledWith(
+      RequestMethod.getRecipeLocalFiles,
+      { uri: DUMMY_URI.replace('file://', '') }
+    )
+    expect(analyzer.getRecipeLocalFiles(DUMMY_URI)).toEqual(
+      recipeLocalFiles
+    )
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'foo',
+          insertText: 'file://foo'
+        }),
+        expect.objectContaining({
+          label: 'images',
+          insertText: 'file://images/'
+        })
+      ])
+    )
+  })
+
+  it('reuses cached recipe-local files for later SRC_URI completions', async () => {
+    analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.CORRECT
+    })
+
+    const recipeLocalFiles = {
+      foundFileUris: [
+        '/home/projects/poky/meta/recipes-core/busybox/foo'
+      ],
+      foundDirs: []
+    }
+    const sendRequest = jest.fn().mockResolvedValue(recipeLocalFiles)
+
+    setCompletionConnection({
+      sendRequest
+    } as unknown as Connection)
+
+    const completionParams = {
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 6,
+        character: 25
+      }
+    }
+
+    await onCompletionHandler(completionParams)
+    await onCompletionHandler(completionParams)
+
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not request recipe-local files outside SRC_URI completion', async () => {
+    analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.COMPLETION
+    })
+
+    const sendRequest = jest.fn()
+
+    setCompletionConnection({
+      sendRequest
+    } as unknown as Connection)
+
+    await onCompletionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 0,
+        character: 1
+      }
+    })
+
+    expect(sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('does not fail SRC_URI completion when the client request is unsupported', async () => {
+    analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.CORRECT
+    })
+
+    const sendRequest = jest.fn().mockRejectedValue(
+      new Error('Unsupported request')
+    )
+    const logError = jest
+      .spyOn(logger, 'error')
+      .mockImplementation()
+
+    setCompletionConnection({
+      sendRequest
+    } as unknown as Connection)
+
+    const result = await onCompletionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 6,
+        character: 25
+      }
+    })
+
+    expect(result).toEqual([])
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Error while getting recipe local files'
+      )
     )
   })
 

--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -9,7 +9,7 @@
  */
 
 import { logger } from '../lib/src/utils/OutputLogger'
-import { type TextDocumentPositionParams, type CompletionItem, type SymbolInformation, CompletionItemKind, type Position } from 'vscode-languageserver/node'
+import { type TextDocumentPositionParams, type CompletionItem, type SymbolInformation, CompletionItemKind, type Position, type Connection } from 'vscode-languageserver/node'
 import { symbolKindToCompletionKind } from '../utils/lsp'
 import { BITBAKE_VARIABLES } from '../completions/bitbake-variables'
 import { RESERVED_KEYWORDS } from '../completions/reserved-keywords'
@@ -25,8 +25,16 @@ import { commonDirectoriesVariables } from '../lib/src/availableVariables'
 import { mergeArraysDistinctly } from '../lib/src/utils/arrays'
 import { type BitbakeSymbolInformation } from '../tree-sitter/declarations'
 import { getSpdxLicenseCompletionResolve, getLicenseCompletionItems, spdxLicenseDescription } from '../completions/spdx-licenses'
+import { RequestMethod, type RequestResult } from '../lib/src/types/requests'
 
 let documentUri = ''
+let connection: Connection | undefined
+
+export function setCompletionConnection (
+  completionConnection: Connection | undefined
+): void {
+  connection = completionConnection
+}
 
 export async function onCompletionHandler (textDocumentPositionParams: TextDocumentPositionParams): Promise<CompletionItem[]> {
   const wordPosition = {
@@ -57,6 +65,8 @@ export async function onCompletionHandler (textDocumentPositionParams: TextDocum
 }
 
 async function getBitBakeCompletionItems (textDocumentPositionParams: TextDocumentPositionParams, word: string | null, wordPosition: Position): Promise<CompletionItem[]> {
+  const completionDocumentUri = textDocumentPositionParams.textDocument.uri
+
   if (analyzer.isString(documentUri, wordPosition.line, wordPosition.character)) {
     const variablesAllowedForRecipeCompletion = ['RDEPENDS', 'IMAGE_INSTALL', 'DEPENDS', 'RRECOMMENDS', 'RSUGGESTS', 'RCONFLICTS', 'RREPLACES', 'CORE_IMAGE_EXTRA_INSTALL', 'PACKAGE_INSTALL', 'PACKAGE_INSTALL_ATTEMPTONLY']
     const isVariableAllowedForRecipeCompletion = analyzer.isStringContentOfVariableAssignment(documentUri, wordPosition.line, wordPosition.character, variablesAllowedForRecipeCompletion)
@@ -72,8 +82,30 @@ async function getBitBakeCompletionItems (textDocumentPositionParams: TextDocume
 
     const variablesAllowedForUriCompletion = ['SRC_URI']
     const isVariableAllowedForUriCompletion = analyzer.isStringContentOfVariableAssignment(documentUri, wordPosition.line, wordPosition.character, variablesAllowedForUriCompletion)
-    const recipeLocalFiles = analyzer.getRecipeLocalFiles(documentUri)
-    if (isVariableAllowedForUriCompletion && recipeLocalFiles !== undefined) {
+
+    if (isVariableAllowedForUriCompletion) {
+      let recipeLocalFiles = analyzer.getRecipeLocalFiles(completionDocumentUri)
+
+      if (recipeLocalFiles === undefined && connection !== undefined) {
+        try {
+          recipeLocalFiles =
+            await connection.sendRequest<RequestResult['getRecipeLocalFiles']>(
+              RequestMethod.getRecipeLocalFiles,
+              { uri: completionDocumentUri.replace('file://', '') }
+            )
+          analyzer.setRecipeLocalFiles(completionDocumentUri, recipeLocalFiles)
+        } catch (error) {
+          // When using the language server without the client, custom
+          // requests are not supported. CoC.nvim disables the server if
+          // this exception escapes the completion handler.
+          logger.error(`Error while getting recipe local files: ${error}`)
+        }
+      }
+
+      if (recipeLocalFiles === undefined) {
+        return []
+      }
+
       const fileUriCompletionItems = recipeLocalFiles.foundFileUris.map<CompletionItem>((fileUri) => {
         return {
           label: path.basename(fileUri),

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -23,7 +23,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument'
 import { analyzer } from './tree-sitter/analyzer'
 import { generateBashParser, generateBitBakeParser } from './tree-sitter/parser'
 import { logger } from './lib/src/utils/OutputLogger'
-import { onCompletionHandler, onCompletionResolveHandler } from './connectionHandlers/onCompletion'
+import { onCompletionHandler, onCompletionResolveHandler, setCompletionConnection } from './connectionHandlers/onCompletion'
 import { onDefinitionHandler, setDefinitionsConnection } from './connectionHandlers/onDefinition'
 import { onHoverHandler } from './connectionHandlers/onHover'
 import { generateEmbeddedLanguageDocs, getEmbeddedLanguageTypeOnPosition } from './embedded-languages/general-support'
@@ -39,6 +39,7 @@ import { onPrepareRenameHandler, onRenameRequestHandler } from './connectionHand
 // Create a connection for the server. The connection uses Node's IPC as a transport
 export const connection: Connection = createConnection(ProposedFeatures.all)
 setDefinitionsConnection(connection)
+setCompletionConnection(connection)
 const documents = new TextDocuments<TextDocument>(TextDocument)
 let workspaceFolder: string | undefined
 let coreMetaFolder: string | undefined
@@ -219,20 +220,7 @@ disposables.push(
 
   documents.onDidOpen(analyzeDocument),
 
-  documents.onDidChangeContent(async (event) => {
-    await analyzeDocument(event)
-
-    if (analyzer.getRecipeLocalFiles(event.document.uri) === undefined) {
-      try {
-        const recipeLocalFiles = await connection.sendRequest<RequestResult['getRecipeLocalFiles']>(RequestMethod.getRecipeLocalFiles, { uri: event.document.uri.replace('file://', '') })
-        analyzer.setRecipeLocalFiles(event.document.uri, recipeLocalFiles)
-      } catch (error) {
-        // When using the language server without the client, custom requests are not supported
-        // The CoC.nvim client will disable the server if an exception is thrown
-        logger.error(`Error while getting recipe local files: ${error}`)
-      }
-    }
-  })
+  documents.onDidChangeContent(analyzeDocument)
 )
 
 connection.listen()


### PR DESCRIPTION
## Summary

Fix unbounded recipe-local discovery that could recursively scan a configured build directory when editing documents such as `build.conf`.

Fixes #537.

## Root cause

Recipe-local discovery was triggered eagerly from document changes and used separate traversal paths for files and directories.

The client also attempted recipe-local discovery for `.conf` documents even though recipe-local links are not applicable there.

## Changes

- add a standalone non-regression commit covering the existing recipe-local document-link behavior;
- skip recipe-local discovery for `.conf` documents before requesting links or starting a scan;
- centralize recipe-local roots and glob-pattern construction for both document links and the language client;
- replace separate file and directory traversal with one asynchronous `fast-glob.stream()` scan;
- return files and directories from the same object-mode stream using absolute paths;
- limit traversal concurrency to 4 and avoid following symbolic links;
- cancel active discovery through `CancellationToken` and `stream.destroy()`;
- avoid adding a separate timeout;
- request recipe-local files lazily only while completing `SRC_URI`;
- cache successful recipe-local discovery results;
- preserve compatibility with clients that do not support the custom request.

## Commit structure

1. `test: cover recipe-local document links`
2. `fix: bound recipe-local file discovery`
3. `optim: defer recipe-local discovery to completion`

## Validation

- ESLint on the modified client and server files;
- `npm run compile`;
- targeted document-link provider suite: 4 tests passed;
- targeted server completion suite: 27 tests passed;
- 31 targeted tests passed in total.
