### PR TITLE
refactor: extract document lifecycle

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -26,6 +26,7 @@ const languages = {
     registerTreeDataProvider: jest.fn(),
     createTreeView: jest.fn(),
     createTerminal: jest.fn(),
+    visibleTextEditors: [],
   };
 
   const TerminalLink = jest.fn();
@@ -38,6 +39,7 @@ const languages = {
     onDidChangeConfiguration: jest.fn(),
     onDidChangeTextDocument: jest.fn(),
     onDidChangeWorkspaceFolders: jest.fn(),
+    onDidCloseTextDocument: jest.fn(),
     onDidCreateFiles: jest.fn(),
     onDidDeleteFiles: jest.fn(),
     onDidRenameFiles: jest.fn(),

--- a/client/src/__tests__/unit-tests/ui/bitbake-document-lifecycle.test.ts
+++ b/client/src/__tests__/unit-tests/ui/bitbake-document-lifecycle.test.ts
@@ -1,0 +1,194 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode'
+import { type LanguageClient } from 'vscode-languageclient/node'
+
+import { type BitbakeDriver } from '../../../driver/BitbakeDriver'
+import { type BitBakeProjectScanner } from '../../../driver/BitBakeProjectScanner'
+import { type BitbakeScanResult } from '../../../lib/src/types/BitbakeScanResult'
+import { registerBitbakeDocumentLifecycle } from '../../../ui/BitbakeDocumentLifecycle'
+
+jest.mock('vscode')
+
+type DocumentHandler = (document: vscode.TextDocument) => void | Promise<void>
+
+function createDocument (
+  fsPath: string,
+  languageId = 'bitbake'
+): vscode.TextDocument {
+  return {
+    uri: { fsPath },
+    languageId
+  } as unknown as vscode.TextDocument
+}
+
+function visibleEditors (): vscode.TextEditor[] {
+  return vscode.window.visibleTextEditors as unknown as vscode.TextEditor[]
+}
+
+function createHarness (recipeNames: string[] = []): {
+  closeHandler: DocumentHandler
+  saveHandler: DocumentHandler
+  sendNotification: jest.Mock
+  isBitbakeSettingsSane: jest.Mock
+  checkBitbakeSettingsSanity: jest.Mock
+} {
+  const sendNotification = jest.fn()
+  const isBitbakeSettingsSane = jest.fn().mockReturnValue(true)
+  const checkBitbakeSettingsSanity = jest.fn().mockResolvedValue(true)
+
+  const driver = {
+    isBitbakeSettingsSane,
+    checkBitbakeSettingsSanity
+  } as unknown as BitbakeDriver
+
+  const scanResult = {
+    _recipes: recipeNames.map((name) => ({ name }))
+  } as BitbakeScanResult
+
+  const scanner = {
+    activeScanResult: scanResult
+  } as unknown as BitBakeProjectScanner
+
+  const client = {
+    sendNotification
+  } as unknown as LanguageClient
+
+  registerBitbakeDocumentLifecycle(driver, scanner, client)
+
+  const closeRegistration =
+    vscode.workspace.onDidCloseTextDocument as unknown as jest.Mock
+  const saveRegistration =
+    vscode.workspace.onDidSaveTextDocument as unknown as jest.Mock
+
+  expect(closeRegistration).toHaveBeenCalledTimes(1)
+  expect(saveRegistration).toHaveBeenCalledTimes(1)
+
+  return {
+    closeHandler: closeRegistration.mock.calls[0][0] as DocumentHandler,
+    saveHandler: saveRegistration.mock.calls[0][0] as DocumentHandler,
+    sendNotification,
+    isBitbakeSettingsSane,
+    checkBitbakeSettingsSanity
+  }
+}
+
+describe('BitbakeDocumentLifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    const disposable = { dispose: jest.fn() }
+
+    const closeRegistration =
+      vscode.workspace.onDidCloseTextDocument as unknown as jest.Mock
+    const saveRegistration =
+      vscode.workspace.onDidSaveTextDocument as unknown as jest.Mock
+    const getConfiguration =
+      vscode.workspace.getConfiguration as unknown as jest.Mock
+
+    closeRegistration.mockReturnValue(disposable)
+    saveRegistration.mockReturnValue(disposable)
+    getConfiguration.mockReturnValue({
+      get: jest.fn().mockReturnValue(true)
+    })
+
+    visibleEditors().length = 0
+  })
+
+  it('removes the scan result when the last recipe document closes', () => {
+    const { closeHandler, sendNotification } = createHarness()
+
+    closeHandler(createDocument('/layers/foo.bb'))
+
+    expect(sendNotification).toHaveBeenCalledWith(
+      'bitbake/removeScanResult',
+      { recipeName: 'foo' }
+    )
+  })
+
+  it('keeps the scan result while a related recipe document remains visible', () => {
+    visibleEditors().push({
+      document: createDocument('/layers/foo.bb')
+    } as vscode.TextEditor)
+
+    const { closeHandler, sendNotification } = createHarness()
+
+    closeHandler(createDocument('/layers/foo.bbappend'))
+
+    expect(sendNotification).not.toHaveBeenCalled()
+  })
+
+  it('ignores saved documents that are not BitBake documents', async () => {
+    const { saveHandler } = createHarness()
+
+    await saveHandler(createDocument('/layers/foo.py', 'python'))
+
+    expect(vscode.commands.executeCommand).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when parse-on-save is disabled', async () => {
+    const getConfiguration =
+      vscode.workspace.getConfiguration as unknown as jest.Mock
+
+    getConfiguration.mockReturnValue({
+      get: jest.fn().mockReturnValue(false)
+    })
+
+    const { saveHandler } = createHarness()
+
+    await saveHandler(createDocument('/layers/foo.bb'))
+
+    expect(vscode.commands.executeCommand).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when BitBake settings fail the sanity check', async () => {
+    const {
+      saveHandler,
+      isBitbakeSettingsSane,
+      checkBitbakeSettingsSanity
+    } = createHarness()
+
+    isBitbakeSettingsSane.mockReturnValue(false)
+    checkBitbakeSettingsSanity.mockResolvedValue(false)
+
+    await saveHandler(createDocument('/layers/foo.bb'))
+
+    expect(checkBitbakeSettingsSanity).toHaveBeenCalledTimes(1)
+    expect(vscode.commands.executeCommand).not.toHaveBeenCalled()
+  })
+
+  it('scans the recipe environment for a known saved recipe', async () => {
+    const { saveHandler } = createHarness(['foo'])
+    const document = createDocument('/layers/foo.bb')
+
+    await saveHandler(document)
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      'bitbake.scan-recipe-env',
+      document.uri
+    )
+  })
+
+  it('scans the global environment for configuration files', async () => {
+    const { saveHandler } = createHarness()
+
+    await saveHandler(createDocument('/build/conf/local.conf'))
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      'bitbake.scan-global-env'
+    )
+  })
+
+  it('falls back to parsing recipes for other saved BitBake files', async () => {
+    const { saveHandler } = createHarness()
+
+    await saveHandler(createDocument('/layers/unknown.bb'))
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      'bitbake.parse-recipes'
+    )
+  })
+})

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -23,8 +23,8 @@ import fs from 'fs'
 import bitbakeEnvScanner from './driver/BitbakeEnvScanner'
 import { BitbakeTerminalProfileProvider } from './ui/BitbakeTerminalProfile'
 import { BitbakeTerminalLinkProvider } from './ui/BitbakeTerminalLinkProvider'
-import { extractRecipeName } from './lib/src/utils/files'
 import { BitbakeConfigPicker } from './ui/BitbakeConfigPicker'
+import { registerBitbakeDocumentLifecycle } from './ui/BitbakeDocumentLifecycle'
 import { type BitbakeScanResult, scanContainsData } from './lib/src/types/BitbakeScanResult'
 import { reviewDiagnostics } from './language/diagnosticsSupport'
 import { embeddedLanguageDocsManager } from './language/EmbeddedLanguageDocsManager'
@@ -246,59 +246,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
   }))
 
   context.subscriptions.push(
-    // Check if the document that was just closed was the last one for a recipe
-    vscode.workspace.onDidCloseTextDocument((document: vscode.TextDocument) => {
-      const ext = ['.bb', '.bbappend', '.inc']
-      const { fsPath } = document.uri
-      if (ext.includes(path.extname(fsPath))) {
-        const recipeName = extractRecipeName(fsPath)
-        const recipeFile = vscode.window.visibleTextEditors.find((editor) => {
-          return ext.includes(path.extname(editor.document.uri.fsPath)) && extractRecipeName(editor.document.uri.fsPath) === recipeName
-        })
-        if (recipeFile === undefined) {
-          logger.debug(`No files related to the recipe ${recipeName}, sending notification to remove scan results`)
-          void client.sendNotification('bitbake/removeScanResult', { recipeName })
-        }
-      }
-    }),
-    // Run different bitbake commands based on the saved document type
-    vscode.workspace.onDidSaveTextDocument(async (document: vscode.TextDocument) => {
-      if (document.languageId !== 'bitbake') {
-        // Embedded files also trigger this event, but we don't do anything with them
-        return
-      }
-      const parseOnSave = vscode.workspace.getConfiguration('bitbake').get('parseOnSave')
-      if (parseOnSave !== true) {
-        return
-      }
-      // Parse-on-save is automatic: skip invalid settings instead of running
-      // commands that would focus the BitBake view on every save.
-      if (!bitbakeDriver.isBitbakeSettingsSane() && !await bitbakeDriver.checkBitbakeSettingsSanity()) {
-        return
-      }
-      const recipeExts = ['.bb', '.bbappend', '.inc']
-      const extsForGlobalEnvScan = ['.conf', '.bbclass']
-      const { fsPath } = document.uri
-
-      if (recipeExts.includes(path.extname(fsPath))) {
-        const foundRecipe = bitBakeProjectScanner.activeScanResult._recipes.find((recipe) => recipe.name === extractRecipeName(fsPath))
-        if (foundRecipe !== undefined) {
-          logger.debug(`[onDidSave] Running 'bitbake -e' against the saved recipe: ${foundRecipe.name}`)
-          // Note that it pends only one scan at a time. See more details in the command implementation.
-          // Saving more than 2 files at the same time could cause the server to miss some of the scans.
-          await vscode.commands.executeCommand('bitbake.scan-recipe-env', document.uri)
-          return
-        }
-      }
-
-      if (extsForGlobalEnvScan.includes(path.extname(fsPath))) {
-        logger.debug('[onDidSave] Running global environment scan')
-        await vscode.commands.executeCommand('bitbake.scan-global-env')
-        return
-      }
-
-      await vscode.commands.executeCommand('bitbake.parse-recipes')
-    })
+    ...registerBitbakeDocumentLifecycle(bitbakeDriver, bitBakeProjectScanner, client)
   )
 
   registerBitbakeCommands(context, bitbakeWorkspace, bitbakeTaskProvider, bitBakeProjectScanner, terminalProvider, client)

--- a/client/src/ui/BitbakeDocumentLifecycle.ts
+++ b/client/src/ui/BitbakeDocumentLifecycle.ts
@@ -1,0 +1,79 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import path from 'path'
+import * as vscode from 'vscode'
+import { type LanguageClient } from 'vscode-languageclient/node'
+
+import { type BitbakeDriver } from '../driver/BitbakeDriver'
+import { type BitBakeProjectScanner } from '../driver/BitBakeProjectScanner'
+import { extractRecipeName } from '../lib/src/utils/files'
+import { logger } from '../lib/src/utils/OutputLogger'
+
+export function registerBitbakeDocumentLifecycle (
+  bitbakeDriver: BitbakeDriver,
+  bitBakeProjectScanner: BitBakeProjectScanner,
+  client: LanguageClient
+): vscode.Disposable[] {
+  function cleanupScanResult (document: vscode.TextDocument): void {
+    const ext = ['.bb', '.bbappend', '.inc']
+    const { fsPath } = document.uri
+    if (ext.includes(path.extname(fsPath))) {
+      const recipeName = extractRecipeName(fsPath)
+      const recipeFile = vscode.window.visibleTextEditors.find((editor) => {
+        return ext.includes(path.extname(editor.document.uri.fsPath)) && extractRecipeName(editor.document.uri.fsPath) === recipeName
+      })
+      if (recipeFile === undefined) {
+        logger.debug(`No files related to the recipe ${recipeName}, sending notification to remove scan results`)
+        void client.sendNotification('bitbake/removeScanResult', { recipeName })
+      }
+    }
+  }
+
+  async function autoRecipeScan (document: vscode.TextDocument): Promise<void> {
+    if (document.languageId !== 'bitbake') {
+      // Embedded files also trigger this event, but we don't do anything with them
+      return
+    }
+    const parseOnSave = vscode.workspace.getConfiguration('bitbake').get('parseOnSave')
+    if (parseOnSave !== true) {
+      return
+    }
+    // Parse-on-save is automatic: skip invalid settings instead of running
+    // commands that would focus the BitBake view on every save.
+    if (!bitbakeDriver.isBitbakeSettingsSane() && !await bitbakeDriver.checkBitbakeSettingsSanity()) {
+      return
+    }
+    const recipeExts = ['.bb', '.bbappend', '.inc']
+    const extsForGlobalEnvScan = ['.conf', '.bbclass']
+    const { fsPath } = document.uri
+
+    if (recipeExts.includes(path.extname(fsPath))) {
+      const foundRecipe = bitBakeProjectScanner.activeScanResult._recipes.find((recipe) => recipe.name === extractRecipeName(fsPath))
+      if (foundRecipe !== undefined) {
+        logger.debug(`[onDidSave] Running 'bitbake -e' against the saved recipe: ${foundRecipe.name}`)
+        // Note that it pends only one scan at a time. See more details in the command implementation.
+        // Saving more than 2 files at the same time could cause the server to miss some of the scans.
+        await vscode.commands.executeCommand('bitbake.scan-recipe-env', document.uri)
+        return
+      }
+    }
+
+    if (extsForGlobalEnvScan.includes(path.extname(fsPath))) {
+      logger.debug('[onDidSave] Running global environment scan')
+      await vscode.commands.executeCommand('bitbake.scan-global-env')
+      return
+    }
+
+    await vscode.commands.executeCommand('bitbake.parse-recipes')
+  }
+
+  return [
+    // Check if the document that was just closed was the last one for a recipe
+    vscode.workspace.onDidCloseTextDocument(cleanupScanResult),
+    // Run different bitbake commands based on the saved document type
+    vscode.workspace.onDidSaveTextDocument(autoRecipeScan)
+  ]
+}


### PR DESCRIPTION
## Summary

Extract the BitBake document lifecycle handling from `extension.ts` into a dedicated `BitbakeDocumentLifecycle` module.

`extension.ts` remains responsible for registering the lifecycle, while the new module owns the behavior triggered when BitBake documents are saved or closed.

This keeps extension activation focused on composition and registration without changing the existing document-handling behavior.

## Behavior covered

The new characterization tests cover:

- removing a recipe scan result when its last related document is closed;
- keeping the scan result while another related recipe document remains visible;
- ignoring saved documents that are not BitBake documents;
- skipping parse-on-save when disabled;
- skipping automatic parsing when BitBake settings fail the sanity check;
- scanning the recipe environment for a known saved recipe;
- scanning the global environment for configuration files;
- falling back to parsing recipes for other saved BitBake files.

## Validation

Validated locally with:

- the dedicated document lifecycle Jest suite: 8 tests passing;
- TypeScript compile;
- ESLint;
- `git diff --check`.

No behavior change is intended.
