### PR TITLE
Extract reusable cancellable file search utility

### DIFF
--- a/client/src/__tests__/unit-tests/document-link-provider.test.ts
+++ b/client/src/__tests__/unit-tests/document-link-provider.test.ts
@@ -13,6 +13,7 @@ import vscode, {
 } from 'vscode'
 import { type LanguageClient } from 'vscode-languageclient/node'
 import { BitbakeDocumentLinkProvider } from '../../documentLinkProvider'
+import { CancellableFileSearch } from '../../utils/CancellableFileSearch'
 import { RequestMethod } from '../../lib/src/types/requests'
 
 jest.mock('vscode')
@@ -213,7 +214,7 @@ describe('BitbakeDocumentLinkProvider', () => {
     const streamSpy = jest.spyOn(fg, 'stream')
 
     const result =
-      await BitbakeDocumentLinkProvider.findFilesAndDirs(
+      await CancellableFileSearch.findFilesAndDirs(
         ['/workspace/**/*'],
         undefined,
         {
@@ -261,7 +262,7 @@ describe('BitbakeDocumentLinkProvider', () => {
     } as unknown as CancellationToken
 
     const scan =
-      BitbakeDocumentLinkProvider.findFilesAndDirs(
+      CancellableFileSearch.findFilesAndDirs(
         ['/workspace/**/*'],
         undefined,
         token

--- a/client/src/documentLinkProvider.ts
+++ b/client/src/documentLinkProvider.ts
@@ -6,20 +6,14 @@
 import vscode from 'vscode'
 import { type LanguageClient } from 'vscode-languageclient/node'
 import { RequestMethod, type RequestResult } from './lib/src/types/requests'
-import { logger } from './lib/src/utils/OutputLogger'
 import path from 'path'
 import { extractRecipeName } from './lib/src/utils/files'
+import { CancellableFileSearch } from './utils/CancellableFileSearch'
 import fg from 'fast-glob'
 
 interface RecipeLocalSearch {
   roots: string[]
 }
-
-type GlobStream =
-  NodeJS.ReadableStream &
-  AsyncIterable<fg.Entry> & {
-    destroy: () => void
-  }
 
 export class BitbakeDocumentLinkProvider implements vscode.DocumentLinkProvider {
   private readonly client: LanguageClient
@@ -67,89 +61,6 @@ export class BitbakeDocumentLinkProvider implements vscode.DocumentLinkProvider 
     })
   }
 
-  public static async findFilesAndDirs (
-    patterns: string[],
-    maxFileResults?: number,
-    token?: vscode.CancellationToken
-  ): Promise<{
-      foundFiles: vscode.Uri[]
-      foundDirs: string[]
-    }> {
-    const foundFiles: vscode.Uri[] = []
-    const foundDirs: string[] = []
-
-    const isCancelled = (): boolean => {
-      return token?.isCancellationRequested === true
-    }
-
-    if (patterns.length === 0 || isCancelled()) {
-      return { foundFiles, foundDirs }
-    }
-
-    const stream = fg.stream(patterns, {
-      absolute: true,
-      concurrency: 4,
-      dot: true,
-      followSymbolicLinks: false,
-      objectMode: true,
-      onlyFiles: false,
-      unique: true
-    }) as GlobStream
-
-    let streamDestroyed = false
-
-    const destroyStream = (): void => {
-      if (streamDestroyed) {
-        return
-      }
-
-      streamDestroyed = true
-      stream.destroy()
-    }
-
-    const cancellationSubscription =
-      typeof token?.onCancellationRequested === 'function'
-        ? token.onCancellationRequested(() => {
-          destroyStream()
-        })
-        : undefined
-
-    try {
-      for await (const entry of stream) {
-        if (isCancelled()) {
-          destroyStream()
-          break
-        }
-
-        if (entry.dirent.isDirectory()) {
-          foundDirs.push(entry.path)
-          continue
-        }
-
-        if (
-          entry.dirent.isFile() &&
-          (
-            maxFileResults === undefined ||
-            foundFiles.length < maxFileResults
-          )
-        ) {
-          foundFiles.push(vscode.Uri.file(entry.path))
-        }
-      }
-    } catch (error) {
-      logger.error(
-        `An error occurred while finding recipe-local entries. ${
-          JSON.stringify(error)
-        }`
-      )
-    } finally {
-      destroyStream()
-      cancellationSubscription?.dispose()
-    }
-
-    return { foundFiles, foundDirs }
-  }
-
   private basenameIsEqual (path1: string, path2: string): boolean {
     return path.basename(path1) === path.basename(path2)
   }
@@ -176,7 +87,7 @@ export class BitbakeDocumentLinkProvider implements vscode.DocumentLinkProvider 
       )
 
     const { foundFiles, foundDirs } =
-      await BitbakeDocumentLinkProvider.findFilesAndDirs(
+      await CancellableFileSearch.findFilesAndDirs(
         patterns,
         filenames.length,
         token

--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -33,6 +33,7 @@ import * as vscode from 'vscode'
 import { middlewareProvideReferences } from './middlewareReferences'
 import { RequestMethod, type RequestParams, type RequestResult } from '../lib/src/types/requests'
 import { BitbakeDocumentLinkProvider } from '../documentLinkProvider'
+import { CancellableFileSearch } from '../utils/CancellableFileSearch'
 import { middlewarePrepareRename, middlewareProvideRenameEdits } from './middlewareRename'
 
 export async function activateLanguageServer (context: ExtensionContext, bitBakeProjectScanner: BitBakeProjectScanner): Promise<LanguageClient> {
@@ -113,7 +114,7 @@ export async function activateLanguageServer (context: ExtensionContext, bitBake
       )
 
     const { foundFiles, foundDirs } =
-      await BitbakeDocumentLinkProvider.findFilesAndDirs(
+      await CancellableFileSearch.findFilesAndDirs(
         patterns
       )
 

--- a/client/src/utils/CancellableFileSearch.ts
+++ b/client/src/utils/CancellableFileSearch.ts
@@ -1,0 +1,99 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import fg from 'fast-glob'
+import vscode from 'vscode'
+import { logger } from '../lib/src/utils/OutputLogger'
+
+type GlobStream =
+  NodeJS.ReadableStream &
+  AsyncIterable<fg.Entry> & {
+    destroy: () => void
+  }
+
+export class CancellableFileSearch {
+  public static async findFilesAndDirs (
+    patterns: string[],
+    maxFileResults?: number,
+    token?: vscode.CancellationToken
+  ): Promise<{
+      foundFiles: vscode.Uri[]
+      foundDirs: string[]
+    }> {
+    const foundFiles: vscode.Uri[] = []
+    const foundDirs: string[] = []
+
+    const isCancelled = (): boolean => {
+      return token?.isCancellationRequested === true
+    }
+
+    if (patterns.length === 0 || isCancelled()) {
+      return { foundFiles, foundDirs }
+    }
+
+    const stream = fg.stream(patterns, {
+      absolute: true,
+      concurrency: 4,
+      dot: true,
+      followSymbolicLinks: false,
+      objectMode: true,
+      onlyFiles: false,
+      unique: true
+    }) as GlobStream
+
+    let streamDestroyed = false
+
+    const destroyStream = (): void => {
+      if (streamDestroyed) {
+        return
+      }
+
+      streamDestroyed = true
+      stream.destroy()
+    }
+
+    const cancellationSubscription =
+      typeof token?.onCancellationRequested === 'function'
+        ? token.onCancellationRequested(() => {
+          destroyStream()
+        })
+        : undefined
+
+    try {
+      for await (const entry of stream) {
+        if (isCancelled()) {
+          destroyStream()
+          break
+        }
+
+        if (entry.dirent.isDirectory()) {
+          foundDirs.push(entry.path)
+          continue
+        }
+
+        if (
+          entry.dirent.isFile() &&
+          (
+            maxFileResults === undefined ||
+            foundFiles.length < maxFileResults
+          )
+        ) {
+          foundFiles.push(vscode.Uri.file(entry.path))
+        }
+      }
+    } catch (error) {
+      logger.error(
+        `An error occurred while searching files and directories. ${
+          JSON.stringify(error)
+        }`
+      )
+    } finally {
+      destroyStream()
+      cancellationSubscription?.dispose()
+    }
+
+    return { foundFiles, foundDirs }
+  }
+}


### PR DESCRIPTION
## Summary

Extract the generic cancellable filesystem traversal from `BitbakeDocumentLinkProvider` into a reusable `CancellableFileSearch` utility.

Recipe-local policy remains close to `BitbakeDocumentLinkProvider`; only the generic search mechanics move to the utility. The language client now uses the same reusable search directly.

The refactor preserves the behavior introduced by #538, including:

- bounded `fast-glob` traversal;
- pre-existing cancellation handling;
- active stream destruction on cancellation;
- cancellation subscription disposal;
- stream cleanup;
- file-result limiting.

No benchmark, timeout, result truncation, or additional traversal-library test coverage is introduced.

## Validation

- document-link provider tests: 4 passed
- server unit tests: 86 passed
- TypeScript compilation passed
- ESLint passed
- `git diff --check` passed

Generated parser, documentation, and SPDX test resources were prepared using the repository-provided fetch scripts and remained ignored by Git.

Closes #540
