### PR TITLE
driver: log VS Code remote context

### DIFF
--- a/client/src/driver/BitbakeDriver.ts
+++ b/client/src/driver/BitbakeDriver.ts
@@ -5,6 +5,7 @@
 
 import EventEmitter from 'events'
 import fs from 'fs'
+import * as vscode from 'vscode'
 
 import { logger } from '../lib/src/utils/OutputLogger'
 import { type BitbakeSettings, loadBitbakeSettings, sanitizeForShell, type BitbakeBuildConfigSettings, getBuildSetting } from '../lib/src/BitbakeSettings'
@@ -69,7 +70,7 @@ export class BitbakeDriver {
   async spawnBitbakeProcess (command: string): Promise<IPty> {
     const { shell, shellEnv, script, workingDirectory } = this.prepareCommand(command)
     await this.waitForBitbakeToFinish()
-    logger.debug(`Executing Bitbake command with ${shell} in ${workingDirectory}: ${script}`)
+    logger.debug(`Executing Bitbake command with ${shell} in ${workingDirectory} (remote: ${vscode.env.remoteName}): ${script}`)
     const child = pty.spawn(
       shell,
       ['-c', script],


### PR DESCRIPTION
## Summary

Include `vscode.env.remoteName` in the existing BitBake command debug log.

This makes the execution context visible when troubleshooting VS Code Remote sessions such as attached containers, without changing command execution behavior.

Related: #415

## Scope

- import the VS Code API in `BitbakeDriver`;
- append the current `vscode.env.remoteName` to the existing debug line before spawning the BitBake process;
- no changes to `pty.spawn`, environment construction, command wrappers, sanity checks, or remote execution behavior.

## Validation

Passed locally on current `staging`:

- `npm run lint`
- `npm run compile`
- `npm run jest -- --runInBand client/src/__tests__/unit-tests/driver/bitbake-driver.test.ts`

Targeted Jest result:

- 1 suite passed
- 9 tests passed

The branch contains one commit and changes only `client/src/driver/BitbakeDriver.ts` (`+2/-1`).
