### PR TITLE
refactor: extract Toaster lifecycle

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -75,6 +75,10 @@ const languages = {
     registerTextEditorCommand: jest.fn(),
   };
 
+  const env = {
+    openExternal: jest.fn(),
+  };
+
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const CodeLens = function CodeLens() {};
 
@@ -154,6 +158,7 @@ const languages = {
     ConfigurationTarget,
     debug,
     commands,
+    env,
     QuickInputButtons,
     tests,
     TestRunProfileKind,

--- a/client/src/__tests__/unit-tests/ui/bitbake-toaster.test.ts
+++ b/client/src/__tests__/unit-tests/ui/bitbake-toaster.test.ts
@@ -1,0 +1,257 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode'
+import * as child_process from 'child_process'
+import type childProcess from 'child_process'
+import { type IPty } from 'node-pty'
+
+import { BitbakeDriver } from '../../../driver/BitbakeDriver'
+import { BitbakeToaster } from '../../../ui/BitbakeToaster'
+import { clientNotificationManager } from '../../../ui/ClientNotificationManager'
+import * as BitbakeTerminal from '../../../ui/BitbakeTerminal'
+import * as ProcessUtils from '../../../utils/ProcessUtils'
+
+jest.mock('vscode')
+jest.mock('child_process', () => ({
+  execSync: jest.fn()
+}))
+
+function createExitProcess (): {
+  process: IPty
+  finish: (exitCode: number) => void
+} {
+  let exitHandler:
+    ((event: { exitCode: number, signal: number }) => void) | undefined
+
+  const process = {
+    onExit: jest.fn(
+      (
+        callback: (event: { exitCode: number, signal: number }) => void
+      ) => {
+        exitHandler = callback
+        return { dispose: jest.fn() }
+      }
+    )
+  } as unknown as IPty
+
+  return {
+    process,
+    finish: (exitCode: number): void => {
+      expect(exitHandler).toBeDefined()
+      exitHandler?.({ exitCode, signal: 0 })
+    }
+  }
+}
+
+function createToaster (): {
+  toaster: BitbakeToaster
+  driver: BitbakeDriver
+} {
+  const driver = new BitbakeDriver()
+  return {
+    toaster: new BitbakeToaster(driver),
+    driver
+  }
+}
+
+describe('BitbakeToaster', () => {
+  beforeEach(() => {
+    jest.spyOn(vscode.env, 'openExternal').mockResolvedValue(true)
+    jest.spyOn(
+      clientNotificationManager,
+      'showToasterStarted'
+    ).mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  it('starts Toaster and opens the browser after a successful exit', async () => {
+    const { toaster, driver } = createToaster()
+    const fakeProcess = createExitProcess()
+
+    const terminalSpy = jest.spyOn(
+      BitbakeTerminal,
+      'runBitbakeTerminalCustomCommand'
+    ).mockResolvedValue(fakeProcess.process)
+
+    await toaster.startInBrowser()
+
+    expect(terminalSpy).toHaveBeenCalledWith(
+      driver,
+      'nohup bash -c "source toaster start"',
+      'Toaster'
+    )
+    expect(vscode.env.openExternal).not.toHaveBeenCalled()
+    expect(
+      clientNotificationManager.showToasterStarted
+    ).not.toHaveBeenCalled()
+
+    fakeProcess.finish(0)
+
+    expect(vscode.Uri.parse).toHaveBeenCalledWith(
+      'http://localhost:8000'
+    )
+    expect(vscode.env.openExternal).toHaveBeenCalledTimes(1)
+    expect(
+      clientNotificationManager.showToasterStarted
+    ).toHaveBeenCalledTimes(1)
+  })
+
+  it('reopens the browser without starting another process', async () => {
+    const { toaster } = createToaster()
+    const fakeProcess = createExitProcess()
+
+    const terminalSpy = jest.spyOn(
+      BitbakeTerminal,
+      'runBitbakeTerminalCustomCommand'
+    ).mockResolvedValue(fakeProcess.process)
+
+    await toaster.startInBrowser()
+    fakeProcess.finish(0)
+
+    terminalSpy.mockClear()
+    jest.mocked(vscode.env.openExternal).mockClear()
+    jest.mocked(
+      clientNotificationManager.showToasterStarted
+    ).mockClear()
+
+    await toaster.startInBrowser()
+
+    expect(terminalSpy).not.toHaveBeenCalled()
+    expect(vscode.env.openExternal).toHaveBeenCalledTimes(1)
+    expect(
+      clientNotificationManager.showToasterStarted
+    ).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a failed start and remains stopped', async () => {
+    const { toaster } = createToaster()
+    const fakeProcess = createExitProcess()
+
+    const terminalSpy = jest.spyOn(
+      BitbakeTerminal,
+      'runBitbakeTerminalCustomCommand'
+    ).mockResolvedValue(fakeProcess.process)
+
+    const errorSpy = jest.spyOn(
+      vscode.window,
+      'showErrorMessage'
+    )
+
+    await toaster.startInBrowser()
+    fakeProcess.finish(7)
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to start Toaster with exit code 7. See terminal output.'
+    )
+    expect(vscode.env.openExternal).not.toHaveBeenCalled()
+    expect(
+      clientNotificationManager.showToasterStarted
+    ).not.toHaveBeenCalled()
+
+    terminalSpy.mockClear()
+
+    await toaster.stop()
+
+    expect(terminalSpy).not.toHaveBeenCalled()
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      'Toaster has not been started'
+    )
+  })
+
+  it('does not run a stop process when already stopped', async () => {
+    const { toaster } = createToaster()
+
+    const terminalSpy = jest.spyOn(
+      BitbakeTerminal,
+      'runBitbakeTerminalCustomCommand'
+    )
+
+    await toaster.stop()
+
+    expect(terminalSpy).not.toHaveBeenCalled()
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      'Toaster has not been started'
+    )
+  })
+
+  it('waits for the stop command and marks Toaster as stopped', async () => {
+    const { toaster, driver } = createToaster()
+    const startProcess = createExitProcess()
+
+    const terminalSpy = jest.spyOn(
+      BitbakeTerminal,
+      'runBitbakeTerminalCustomCommand'
+    ).mockResolvedValue(startProcess.process)
+
+    await toaster.startInBrowser()
+    startProcess.finish(0)
+
+    terminalSpy.mockClear()
+
+    const stopProcess = Promise.resolve(
+      createExitProcess().process
+    )
+    terminalSpy.mockReturnValue(stopProcess)
+
+    const finishSpy = jest.spyOn(
+      ProcessUtils,
+      'finishProcessExecution'
+    ).mockResolvedValue(
+      {} as childProcess.SpawnSyncReturns<Buffer>
+    )
+
+    await toaster.stop()
+
+    expect(terminalSpy).toHaveBeenCalledWith(
+      driver,
+      'source toaster stop',
+      'Toaster'
+    )
+    expect(finishSpy).toHaveBeenCalledWith(stopProcess)
+
+    terminalSpy.mockClear()
+
+    await toaster.stop()
+
+    expect(terminalSpy).not.toHaveBeenCalled()
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      'Toaster has not been started'
+    )
+  })
+
+  it('stops a running Toaster synchronously on shutdown', async () => {
+    const { toaster } = createToaster()
+    const startProcess = createExitProcess()
+
+    jest.spyOn(
+      BitbakeTerminal,
+      'runBitbakeTerminalCustomCommand'
+    ).mockResolvedValue(startProcess.process)
+
+    await toaster.startInBrowser()
+    startProcess.finish(0)
+
+    const execMock = child_process.execSync as unknown as jest.Mock
+    execMock.mockReturnValue(Buffer.from(''))
+
+    await toaster.stopOnShutdown()
+
+    expect(execMock).toHaveBeenCalledWith(
+      'source toaster stop',
+      { shell: '/bin/bash' }
+    )
+
+    execMock.mockClear()
+
+    await toaster.stopOnShutdown()
+
+    expect(execMock).not.toHaveBeenCalled()
+  })
+})

--- a/client/src/ui/BitbakeCommands.ts
+++ b/client/src/ui/BitbakeCommands.ts
@@ -26,6 +26,7 @@ import { clientNotificationManager } from './ClientNotificationManager'
 import { bitbakeESDKMode, configureDevtoolSDKFallback, generateCPPProperties } from '../driver/BitbakeESDK'
 import bitbakeEnvScanner from '../driver/BitbakeEnvScanner'
 import { type BitbakeTerminalProfileProvider, openBitbakeTerminalProfile } from './BitbakeTerminalProfile'
+import { BitbakeToaster } from './BitbakeToaster'
 import { mergeArraysDistinctly } from '../lib/src/utils/arrays'
 import { finishProcessExecution } from '../utils/ProcessUtils'
 import { type LanguageClient } from 'vscode-languageclient/node'
@@ -34,6 +35,8 @@ import { getVariableValue } from '../language/languageClient'
 let parsingPending = false
 
 export function registerBitbakeCommands (context: vscode.ExtensionContext, bitbakeWorkspace: BitbakeWorkspace, bitbakeTaskProvider: BitbakeTaskProvider, bitBakeProjectScanner: BitBakeProjectScanner, bitbakeTerminalProfileProvider: BitbakeTerminalProfileProvider, client: LanguageClient): void {
+  const bitbakeToaster = new BitbakeToaster(bitBakeProjectScanner.bitbakeDriver)
+
   context.subscriptions.push(
     vscode.commands.registerCommand('bitbake.parse-recipes', async () => { await parseAllrecipes(bitbakeWorkspace, bitbakeTaskProvider) }),
     vscode.commands.registerCommand('bitbake.build-recipe', async (uri) => { await buildRecipeCommand(bitbakeWorkspace, bitBakeProjectScanner, uri) }),
@@ -49,8 +52,8 @@ export function registerBitbakeCommands (context: vscode.ExtensionContext, bitba
     vscode.commands.registerCommand('bitbake.open-recipe-workdir', async (uri) => { await openRecipeWorkdirCommand(bitbakeWorkspace, bitBakeProjectScanner, client, uri) }),
     vscode.commands.registerCommand('bitbake.recipe-devshell', async (uri) => { await openBitbakeDevshell(bitbakeTerminalProfileProvider, bitbakeWorkspace, bitBakeProjectScanner, uri) }),
     vscode.commands.registerCommand('bitbake.collapse-list', async () => { await collapseActiveList() }),
-    vscode.commands.registerCommand('bitbake.start-toaster-in-browser', async () => { await startToasterInBrowser(bitBakeProjectScanner.bitbakeDriver) }),
-    vscode.commands.registerCommand('bitbake.stop-toaster', async () => { await stopToaster(bitBakeProjectScanner.bitbakeDriver) }),
+    vscode.commands.registerCommand('bitbake.start-toaster-in-browser', async () => { await bitbakeToaster.startInBrowser() }),
+    vscode.commands.registerCommand('bitbake.stop-toaster', async () => { await bitbakeToaster.stop() }),
     vscode.commands.registerCommand('bitbake.clear-workspace-state', async () => { await clearAllWorkspaceState(context) }),
     vscode.commands.registerCommand('bitbake.examine-dependency-taskexp', async (uri) => { await examineDependenciesTaskexp(bitbakeWorkspace, bitBakeProjectScanner, uri) }),
     // Handles enqueued parsing requests (onSave)
@@ -65,7 +68,7 @@ export function registerBitbakeCommands (context: vscode.ExtensionContext, bitba
     // Close Toaster on extension shutdown
     {
       dispose: async () => {
-        await stopToasterOnShutdown(bitBakeProjectScanner.bitbakeDriver)
+        await bitbakeToaster.stopOnShutdown()
       }
     }
   )
@@ -217,60 +220,6 @@ async function runTaskCommand (bitbakeWorkspace: BitbakeWorkspace, bitBakeProjec
       `Bitbake: Task: ${chosenTask}: ${chosenRecipe}`)
     }
   }
-}
-
-export let isToasterStarted = false
-
-function openToasterBrowser (): void {
-  const DEFAULT_TOASTER_PORT = 8000
-  const url = `http://localhost:${DEFAULT_TOASTER_PORT}`
-  void vscode.env.openExternal(vscode.Uri.parse(url)).then(success => {
-    if (!success) {
-      void vscode.window.showErrorMessage(`Failed to open URL ${url}`)
-    }
-  })
-}
-
-async function startToasterInBrowser (bitbakeDriver: BitbakeDriver): Promise<void> {
-  if (isToasterStarted) {
-    openToasterBrowser();
-    clientNotificationManager.showToasterStarted()
-    return
-  }
-  const command = `nohup bash -c "${bitbakeDriver.composeToasterCommand('start')}"`
-  const process = await runBitbakeTerminalCustomCommand(bitbakeDriver, command, 'Toaster')
-  process.onExit((e) => {
-    if (e.exitCode !== 0) {
-      void vscode.window.showErrorMessage(`Failed to start Toaster with exit code ${e.exitCode}. See terminal output.`)
-      return
-    }
-    isToasterStarted = true
-    openToasterBrowser()
-    clientNotificationManager.showToasterStarted()
-  })
-}
-
-async function stopToaster (bitbakeDriver: BitbakeDriver): Promise<void> {
-  if (!isToasterStarted) {
-    void vscode.window.showInformationMessage('Toaster has not been started')
-    return
-  }
-  const command = bitbakeDriver.composeToasterCommand('stop')
-  const process = runBitbakeTerminalCustomCommand(bitbakeDriver, command, 'Toaster')
-  await finishProcessExecution(process)
-  isToasterStarted = false
-}
-
-export async function stopToasterOnShutdown (bitbakeDriver: BitbakeDriver): Promise<void> {
-  if (!isToasterStarted) {
-    return
-  }
-  const command = bitbakeDriver.composeToasterCommand('stop')
-  const script = bitbakeDriver.composeBitbakeScript(command)
-  // We can't spawn terminals or ptys when closing the extension, so we use child_process to stop Toaster
-  // Use BitbakeTerminals to spawn commands outside of this context! This is a special shutdown case.
-  child_process.execSync(script, { shell: '/bin/bash' })
-  isToasterStarted = false
 }
 
 async function selectTask (client: LanguageClient, recipe: string): Promise<string | undefined> {

--- a/client/src/ui/BitbakeToaster.ts
+++ b/client/src/ui/BitbakeToaster.ts
@@ -1,0 +1,88 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode'
+import * as child_process from 'child_process'
+
+import { type BitbakeDriver } from '../driver/BitbakeDriver'
+import { clientNotificationManager } from './ClientNotificationManager'
+import { runBitbakeTerminalCustomCommand } from './BitbakeTerminal'
+import { finishProcessExecution } from '../utils/ProcessUtils'
+
+export class BitbakeToaster {
+  private started = false
+
+  constructor (private readonly bitbakeDriver: BitbakeDriver) {}
+
+  private openBrowser (): void {
+    const DEFAULT_TOASTER_PORT = 8000
+    const url = `http://localhost:${DEFAULT_TOASTER_PORT}`
+
+    void vscode.env.openExternal(vscode.Uri.parse(url)).then(success => {
+      if (!success) {
+        void vscode.window.showErrorMessage(`Failed to open URL ${url}`)
+      }
+    })
+  }
+
+  async startInBrowser (): Promise<void> {
+    if (this.started) {
+      this.openBrowser()
+      clientNotificationManager.showToasterStarted()
+      return
+    }
+
+    const command = `nohup bash -c "${this.bitbakeDriver.composeToasterCommand('start')}"`
+    const process = await runBitbakeTerminalCustomCommand(
+      this.bitbakeDriver,
+      command,
+      'Toaster'
+    )
+
+    process.onExit((event) => {
+      if (event.exitCode !== 0) {
+        void vscode.window.showErrorMessage(
+          `Failed to start Toaster with exit code ${event.exitCode}. See terminal output.`
+        )
+        return
+      }
+
+      this.started = true
+      this.openBrowser()
+      clientNotificationManager.showToasterStarted()
+    })
+  }
+
+  async stop (): Promise<void> {
+    if (this.started === false) {
+      void vscode.window.showInformationMessage('Toaster has not been started')
+      return
+    }
+
+    const command = this.bitbakeDriver.composeToasterCommand('stop')
+    const process = runBitbakeTerminalCustomCommand(
+      this.bitbakeDriver,
+      command,
+      'Toaster'
+    )
+
+    await finishProcessExecution(process)
+    this.started = false
+  }
+
+  async stopOnShutdown (): Promise<void> {
+    if (this.started === false) {
+      return
+    }
+
+    const command = this.bitbakeDriver.composeToasterCommand('stop')
+    const script = this.bitbakeDriver.composeBitbakeScript(command)
+
+    // We can't spawn terminals or ptys when closing the extension, so we use child_process to stop Toaster
+    // Use BitbakeTerminals to spawn commands outside of this context! This is a special shutdown case.
+    child_process.execSync(script, { shell: '/bin/bash' })
+    this.started = false
+  }
+}


### PR DESCRIPTION
## Summary

Extract the Toaster lifecycle from `BitbakeCommands.ts` into a dedicated `BitbakeToaster` class.

The new class owns:

- Toaster started state;
- start and browser opening;
- normal stop handling;
- synchronous shutdown handling.

`BitbakeCommands.ts` now only registers the VS Code commands and delegates those operations to the lifecycle object.

No behavior change is intended.

## Tests

Added characterization coverage for:

- successful start;
- reopening the browser when already started;
- failed start;
- stopping when already stopped;
- normal stop completion and state reset;
- synchronous stop during extension shutdown.

Validated locally with:

- targeted Jest tests for `bitbake-commands` and `bitbake-toaster`;
- TypeScript compile;
- ESLint;
- `git diff --check`.

The broader client test run was also attempted. `scanner.test.ts` requires the BitBake integration fixture to be initialized and could not run in this worktree because its `init-build-env` file is absent; the remaining suites passed.
