### PR TITLE
test: cover command wrapper recipe final values

### DIFF
--- a/integration-tests/src/tests/command-wrapper.test.ts
+++ b/integration-tests/src/tests/command-wrapper.test.ts
@@ -60,4 +60,41 @@ suite('Bitbake Command Wrapper', () => {
       return files.length === 1
     })
   }).timeout(BITBAKE_TIMEOUT)
+
+  test('Bitbake command wrapper exposes scanned recipe final values in hover', async () => {
+    const recipeUris = await vscode.workspace.findFiles(
+      'layers/openembedded-core/meta/recipes-core/base-files/base-files_*.bb'
+    )
+    assert.strictEqual(recipeUris.length, 1)
+
+    const recipeUri = recipeUris[0]
+    const document = await vscode.workspace.openTextDocument(recipeUri)
+    const recipeText = document.getText()
+    const summaryMatch = /^SUMMARY\s*=\s*"([^"]+)"/m.exec(recipeText)
+    assert.notStrictEqual(summaryMatch, null)
+
+    const expectedSummary = summaryMatch?.[1] as string
+    const summaryOffset = recipeText.indexOf('SUMMARY')
+    assert.notStrictEqual(summaryOffset, -1)
+
+    const position = document.positionAt(summaryOffset + 2)
+    let hoverContent = ''
+
+    await vscode.commands.executeCommand('bitbake.scan-recipe-env', 'base-files')
+
+    await assertWillComeTrue(async () => {
+      const hoverResult = await vscode.commands.executeCommand<vscode.Hover[]>(
+        'vscode.executeHoverProvider',
+        recipeUri,
+        position
+      )
+      const content = hoverResult[0]?.contents[0]
+      hoverContent = content instanceof vscode.MarkdownString ? content.value : ''
+      return hoverContent.includes('**Final Value**') &&
+        hoverContent.includes(expectedSummary)
+    })
+
+    assert.strictEqual(hoverContent.includes('**Final Value**'), true)
+    assert.strictEqual(hoverContent.includes(expectedSummary), true)
+  }).timeout(BITBAKE_TIMEOUT)
 })


### PR DESCRIPTION
## Summary

Add integration regression coverage for recipe final values when BitBake commands are executed through `commandWrapper`.

The test:

- uses the real `base-files` recipe from the integration fixture;
- reads its `SUMMARY` value from the recipe source;
- runs `bitbake.scan-recipe-env` through the configured command wrapper;
- queries the VS Code hover provider;
- verifies that the hover exposes both `Final Value` and the expected recipe value.

## Context

This follows the scenario reported in #450, where a Makefile-based wrapper carries BitBake commands into a container.

I investigated the current `staging` behavior before changing production code. The reported loss of variable current/final values was not reproducible with the current implementation: command execution through the wrapper, recipe environment scanning, and hover final-value propagation all worked in the integration environment.

Since no production defect could be demonstrated, this PR intentionally adds regression coverage only rather than changing runtime behavior.

Refs #450

## Validation

- `npm run compile` — PASS
- targeted `command-wrapper.test.js` integration suite — both functional tests PASS
- tested with the integration harness pinned to VS Code 1.102.3

The targeted suite subsequently hits its existing `suiteTeardown` timeout while restoring invalid BitBake settings. The same teardown failure was reproduced against the upstream test without this regression test, so it is independent of this change.
